### PR TITLE
Added Event Recorder API for recording metric events.

### DIFF
--- a/docs/reference/eosmetrics/eosmetrics-docs.xml
+++ b/docs/reference/eosmetrics/eosmetrics-docs.xml
@@ -22,6 +22,7 @@
     <xi:include href="xml/emtr-util.xml"/>
     <xi:include href="xml/emtr-connection.xml"/>
     <xi:include href="xml/emtr-sender.xml"/>
+    <xi:include href="xml/emtr-event-recorder.xml"/>
   </chapter>
 
   <chapter id="object-tree">

--- a/docs/reference/eosmetrics/eosmetrics-sections.txt
+++ b/docs/reference/eosmetrics/eosmetrics-sections.txt
@@ -68,3 +68,22 @@ EMTR_SENDER_GET_CLASS
 EMTR_TYPE_SENDER
 emtr_sender_get_type
 </SECTION>
+
+<SECTION>
+<FILE>emtr-event-recorder</FILE>
+<TITLE>EmtrEventRecorder</TITLE>
+EmtrEventRecorder
+EmtrEventRecorderClass
+emtr_event_recorder_new
+<SUBSECTION Methods>
+emtr_event_recorder_record_event
+emtr_event_recorder_record_events
+<SUBSECTION Standard>
+EMTR_EVENT_RECORDER
+EMTR_EVENT_RECORDER_CLASS
+EMTR_EVENT_RECORDER_GET_CLASS
+EMTR_IS_EVENT_RECORDER
+EMTR_IS_EVENT_RECORDER_CLASS
+EMTR_TYPE_EVENT_RECORDER
+emtr_event_recorder_get_type
+</SECTION>

--- a/eosmetrics/Makefile.am.inc
+++ b/eosmetrics/Makefile.am.inc
@@ -4,6 +4,7 @@ eosmetrics_public_installed_headers = eosmetrics/eosmetrics.h
 
 eosmetrics_private_installed_headers = \
 	eosmetrics/emtr-enums.h \
+	eosmetrics/emtr-event-recorder.h \
 	eosmetrics/emtr-macros.h \
 	eosmetrics/emtr-types.h \
 	eosmetrics/emtr-version.h \
@@ -14,6 +15,7 @@ eosmetrics_private_installed_headers = \
 
 eosmetrics_library_sources = \
 	eosmetrics/emtr-connection.c \
+	eosmetrics/emtr-event-recorder.c \
 	eosmetrics/emtr-mac.c eosmetrics/emtr-mac-private.h \
 	eosmetrics/emtr-osversion.c eosmetrics/emtr-osversion-private.h \
 	eosmetrics/emtr-sender.c \

--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -1,0 +1,160 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2013 Endless Mobile, Inc. */
+
+#include "emtr-event-recorder.h"
+
+/**
+ * SECTION:emtr-event-recorder
+ * @title: Event Recorder
+ * @short_description: Records metric events to metric system daemon.
+ * @include: eosmetrics/eosmetrics.h
+ *
+ * The event recorder asynchronously sends metric events to the metric system
+ * daemon via D-Bus. The system daemon then delivers metrics to the server on
+ * a best-effort basis. No feedback is given regarding the outcome of delivery.
+ *
+ * This API may be called from Javascript as follows.
+ *
+ * |[
+ * const EosMetrics = imports.gi.EosMetrics;
+ * const GLib = imports.gi.GLib;
+ * const MEANINGLESS_EVENT = 12;
+ * const MEANINGLESS_AGGREGATED_EVENT = 7;
+ * const MEANINGLESS_EVENT_WITH_AUX_DATA = 8;
+ *
+ * let eventRecorder = EosMetrics.EventRecorder.new();
+ *
+ * // Records a single instance of MEANINGLESS_EVENT along with the current
+ * // time.
+ * eventRecorder.prototype.record_event(MEANINGLESS_EVENT, null);
+ *
+ * // Records the fact that MEANINGLESS_AGGREGATED_EVENT occurred 23
+ * // times since the last time it was recorded.
+ * eventRecorder.prototype.record_events(MEANINGLESS_AGGREGATED_EVENT,
+ *   23, null);
+ *
+ * // Records MEANINGLESS_EVENT_WITH_AUX_DATA along with some auxiliary data and
+ * // the current time.
+ * eventRecorder.prototype.record_event(MEANINGLESS_EVENT_WITH_AUX_DATA,
+ *   new GLib.Variant('a{sv}', {
+ *     units_of_smoke_ground: new GLib.Variant('u', units),
+ *     grinding_time: new GLib.Variant('u', time)
+ *   }););
+ * ]|
+ */
+
+typedef struct
+{
+  int ignored;
+  // TODO: Add fields.
+} EmtrEventRecorderPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (EmtrEventRecorder, emtr_event_recorder, G_TYPE_OBJECT)
+
+static void
+emtr_event_recorder_finalize (GObject *object)
+{
+  EmtrEventRecorder *self = EMTR_EVENT_RECORDER (object);
+  EmtrEventRecorderPrivate *priv = emtr_event_recorder_get_instance_private (self);
+
+  G_OBJECT_CLASS (emtr_event_recorder_parent_class)->finalize (object);
+}
+
+static void
+emtr_event_recorder_class_init (EmtrEventRecorderClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  object_class->finalize = emtr_event_recorder_finalize;
+}
+
+static void
+emtr_event_recorder_init (EmtrEventRecorder *self)
+{
+}
+
+/* PUBLIC API */
+
+/**
+ * emtr_event_recorder_new:
+ *
+ * Convenience function for creating a new #EmtrEventRecorder in the C API.
+ *
+ * Returns: (transfer full): a new #EmtrEventRecorder.
+ * Free with g_object_unref() when done if using C.
+ */
+EmtrEventRecorder *
+emtr_event_recorder_new (void)
+{
+  return g_object_new (EMTR_TYPE_EVENT_RECORDER, NULL);
+}
+
+/**
+ * emtr_event_recorder_record_event:
+ * @self: the event recorder
+ * @event_id: the type of event that took place
+ * @auxiliary_payload: miscellaneous data to associate with the event
+ *
+ * Make a best-effort to record the fact that an event of type @event_id
+ * happened at the current time. Optionally, associate arbitrary data,
+ * @auxiliary_payload, with this particular instance of the event. Under no
+ * circumstances should personally-identifiable information be included in the
+ * @auxiliary_payload or @event_id. Large auxiliary payloads dominate the size
+ * of the event and should therefore be used sparingly. Events for which precise
+ * timing information is not required should instead be recorded using
+ * emtr_event_recorder_record_events() to conserve bandwidth.
+ *
+ * At the discretion of the metrics system, the event may be discarded before
+ * being reported to the metrics server. The event may take arbitrarily long to
+ * reach the server and may be persisted unencrypted on the client for
+ * arbitrarily long. There is no guarantee that the event is delivered via the
+ * network; for example, it may instead be delivered manually on a USB drive.
+ * No indication of successful or failed delivery is provided, and no
+ * application should rely on successful delivery. The event will not be
+ * aggregated with other events before reaching the server.
+ */
+// TODO: Add link to mapping of event IDs to human-readable event descriptions.
+void
+emtr_event_recorder_record_event (EmtrEventRecorder *self,
+                                  int                event_id,
+                                  GVariant          *auxiliary_payload)
+{
+  // TODO: Implement.
+}
+
+/**
+ * emtr_event_recorder_record_events:
+ * @self: the event recorder
+ * @event_id: the type of events that took place
+ * @num_events: the number of times the event type took place
+ * @auxiliary_payload: miscellaneous data to associate with the events
+ *
+ * Make a best-effort to record the fact that @num_events events of type
+ * @event_id happened between the current time and the previous such recording.
+ * Optionally, associate arbitrary data, @auxiliary_payload, with these
+ * particular instances of the event. Under no circumstances should
+ * personally-identifiable information be included in the @auxiliary_payload,
+ * the @event_id, or @num_events. Large auxiliary payloads dominate the size of
+ * the event and should therefore be used sparingly. Events for which precise
+ * timing information is required should instead be recorded using
+ * emtr_event_recorder_record_event().
+ *
+ * At the discretion of the metrics system, the events may be discarded before
+ * being reported to the metrics server. The events may take arbitrarily long to
+ * reach the server and may be persisted unencrypted on the client for
+ * arbitrarily long. There is no guarantee that the events are delivered via the
+ * network; for example, they may instead be delivered manually on a USB drive.
+ * No indication of successful or failed delivery is provided, and no
+ * application should rely on successful delivery. To conserve bandwidth, the
+ * events may be aggregated in a lossy fashion with other events with the same
+ * @event_id before reaching the server.
+ */
+// TODO: Add link to mapping of event IDs to human-readable event descriptions.
+void
+emtr_event_recorder_record_events (EmtrEventRecorder *self,
+                                   int                event_id,
+                                   signed long long   num_events,
+                                   GVariant          *auxiliary_payload)
+{
+  // TODO: Implement.
+}

--- a/eosmetrics/emtr-event-recorder.h
+++ b/eosmetrics/emtr-event-recorder.h
@@ -1,0 +1,85 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#ifndef EMTR_EVENT_RECORDER_H
+#define EMTR_EVENT_RECORDER_H
+
+#if !(defined(_EMTR_INSIDE_EOSMETRICS_H) || defined(COMPILING_EOS_METRICS))
+#error "Please do not include this header file directly."
+#endif
+
+#include "emtr-types.h"
+#include <glib-object.h>
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#define EMTR_TYPE_EVENT_RECORDER emtr_event_recorder_get_type()
+
+#define EMTR_EVENT_RECORDER(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST ((obj), \
+  EMTR_TYPE_EVENT_RECORDER, EmtrEventRecorder))
+
+#define EMTR_EVENT_RECORDER_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST ((klass), \
+  EMTR_TYPE_EVENT_RECORDER, EmtrEventRecorderClass))
+
+#define EMTR_IS_EVENT_RECORDER(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), \
+  EMTR_TYPE_EVENT_RECORDER))
+
+#define EMTR_IS_EVENT_RECORDER_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE ((klass), \
+  EMTR_TYPE_EVENT_RECORDER))
+
+#define EMTR_EVENT_RECORDER_GET_CLASS(obj) \
+  (G_TYPE_INSTANCE_GET_CLASS ((obj), \
+  EMTR_TYPE_EVENT_RECORDER, EventRecorderClass))
+
+/**
+ * EmtrEventRecorder:
+ *
+ * This instance structure contains no public members.
+ */
+typedef struct _EmtrEventRecorder EmtrEventRecorder;
+
+/**
+ * EmtrEventRecorderClass:
+ *
+ * This class structure contains no public members.
+ */
+typedef struct _EmtrEventRecorderClass EmtrEventRecorderClass;
+
+struct _EmtrEventRecorder
+{
+  /*< private >*/
+  GObject parent;
+};
+
+struct _EmtrEventRecorderClass
+{
+  /*< private >*/
+  GObjectClass parent_class;
+};
+
+EMTR_ALL_API_VERSIONS
+GType              emtr_event_recorder_get_type      (void) G_GNUC_CONST;
+
+EMTR_ALL_API_VERSIONS
+EmtrEventRecorder *emtr_event_recorder_new           (void);
+
+EMTR_ALL_API_VERSIONS
+void               emtr_event_recorder_record_event  (EmtrEventRecorder *self,
+                                                      int                event_id,
+                                                      GVariant          *auxiliary_payload);
+
+EMTR_ALL_API_VERSIONS
+void               emtr_event_recorder_record_events (EmtrEventRecorder *self,
+                                                      int                event_id,
+                                                      signed long long   num_events,
+                                                      GVariant          *auxiliary_payload);
+
+G_END_DECLS
+
+#endif /* EMTR_EVENT_RECORDER_H */

--- a/eosmetrics/eosmetrics.h
+++ b/eosmetrics/eosmetrics.h
@@ -14,6 +14,7 @@ G_BEGIN_DECLS
 #include "emtr-util.h"
 #include "emtr-connection.h"
 #include "emtr-sender.h"
+#include "emtr-event-recorder.h"
 
 #undef _EMTR_INSIDE_EOSMETRICS_H
 

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -10,6 +10,7 @@ TEST_LIBS = @EOSMETRICS_LIBS@ $(top_builddir)/libeosmetrics-@EMTR_API_VERSION@.l
 tests_run_tests_SOURCES = \
 	tests/run-tests.c tests/run-tests.h \
 	tests/test-connection.c \
+	tests/test-event-recorder.c \
 	tests/test-mac.c \
 	tests/test-osversion.c \
 	tests/test-uuid.c \

--- a/tests/run-tests.c
+++ b/tests/run-tests.c
@@ -98,6 +98,7 @@ main (int    argc,
   add_web_tests ();
   add_connection_tests ();
   add_sender_tests ();
+  add_event_recorder_tests ();
 
   return g_test_run ();
 }

--- a/tests/run-tests.h
+++ b/tests/run-tests.h
@@ -62,12 +62,13 @@ void      set_up_mock_version_file      (const gchar       *contents);
 
 /* Each module adds its own test cases: */
 
-void add_util_tests       (void);
-void add_osversion_tests  (void);
-void add_uuid_tests       (void);
-void add_mac_tests        (void);
-void add_web_tests        (void);
-void add_connection_tests (void);
-void add_sender_tests     (void);
+void add_util_tests           (void);
+void add_osversion_tests      (void);
+void add_uuid_tests           (void);
+void add_mac_tests            (void);
+void add_web_tests            (void);
+void add_connection_tests     (void);
+void add_sender_tests         (void);
+void add_event_recorder_tests (void);
 
 #endif /* RUN_TESTS_H */

--- a/tests/test-event-recorder.c
+++ b/tests/test-event-recorder.c
@@ -1,0 +1,39 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#include <eosmetrics/emtr-event-recorder.h>
+#include "run-tests.h"
+
+static void
+test_event_recorder_new_succeeds (void)
+{
+  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  g_assert (event_recorder != NULL);
+}
+
+static void
+test_event_recorder_record_event (void)
+{
+  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  emtr_event_recorder_record_event (event_recorder, 0, NULL);
+  // TODO: Test functionality once implemented.
+}
+
+static void
+test_event_recorder_record_events (void)
+{
+  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  emtr_event_recorder_record_events (event_recorder, 1, 12LL, NULL);
+  // TODO: Test functionality once implemented.
+}
+
+void
+add_event_recorder_tests (void)
+{
+  g_test_add_func ("/event-recorder/new", test_event_recorder_new_succeeds);
+  g_test_add_func ("/event-recorder/record-event",
+                   test_event_recorder_record_event);
+  g_test_add_func ("/event-recorder/record-events",
+                   test_event_recorder_record_events);
+}


### PR DESCRIPTION
[endlessm/eos-sdk#576] I am shamelessly aping emtr-sender.c and emtr-sender.h to create a pruned down version of these files. The idea is that this new interface would be exposed to all applications, and the old interface will (after being modified) be internal to the metrics system. If it seems like something is unnecessary it probably is; please point it out.
