### PR TITLE
Free GObject with g_object_unref(), not g_free()

### DIFF
--- a/eosmetrics/emtr-mac.c
+++ b/eosmetrics/emtr-mac.c
@@ -122,7 +122,7 @@ emtr_mac_gen (void)
     {
       g_debug ("Could not determine MAC address: %s", error->message);
       g_error_free (error);
-      g_free (sysfs_interfaces_dir);
+      g_object_unref (sysfs_interfaces_dir);
       goto fail;
     }
 


### PR DESCRIPTION
In a little-used code path, a GObject was being freed with g_free()
instead of g_object_unref().

[endlessm/eos-sdk#467]
