### PR TITLE
Use subshell to print out log and fail

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -17,4 +17,4 @@ override_dh_auto_configure:
 	dh_auto_configure -- --enable-gtk-doc --enable-gir-doc
 
 override_dh_auto_test:
-	dh_auto_test || find . -name '*.log' | xargs cat && false
+	dh_auto_test || ( find . -name '*.log' | xargs cat; false )


### PR DESCRIPTION
Previously, I had gotten the priority of bash short-circuit operators
wrong. This caused 'false' to be executed even when the tests
completed successfully.

[endlessm/eos-sdk#467]
