### PR TITLE
Added missing run-time dependency to package that is causing a downstrea...

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Package: eos-metrics-0-dev
 Section: non-free/libdevel
 Architecture: any
 Depends: libeosmetrics-0-0 (= ${binary:Version}),
+         libjson-glib-dev (>= 0.16),
          ${misc:Depends}
 Description: Files needed for developing using the EndlessOS Metrics Kit
  Install this package if you are compiling C programs that use the EndlessOS


### PR DESCRIPTION
...m build failure in eos-metrics-instrumentation.

[endlessm/eos-sdk#856]
