### PR TITLE
Added a missing runtime dependency that is causing a downstream build fa...

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Architecture: any
 Depends: libeosmetrics-0-0 (= ${binary:Version}),
          libjson-glib-dev (>= 0.16),
          libsoup2.4-dev (>= 2.42),
+         uuid-dev,
          ${misc:Depends}
 Description: Files needed for developing using the EndlessOS Metrics Kit
  Install this package if you are compiling C programs that use the EndlessOS


### PR DESCRIPTION
...ilure in eos-metrics-instrumentation.

[endlessm/eos-sdk#856]
