### PR TITLE
Added Minimum-Viable Persistent Cache

### DIFF
--- a/docs/reference/eosmetrics/Makefile.am
+++ b/docs/reference/eosmetrics/Makefile.am
@@ -54,6 +54,7 @@ IGNORE_HFILES= \
 	emtr-util-private.h \
 	emtr-uuid-private.h \
 	emtr-web-private.h \
+	emtr-persistent-cache-private.h \
 	$(NULL)
 
 # Images to copy into HTML directory.

--- a/eosmetrics/Makefile.am.inc
+++ b/eosmetrics/Makefile.am.inc
@@ -3,15 +3,15 @@
 eosmetrics_public_installed_headers = eosmetrics/eosmetrics.h
 
 eosmetrics_private_installed_headers = \
+	eosmetrics/emtr-connection.h \
 	eosmetrics/emtr-enums.h \
 	eosmetrics/emtr-event-recorder.h \
 	eosmetrics/emtr-event-types.h \
 	eosmetrics/emtr-macros.h \
-	eosmetrics/emtr-types.h \
-	eosmetrics/emtr-version.h \
-	eosmetrics/emtr-util.h \
-	eosmetrics/emtr-connection.h \
 	eosmetrics/emtr-sender.h \
+	eosmetrics/emtr-types.h \
+	eosmetrics/emtr-util.h \
+	eosmetrics/emtr-version.h \
 	$(NULL)
 
 eosmetrics_library_sources = \
@@ -19,6 +19,7 @@ eosmetrics_library_sources = \
 	eosmetrics/emtr-event-recorder.c \
 	eosmetrics/emtr-mac.c eosmetrics/emtr-mac-private.h \
 	eosmetrics/emtr-osversion.c eosmetrics/emtr-osversion-private.h \
+	eosmetrics/emtr-persistent-cache.c eosmetrics/emtr-persistent-cache-private.h \
 	eosmetrics/emtr-sender.c \
 	eosmetrics/emtr-util.c eosmetrics/emtr-util-private.h \
 	eosmetrics/emtr-uuid.c eosmetrics/emtr-uuid-private.h \

--- a/eosmetrics/emtr-persistent-cache-private.h
+++ b/eosmetrics/emtr-persistent-cache-private.h
@@ -1,0 +1,105 @@
+/* Copyright 2014 Endless Mobile, Inc. */
+
+/* Emtr_Persistent_cache_private.h */
+
+#ifndef __EMTR_PERSISTENT_CACHE_H__
+#define __EMTR_PERSISTENT_CACHE_H__
+
+#if !(defined(_EMTR_INSIDE_EOSMETRICS_H) || defined(COMPILING_EOS_METRICS))
+#error "Please do not include this header file directly."
+#endif
+
+#include "emtr-types.h"
+#include <glib-object.h>
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#define EMTR_TYPE_PERSISTENT_CACHE emtr_persistent_cache_get_type()
+
+#define EMTR_PERSISTENT_CACHE(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), EMTR_TYPE_PERSISTENT_CACHE, Emtr_Persistent_Cache))
+
+#define EMTR_PERSISTENT_CACHE_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST ((klass), EMTR_TYPE_PERSISTENT_CACHE, Emtr_Persistent_CacheClass))
+
+#define EMTR_IS_PERSISTENT_CACHE(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), EMTR_TYPE_PERSISTENT_CACHE))
+
+#define EMTR_IS_PERSISTENT_CACHE_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), EMTR_TYPE_PERSISTENT_CACHE))
+
+#define EMTR_PERSISTENT_CACHE_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), EMTR_TYPE_PERSISTENT_CACHE, Emtr_Persistent_CacheClass))
+
+/*
+ * The location of the meta-file containing the local cache meta-data.
+ */
+#define LOCAL_CACHE_VERSION_METAFILE "local_metafile"
+
+/*
+ * The prefix for all metrics cache files.
+ */
+#define CACHE_PREFIX "cache_"
+
+/*
+ * The suffixes for each metric type's file.
+ */
+#define INDIVIDUAL_SUFFIX "individual.metrics"
+#define AGGREGATE_SUFFIX  "aggregate.metrics"
+#define SEQUENCE_SUFFIX   "sequence.metrics"
+
+/*
+ * GVariant Types for deserializing metrics.
+ */
+#define INDIVIDUAL_TYPE "(ayxmv)"
+#define AGGREGATE_TYPE  "(ayxxmv)"
+#define SEQUENCE_TYPE   "(aya(xmv))"
+
+typedef struct _Emtr_Persistent_Cache Emtr_Persistent_Cache;
+typedef struct _Emtr_Persistent_CacheClass Emtr_Persistent_CacheClass;
+typedef struct _Emtr_Persistent_CachePrivate Emtr_Persistent_CachePrivate;
+
+/*
+ * CAPAICTY_LOW = No urgent need to write to network.
+ * CAPACITY_HIGH = Should write to network when possible. Occupancy is beyond a threshold.
+ * CAPACITY_MAX = Should write to network when possible. Occupancy is at or 
+ *                near 100% and metrics are being ignored!
+ */
+typedef enum {CAPACITY_LOW, CAPACITY_HIGH, CAPACITY_MAX} capacity_t;
+
+struct _Emtr_Persistent_Cache
+{
+  GObject parent;
+};
+
+struct _Emtr_Persistent_CacheClass
+{
+  GObjectClass parent_class;
+};
+
+GType emtr_persistent_cache_get_type (void) G_GNUC_CONST;
+
+Emtr_Persistent_Cache *emtr_persistent_cache_get_default                       (GCancellable           *cancellable,
+                                                                                GError                **error);
+
+gboolean               emtr_persistent_cache_drain_metrics                     (Emtr_Persistent_Cache  *self,
+                                                                                GVariant             ***list_of_individual_metrics,
+                                                                                GVariant             ***list_of_aggregate_metrics,
+                                                                                GVariant             ***list_of_sequence_metrics);
+
+gboolean               emtr_persistent_cache_store_metrics                     (Emtr_Persistent_Cache  *self,
+                                                                                GVariant              **list_of_individual_metrics,
+                                                                                GVariant              **list_of_aggregate_metrics,
+                                                                                GVariant              **list_of_sequence_metrics,
+                                                                                capacity_t             *capacity);
+/*
+ * Function should only be used in testing code, NOT in production code.
+ */
+Emtr_Persistent_Cache* emtr_persistent_cache_new                              (GCancellable           *cancellable,
+                                                                               GError                **error,
+                                                                               gchar                  *custom_directory,
+                                                                               guint                   custom_cache_size);
+/*
+ * Function should only be used in testing code, NOT in production code.
+ */
+gboolean               emtr_persistent_cache_set_different_version_for_testing (Emtr_Persistent_Cache *self);
+
+G_END_DECLS
+
+#endif /* __EMTR_PERSISTENT_CACHE_H__ */

--- a/eosmetrics/emtr-persistent-cache.c
+++ b/eosmetrics/emtr-persistent-cache.c
@@ -1,0 +1,823 @@
+/* Copyright 2014 Endless Mobile, Inc. */
+
+/* emtr_persistent_cache.c */
+
+#include "emtr-persistent-cache-private.h"
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib/gprintf.h>
+#include <glib-object.h>
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+/*
+ * SECTION:emtr_persistent_cache.c
+ * @title: Persistent Cache
+ * @short_description: Stores metrics locally (on the user's machine).
+ * @include: eosmetrics/eosmetrics.h
+ *
+ * The Persistent Cache is the sink to which an event recorder flushes 
+ * metrics. It will store these metrics until a drain operation is
+ * requested or the Persistent Cache is purged due to versioning.
+ * 
+ * Should the cached metrics occupy more than MAX_CACHE_SIZE bytes, the
+ * Persistent Cache will begin ignoring new metrics until the old ones have
+ * been removed.
+ *
+ * If the CURRENT_CACHE_VERSION is incremented to indicate 
+ * backwards-incompatible versioning, any cached metrics will be deleted, and 
+ * the file indicating the local cache version will be updated to the reflect 
+ * the new version number.
+ */
+
+static gboolean   emtr_persistent_cache_append_metric                    (Emtr_Persistent_Cache *self, 
+                                                                          GFile                 *file, 
+                                                                          GVariant              *metric);
+
+static gboolean   emtr_persistent_cache_apply_cache_versioning           (Emtr_Persistent_Cache *self, 
+                                                                          GCancellable          *cancellable, 
+                                                                          GError               **error);
+
+static gboolean   emtr_persistent_cache_drain_metrics_file               (Emtr_Persistent_Cache *self, 
+                                                                          GVariant            ***return_list, 
+                                                                          gchar                 *path_ending, 
+                                                                          gchar                 *variant_type);
+
+static GVariant*  emtr_persistent_cache_flip_bytes_if_big_endian_machine (Emtr_Persistent_Cache *self, 
+                                                                          GVariant              *variant);
+
+static void       emtr_persistent_cache_free_variant_list                (Emtr_Persistent_Cache *self,
+                                                                          GVariant             **list);
+
+static GFile*     emtr_persistent_cache_get_cache_file                   (Emtr_Persistent_Cache *self, 
+                                                                          gchar                 *path_ending);
+
+static gboolean   emtr_persistent_cache_has_room                         (Emtr_Persistent_Cache *self, 
+                                                                          gsize                  size);
+
+static void       emtr_persistent_cache_initable_init                    (GInitableIface        *iface);
+
+static gboolean   emtr_persistent_cache_load_cache_size                  (Emtr_Persistent_Cache *self, 
+                                                                          GCancellable          *cancellable, 
+                                                                          GError               **error);
+
+static gboolean   emtr_persistent_cache_load_local_cache_version         (Emtr_Persistent_Cache *self, 
+                                                                          gint64                *version);
+
+static gboolean   emtr_persistent_cache_may_fail_init                    (GInitable             *self, 
+                                                                          GCancellable          *cancellable, 
+                                                                          GError               **error);
+
+static gboolean   emtr_persistent_cache_purge_cache_files                (Emtr_Persistent_Cache *self, 
+                                                                          GCancellable          *cancellable, 
+                                                                          GError               **error);
+
+static gboolean   emtr_persistent_cache_store_metric_list                (Emtr_Persistent_Cache *self, 
+                                                                          GFile                 *file,
+                                                                          GVariant             **list, 
+                                                                          capacity_t            *capacity);
+
+static gboolean   emtr_persistent_cache_update_cache_version_number      (Emtr_Persistent_Cache *self, 
+                                                                          GCancellable          *cancellable, 
+                                                                          GError               **error);
+
+static capacity_t emtr_persistent_cache_update_capacity                  (Emtr_Persistent_Cache *self);
+
+typedef struct GVariantWritable
+{
+  gsize length;
+  gpointer data;
+} GVariantWritable;
+
+struct _Emtr_Persistent_CachePrivate
+{
+  guint64 cache_size;
+  capacity_t capacity;
+};                                                   
+
+G_DEFINE_TYPE_WITH_CODE (Emtr_Persistent_Cache, emtr_persistent_cache, G_TYPE_OBJECT,
+                         G_ADD_PRIVATE (Emtr_Persistent_Cache)
+                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, emtr_persistent_cache_initable_init))
+
+/*
+ * If this version is greater than the version of the persisted metrics,
+ * they will be purged from the system, and the file indicating which
+ * version the persisted metrics currently have will be updated.
+ */
+#define CURRENT_CACHE_VERSION 2
+
+/*
+ * The point at which the capacity switches fron LOW to HIGH.
+ */
+#define HIGH_CAPACITY_THRESHOLD 0.75 // 75%
+
+#define PERSISTENT_CACHE_PRIVATE(o) \
+  (G_TYPE_INSTANCE_GET_PRIVATE ((o), EMTR_TYPE_PERSISTENT_CACHE, Emtr_Persistent_CachePrivate))
+
+/*
+ * The largest amount of memory (in bytes) that the metrics cache may
+ * occupy before incoming metrics are ignored.
+ *
+ * Should never be altered in production code!
+ */
+static guint64 MAX_CACHE_SIZE = 102400; // 100 kB
+
+/*
+ * The directory metrics and their meta-file are saved to. 
+ * Is listed in all caps because it should be treated as though
+ * it were immutable by production code.  Only testing code should
+ * ever alter this variable.
+ */
+static gchar* CACHE_DIRECTORY = "/etc/metrics_cache/";
+
+static void
+emtr_persistent_cache_class_init (Emtr_Persistent_CacheClass *klass)
+{
+
+}
+
+static void
+emtr_persistent_cache_init (Emtr_Persistent_Cache *self)
+{
+  Emtr_Persistent_CachePrivate *priv = emtr_persistent_cache_get_instance_private (self);
+  priv->cache_size = 0L;
+  priv->capacity = CAPACITY_LOW;
+}
+
+static gboolean
+emtr_persistent_cache_may_fail_init (GInitable    *self,
+                                     GCancellable *cancellable,
+                                     GError      **error)
+{
+  gboolean versioning_success = emtr_persistent_cache_apply_cache_versioning (EMTR_PERSISTENT_CACHE (self),
+                                                                              cancellable,
+                                                                              error);
+  if (!versioning_success)
+    return FALSE;
+
+  return emtr_persistent_cache_load_cache_size (EMTR_PERSISTENT_CACHE (self),
+                                                cancellable,
+                                                error);
+}
+
+static void
+emtr_persistent_cache_initable_init (GInitableIface *iface)
+{
+  iface->init = emtr_persistent_cache_may_fail_init;
+}
+
+/*
+ * Constructor for creating a new Persistent Cache.
+ * Returns a singleton instance of a Persistent Cache.
+ * Please use this in production instead of the testing constructor!
+ */
+Emtr_Persistent_Cache*
+emtr_persistent_cache_get_default (GCancellable *cancellable,
+                                   GError      **error)
+{
+  static Emtr_Persistent_Cache *singleton_cache;
+  static gboolean run_before = FALSE;
+  G_LOCK_DEFINE_STATIC (run_before);
+
+  G_LOCK (run_before);
+  if (!run_before)
+  {
+    singleton_cache = g_initable_new (EMTR_TYPE_PERSISTENT_CACHE, 
+                                      cancellable, 
+                                      error,
+                                      NULL);
+    run_before = TRUE;
+  }
+  G_UNLOCK (run_before);
+
+  return singleton_cache;
+}
+
+/*
+ * You should use emtr_persistent_cache_get_default() instead of this function.
+ * Function should only be used in testing code, NOT in production code.
+ * Should always use a custom directory.  A custom cache size may be specified,
+ * but if set to 0, the production value will be used. 
+ */
+Emtr_Persistent_Cache*
+emtr_persistent_cache_new (GCancellable *cancellable,
+                           GError      **error,
+                           gchar        *custom_directory,
+                           guint         custom_cache_size)
+{
+  MAX_CACHE_SIZE = (guint64) custom_cache_size;
+  CACHE_DIRECTORY = custom_directory;
+  return g_initable_new (EMTR_TYPE_PERSISTENT_CACHE, 
+                         cancellable,
+                         error,
+                         NULL);
+}
+
+/*
+ * Will transfer all metrics in the corresponding file into the out parameter 
+ * 'return_list'. The list will be NULL-terminated.  Returns TRUE on success, 
+ * and FALSE if any I/O error occured. Contents of return_list are undefined if 
+ * the return value is FALSE.
+ */
+static gboolean
+emtr_persistent_cache_drain_metrics_file (Emtr_Persistent_Cache *self,
+                                          GVariant            ***return_list,
+                                          gchar                 *path_ending,
+                                          gchar                 *variant_type)
+{
+  GError *error = NULL;
+  GFile *file = emtr_persistent_cache_get_cache_file (self, path_ending);
+  GFileInputStream *file_stream = g_file_read (file, NULL, &error);
+  
+  if (file_stream == NULL)
+  {
+    g_critical ("Failed to open input stream to drain metrics. Error: %s\n",
+                 error->message);
+    g_error_free (error);
+    g_object_unref (file);
+    return FALSE;
+  }
+  GInputStream *stream = G_INPUT_STREAM (file_stream);
+
+  GArray *dynamic_array = g_array_new (FALSE, FALSE, sizeof (GVariant *));
+  
+  while (TRUE)
+  {
+    GVariantWritable writable;
+    gssize length_bytes_read = g_input_stream_read (stream, 
+                                                    &(writable.length), 
+                                                    sizeof (gsize), 
+                                                    NULL, 
+                                                    &error);
+    if (length_bytes_read == 0) // EOF
+      break;
+
+    if (error != NULL)
+    {
+      gchar *fpath = g_file_get_path (file);
+      g_critical ("Failed to read length of metric from input stream to drain metrics. File: %s . Error: %s\n", 
+                   fpath, error->message);
+      g_free (fpath);
+      g_error_free (error);
+      g_object_unref (stream);
+      g_object_unref (file);
+      g_array_free (dynamic_array, TRUE);
+      return FALSE;
+    }
+    if (length_bytes_read != sizeof (gsize))
+    {
+      g_critical ("We read %i bytes but expected %u bytes!\n", 
+                  length_bytes_read, sizeof (gsize));
+      g_object_unref (stream);
+      g_object_unref (file);
+      g_array_free (dynamic_array, TRUE);
+      return FALSE;
+    }
+
+    writable.data = g_new (guchar, writable.length);
+    gssize data_bytes_read = g_input_stream_read (stream, 
+                                                  writable.data, 
+                                                  writable.length, 
+                                                  NULL, 
+                                                  &error);
+    if (data_bytes_read != writable.length)
+      g_critical ("We read %i bytes of metric data when looking for %u!\n", 
+                  data_bytes_read, writable.length);
+
+    if (error != NULL)
+    {
+      gchar *fpath = g_file_get_path (file);
+      g_critical ("Failed to read metric from input stream to drain metrics. File: %s . Error: %s\n", 
+                   fpath, error->message);
+      g_free (fpath);
+      g_error_free (error);
+      g_object_unref (stream);
+      g_object_unref (file);
+      g_array_free (dynamic_array, TRUE);
+      return FALSE;
+    }
+    // Deserialize
+    GVariant *current_metric = g_variant_new_from_data (G_VARIANT_TYPE (variant_type),
+                                                        writable.data,
+                                                        writable.length,
+                                                        FALSE,
+                                                        (GDestroyNotify) g_free,
+                                                        writable.data);
+    // Correct byte_ordering if necessary.
+    GVariant *native_endian_metric = emtr_persistent_cache_flip_bytes_if_big_endian_machine (self, 
+                                                                                             current_metric);
+
+    g_variant_unref (current_metric);
+    g_array_append_val (dynamic_array, native_endian_metric);
+  }
+  g_object_unref (stream);
+  g_object_unref (file);
+
+  *return_list = g_new (GVariant *, dynamic_array->len + 1);
+  memcpy (*return_list, dynamic_array->data, dynamic_array->len * sizeof (GVariant *));
+  (*return_list)[dynamic_array->len] = NULL;
+  g_array_free (dynamic_array, TRUE);
+  
+  return TRUE;
+}
+
+/*
+ * Will transfer all metrics on disk into the three out parameters. Each list is NULL-terminated. 
+ * Will delete all metrics from disk immediately afterward. Returns %TRUE on success. If any I/O
+ * operation fails, will return %FALSE and the out parameters' contents will be undefined.
+ */
+gboolean
+emtr_persistent_cache_drain_metrics (Emtr_Persistent_Cache  *self,
+                                     GVariant             ***list_of_individual_metrics,
+                                     GVariant             ***list_of_aggregate_metrics,
+                                     GVariant             ***list_of_sequence_metrics)
+{
+  gboolean ind_success = emtr_persistent_cache_drain_metrics_file (self, 
+                                                                   list_of_individual_metrics, 
+                                                                   INDIVIDUAL_SUFFIX,
+                                                                   INDIVIDUAL_TYPE);
+  if (!ind_success)
+    return FALSE;
+  
+  gboolean agg_success = emtr_persistent_cache_drain_metrics_file (self,
+                                                                   list_of_aggregate_metrics,
+                                                                   AGGREGATE_SUFFIX,
+                                                                   AGGREGATE_TYPE);
+  if (!agg_success)
+  {
+    emtr_persistent_cache_free_variant_list (self, *list_of_individual_metrics);
+    return FALSE;
+  }
+
+  gboolean seq_success = emtr_persistent_cache_drain_metrics_file (self,
+                                                                   list_of_sequence_metrics,
+                                                                   SEQUENCE_SUFFIX,
+                                                                   SEQUENCE_TYPE);
+  if (!seq_success)
+  {
+    emtr_persistent_cache_free_variant_list (self, *list_of_individual_metrics);
+    emtr_persistent_cache_free_variant_list (self, *list_of_aggregate_metrics);
+    return FALSE;
+  }
+  
+  GError *error = NULL;
+  if (!emtr_persistent_cache_purge_cache_files (self, NULL, &error))
+  {
+    g_error_free (error); // The error has served its purpose in the previous call.
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/*
+ * Frees all resources contained within a GVariant* list, including
+ * the list itself.
+ */
+static void
+emtr_persistent_cache_free_variant_list (Emtr_Persistent_Cache *self,
+                                         GVariant             **list)
+{
+  g_return_if_fail (list != NULL);
+
+  for (int i = 0; list[i] != NULL; i++)
+  {
+    g_variant_unref (list[i]);
+  }
+  g_free (list);
+}
+
+/*
+ *  Attempts to write a NULL-terminated list of GVariant metrics to a given file.
+ *  Will update capacity given to it.  Automatically increments priv->cache_size.
+ *  Returns %FALSE if any metrics failed due to I/O error. %TRUE otherwise.
+ *  Regardless of success or failure, the capacity will be correctly returned
+ *  via its out parameter.
+ */
+static gboolean
+emtr_persistent_cache_store_metric_list (Emtr_Persistent_Cache *self,
+                                         GFile                 *file,
+                                         GVariant             **list,
+                                         capacity_t            *capacity)
+{
+  gboolean success = TRUE;
+  Emtr_Persistent_CachePrivate *priv = emtr_persistent_cache_get_instance_private (self);
+  if (list == NULL)
+    g_error ("Attempted to store a GVariant list that was actually a NULL pointer!\n");
+
+  for (int i = 0; list[i] != NULL; i++)
+  {
+    GVariant *current_metric = list[i];
+    gsize metric_size = sizeof (gsize) + g_variant_get_size (current_metric);
+    if (emtr_persistent_cache_has_room (self, metric_size))
+    {
+      success = emtr_persistent_cache_append_metric (self, file, current_metric);
+      if (!success)
+      {
+        g_critical ("Failed to write metric. Dropping some metrics.\n");
+        break;
+      }
+      priv->cache_size += metric_size;
+    }
+    else
+    {
+      // This is how we know we are at max capacity -- we've been dropping metrics.
+      priv->capacity = CAPACITY_MAX;
+      break;
+    }
+  }
+  
+  *capacity = emtr_persistent_cache_update_capacity (self);
+  return success;
+}
+
+/*
+ * Will store all metrics passed to it onto disk if doing so would not exceed its space
+ * limitation.  Each list must be NULL-terminated or NULL itself. 
+ * Will return the capacity of the cache via the out parameter 'capacity'.
+ * Returns %TRUE on success, even if the metrics are intentionally dropped due to space
+ * limitations.  Returns %FALSE only on I/O error.
+ *
+ * Regardless of success or failure, the capacity will be correctly returned
+ * via its out parameter.
+ *
+ * GVariants are assumed to be in the native endianness of the machine.
+ */
+gboolean
+emtr_persistent_cache_store_metrics (Emtr_Persistent_Cache  *self,
+                                     GVariant              **list_of_individual_metrics,
+                                     GVariant              **list_of_aggregate_metrics,
+                                     GVariant              **list_of_sequence_metrics,
+                                     capacity_t             *capacity)
+{
+  GFile *ind_file = emtr_persistent_cache_get_cache_file (self, INDIVIDUAL_SUFFIX);
+  gboolean ind_success = emtr_persistent_cache_store_metric_list (self, 
+                                                                  ind_file,
+                                                                  list_of_individual_metrics,
+                                                                  capacity);
+  g_object_unref (ind_file);
+  if (!ind_success)
+    return FALSE;
+
+  GFile *agg_file = emtr_persistent_cache_get_cache_file (self, AGGREGATE_SUFFIX);
+  gboolean agg_success = emtr_persistent_cache_store_metric_list (self,
+                                                                  agg_file,
+                                                                  list_of_aggregate_metrics,
+                                                                  capacity);
+  g_object_unref (agg_file);
+  if (!agg_success)
+    return FALSE;
+
+  GFile *seq_file = emtr_persistent_cache_get_cache_file (self, SEQUENCE_SUFFIX);
+  gboolean seq_success = emtr_persistent_cache_store_metric_list (self, 
+                                                                  seq_file, 
+                                                                  list_of_sequence_metrics,
+                                                                  capacity);
+  g_object_unref (seq_file);
+  if (!seq_success)
+    return FALSE;
+
+  // capacity is updated within the list storing functions.
+  return TRUE;
+}
+
+/*
+ * Creates and returns a newly allocated GFile* corresponding to the cache file ending or 
+ * metafile ending given to it as path_ending.
+ */
+static GFile*
+emtr_persistent_cache_get_cache_file (Emtr_Persistent_Cache *self,
+                                      gchar                 *path_ending)
+{
+  gchar *path;
+  path = g_strconcat (CACHE_DIRECTORY, CACHE_PREFIX, path_ending, NULL);
+  GFile *file = g_file_new_for_path (path);
+  g_free (path);
+  return file;
+}
+
+/*
+ * Should only be called if the version is out of date, corrupted, or the cache 
+ * file does not exist. Replaces the content of all cache files with the empty 
+ * string. Will create these empty files if they do not already exist.
+ * Returns TRUE on success and FALSE on I/O failure.
+ */
+static gboolean
+emtr_persistent_cache_purge_cache_files (Emtr_Persistent_Cache *self,
+                                         GCancellable          *cancellable,
+                                         GError               **error)
+{
+  GFile *ind_file = emtr_persistent_cache_get_cache_file (self, INDIVIDUAL_SUFFIX);
+  gboolean success = g_file_replace_contents (ind_file, "", 0, NULL, FALSE,
+                                              G_FILE_CREATE_PRIVATE | G_FILE_CREATE_REPLACE_DESTINATION, 
+                                              NULL, cancellable, error);
+  if (!success)
+  {
+    if (error != NULL)
+      g_critical ("Failed to purge cache files. Error: %s\n", (*error)->message);
+    else
+      g_critical ("Failed to purge cache files.\n");
+    g_object_unref (ind_file);
+    return FALSE;
+  }
+  g_object_unref (ind_file);
+
+  GFile *agg_file = emtr_persistent_cache_get_cache_file (self, AGGREGATE_SUFFIX);
+  success = g_file_replace_contents (agg_file, "", 0, NULL, FALSE, 
+                                     G_FILE_CREATE_PRIVATE | G_FILE_CREATE_REPLACE_DESTINATION, 
+                                     NULL, cancellable, error);
+  if (!success)
+  {
+    if (error != NULL)
+      g_critical ("Failed to purge cache files. Error: %s\n", (*error)->message);
+    else
+      g_critical ("Failed to purge cache files.\n");
+    g_object_unref (agg_file);
+    return FALSE;
+  }
+  g_object_unref (agg_file);
+
+  GFile *seq_file = emtr_persistent_cache_get_cache_file (self, SEQUENCE_SUFFIX);
+  success = g_file_replace_contents (seq_file, "", 0, NULL, FALSE,
+                                     G_FILE_CREATE_PRIVATE | G_FILE_CREATE_REPLACE_DESTINATION,
+                                     NULL, cancellable, error);
+  if (!success)
+  {
+    if (error != NULL)
+      g_critical ("Failed to purge cache files. Error: %s\n", (*error)->message);
+    else
+      g_critical ("Failed to purge cache files.\n");
+    g_object_unref (seq_file);
+    return FALSE;
+  }
+  g_object_unref (seq_file);
+
+  Emtr_Persistent_CachePrivate *priv = emtr_persistent_cache_get_instance_private (self);
+  priv->cache_size = 0L;
+  priv->capacity = CAPACITY_LOW;
+
+  return TRUE;
+}
+
+/*
+ * Loads the local cache version into memory from disk. 
+ * Returns %TRUE on success and %FALSE on I/O error including 
+ * if the file doesn't exist.
+ */
+static gboolean
+emtr_persistent_cache_load_local_cache_version (Emtr_Persistent_Cache *self,
+                                                gint64                *version)
+{
+  gchar *filepath = g_strconcat (CACHE_DIRECTORY, LOCAL_CACHE_VERSION_METAFILE, NULL);
+  gchar *version_string = NULL;
+
+  if (g_file_get_contents (filepath, &version_string, NULL, NULL))
+  {
+    gint64 version_int = g_ascii_strtoll (version_string, NULL, 10);
+    if (version_int == 0) // Error code for failure.
+    {
+      gint e = errno;
+      const gchar *err_str = g_strerror (e);
+      g_critical ("Version file seems to be corrupted. Error: %s\n", err_str);
+      return FALSE;
+    }
+    *version = version_int;
+
+    g_free (version_string);
+    g_free (filepath);
+    return TRUE;
+  }
+  else
+  {
+    g_free (filepath);
+    return FALSE;
+  }
+}
+
+/*
+ * Attempts to append (cache) a metric at the end of a file.
+ * Returns TRUE on success and FALSE on failure. 
+ */
+static gboolean
+emtr_persistent_cache_append_metric (Emtr_Persistent_Cache *self,
+                                     GFile                 *file,
+                                     GVariant              *metric)
+{
+  GError *error = NULL;
+  GFileOutputStream *stream = g_file_append_to (file, 
+                                                G_FILE_CREATE_NONE,
+                                                NULL,
+                                                &error);
+  if (stream == NULL)
+  {
+    gchar *path = g_file_get_path (file);
+    g_critical ("Failed to open stream to cache file: %s . Error: %s\n", 
+                path, error->message);
+    g_free (path);
+    g_error_free (error);
+    return FALSE;
+  }
+
+  GVariant *native_endian_metric = emtr_persistent_cache_flip_bytes_if_big_endian_machine (self, 
+                                                                                           metric);
+  GVariantWritable writable;
+  writable.length = g_variant_get_size (native_endian_metric);
+  writable.data = (gpointer) g_variant_get_data (native_endian_metric);
+  
+  GString *writable_string = g_string_new ("");
+  g_string_append_len (writable_string, (const gchar *) &writable.length, sizeof (writable.length));
+  g_string_append_len (writable_string, writable.data, writable.length);
+  gboolean success = g_output_stream_write_all (G_OUTPUT_STREAM (stream), writable_string->str,
+                                                writable_string->len, NULL, NULL, &error);
+  g_string_free (writable_string, TRUE);
+  g_variant_unref (native_endian_metric);
+  
+  if (!success)
+  {
+    gchar *path = g_file_get_path (file);
+    g_critical ("Failed to write to cache file: %s . Error: %s\n",
+                 path, error->message);
+    g_object_unref (stream);
+    g_free (path);
+    g_error_free (error);
+    return FALSE;
+  }
+
+  g_object_unref (stream);
+  return TRUE;
+}
+
+/*
+ * Will return a GVariant* with the bytes set to the opposite byte_order if
+ * the machine is a big-endian machine.
+ *
+ * The returned GVariant* should have g_variant_unref() called on it when it is
+ * no longer needed.
+ */
+static GVariant *
+emtr_persistent_cache_flip_bytes_if_big_endian_machine (Emtr_Persistent_Cache *self,
+                                                        GVariant              *variant)
+{
+  if (G_BYTE_ORDER == G_BIG_ENDIAN)
+  {
+    return g_variant_byteswap (variant);
+  }
+  else if (G_BYTE_ORDER != G_LITTLE_ENDIAN)
+  {
+    g_error ("Holy crap! This machine is neither big NOR little-endian, time to panic. AAHAHAHAHAH!\n");
+  }
+  return g_variant_ref (variant);
+}
+
+/*
+ * Updates the metafile cache version number and creates a new meta_file if one doesn't exist.
+ * Returns %TRUE on success.
+ */
+static gboolean
+emtr_persistent_cache_update_cache_version_number (Emtr_Persistent_Cache *self,
+                                                   GCancellable          *cancellable,
+                                                   GError               **error)
+{
+  GFile *meta_file = emtr_persistent_cache_get_cache_file (self, LOCAL_CACHE_VERSION_METAFILE);
+  gchar *version_string = g_strdup_printf ("%i", CURRENT_CACHE_VERSION);
+  gsize version_size = strlen (version_string);
+  gboolean success = g_file_replace_contents (meta_file, version_string, version_size, NULL, FALSE,
+                                              G_FILE_CREATE_PRIVATE | G_FILE_CREATE_REPLACE_DESTINATION,
+                                              NULL, cancellable, error);
+  g_object_unref (meta_file);
+  g_free (version_string);
+  return success;
+}
+
+/*
+ * Testing function that overwrites the metafile with an "older" version number.
+ * Returns TRUE on success, FALSE on failure.
+ */
+gboolean
+emtr_persistent_cache_set_different_version_for_testing (Emtr_Persistent_Cache *self)
+{
+  gint diff_version = CURRENT_CACHE_VERSION - 1;
+  gchar *ver_string = g_strdup_printf ("%i", diff_version);
+  gsize ver_size = strlen (ver_string);
+  GFile *meta_file = emtr_persistent_cache_get_cache_file (self, LOCAL_CACHE_VERSION_METAFILE);
+  gboolean success = g_file_replace_contents (meta_file,ver_string, ver_size, 
+                                              NULL, FALSE, G_FILE_CREATE_NONE, 
+                                              NULL, NULL, NULL);
+  g_object_unref (meta_file);
+  g_free (ver_string);
+  return success;
+}
+
+/*
+ * If the cache version file is out of date or not found, it wil attempt to remove all cached metrics.
+ * If it succeeds, it will update the cache version file to the new_version provided. Will create the
+ * cache directory if it doesn't exist.
+ * Returns %TRUE on success.
+ */
+static gboolean
+emtr_persistent_cache_apply_cache_versioning (Emtr_Persistent_Cache *self,
+                                              GCancellable          *cancellable,
+                                              GError               **error)
+{
+  if (g_mkdir_with_parents (CACHE_DIRECTORY, 0777) != 0)
+  {
+    const gchar *err_str = g_strerror (errno); // Don't free.
+    g_critical ("Failed to create directory: %s . Error:%s\n", CACHE_DIRECTORY, err_str);
+    return FALSE;
+  }
+
+  gint64 old_version;
+  // We don't care about the error here.
+  gboolean could_find = emtr_persistent_cache_load_local_cache_version (self, &old_version);
+  if (!could_find || CURRENT_CACHE_VERSION != old_version)
+  {
+    gboolean success = emtr_persistent_cache_purge_cache_files (self, cancellable, error);
+    if (!success)
+    {
+      if (error != NULL)
+        g_critical ("Failed to purge cache files! Will not update version number. Error: %s\n",
+                    (*error)->message);
+      else
+        g_critical ("Failed to purge cache files! Will not update version number.\n");
+      return FALSE;
+    }
+
+    success = emtr_persistent_cache_update_cache_version_number (self, cancellable, error);
+    if (!success)
+    {
+      if (error != NULL)
+        g_critical ("Failed to update cache version number to %i. Error: %s\n", 
+                    CURRENT_CACHE_VERSION, (*error)->message);
+      else
+        g_critical ("Failed to update cache version number to %i.\n", CURRENT_CACHE_VERSION);
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/*
+ * Sets the cache_size variable of self to the total size in bytes of the cache files.
+ * Returns %TRUE on success.
+ */
+static gboolean
+emtr_persistent_cache_load_cache_size (Emtr_Persistent_Cache *self,
+                                       GCancellable          *cancellable,
+                                       GError               **error)
+{
+  GFile *dir = g_file_new_for_path (CACHE_DIRECTORY);
+  guint64 disk_used;
+  gboolean success = g_file_measure_disk_usage (dir, G_FILE_MEASURE_REPORT_ANY_ERROR, NULL, NULL, NULL,
+                                                &disk_used, NULL, NULL, error);
+  g_object_unref (dir);
+  if (!success)
+  {
+    if (error != NULL)
+      g_critical ("Failed to measure disk usage. Error: %s\n", (*error)->message);
+    else
+      g_critical ("Failed to measure disk usage.\n");
+    return FALSE;
+  }
+
+  Emtr_Persistent_CachePrivate *priv = emtr_persistent_cache_get_instance_private (self);
+  priv->cache_size = disk_used;
+  emtr_persistent_cache_update_capacity (self);
+  return success;
+}
+
+/*
+ * Returns a hint (capacity_t) as to how filled up the cache is and
+ * updates the internal value of capacity.
+ */
+static capacity_t
+emtr_persistent_cache_update_capacity (Emtr_Persistent_Cache *self)
+{
+  Emtr_Persistent_CachePrivate *priv = emtr_persistent_cache_get_instance_private (self);
+  if (priv->capacity == CAPACITY_MAX)
+    return CAPACITY_MAX;
+
+  if (priv->cache_size >= HIGH_CAPACITY_THRESHOLD * MAX_CACHE_SIZE)
+    priv->capacity = CAPACITY_HIGH;
+  else
+    priv->capacity = CAPACITY_LOW;
+
+  return priv->capacity;
+}
+
+/*
+ * Will check if the cache can store 'size' additional bytes. Returns
+ * %TRUE if it can, %FALSE otherwise.
+ */
+static gboolean
+emtr_persistent_cache_has_room (Emtr_Persistent_Cache *self, 
+                                gsize                  size)
+{
+  Emtr_Persistent_CachePrivate *priv = emtr_persistent_cache_get_instance_private (self);
+  if (priv->capacity == CAPACITY_MAX)
+    return FALSE;
+  return priv->cache_size + size <= MAX_CACHE_SIZE;
+}

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -11,6 +11,7 @@ tests_run_tests_SOURCES = \
 	tests/run-tests.c tests/run-tests.h \
 	tests/test-connection.c \
 	tests/test-event-recorder.c \
+	tests/test-persistent-cache.c \
 	tests/test-mac.c \
 	tests/test-osversion.c \
 	tests/test-uuid.c \

--- a/tests/run-tests.c
+++ b/tests/run-tests.c
@@ -99,6 +99,7 @@ main (int    argc,
   add_connection_tests ();
   add_sender_tests ();
   add_event_recorder_tests ();
+  add_persistent_cache_tests ();
 
   return g_test_run ();
 }

--- a/tests/run-tests.h
+++ b/tests/run-tests.h
@@ -62,13 +62,14 @@ void      set_up_mock_version_file      (const gchar       *contents);
 
 /* Each module adds its own test cases: */
 
-void add_util_tests           (void);
-void add_osversion_tests      (void);
-void add_uuid_tests           (void);
-void add_mac_tests            (void);
-void add_web_tests            (void);
-void add_connection_tests     (void);
-void add_sender_tests         (void);
-void add_event_recorder_tests (void);
+void add_util_tests             (void);
+void add_osversion_tests        (void);
+void add_uuid_tests             (void);
+void add_mac_tests              (void);
+void add_web_tests              (void);
+void add_connection_tests       (void);
+void add_sender_tests           (void);
+void add_event_recorder_tests   (void);
+void add_persistent_cache_tests (void);
 
 #endif /* RUN_TESTS_H */

--- a/tests/test-persistent-cache.c
+++ b/tests/test-persistent-cache.c
@@ -1,0 +1,602 @@
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#include "run-tests.h"
+
+#include "eosmetrics/emtr-persistent-cache-private.h"
+
+#include <glib.h>
+#include <stdio.h>
+#include <glib/gstdio.h>
+
+static gchar *TEST_DIRECTORY = "/tmp/metrics_testing/";
+
+#define TEST_SIZE 1024000
+
+// ---- Helper functions come first ----
+
+static void
+tear_down_file (gchar *dir, gchar *file)
+{
+  gchar *combo = g_strconcat (dir, file, NULL);
+  g_unlink (combo);
+  g_free (combo);
+  return;
+}
+
+static void
+tear_down_files (gchar *directory)
+{
+  tear_down_file (directory, CACHE_PREFIX INDIVIDUAL_SUFFIX);
+  tear_down_file (directory, CACHE_PREFIX AGGREGATE_SUFFIX);
+  tear_down_file (directory, CACHE_PREFIX SEQUENCE_SUFFIX);
+  tear_down_file (directory, CACHE_PREFIX LOCAL_CACHE_VERSION_METAFILE);
+  g_rmdir (directory);
+}
+
+static GVariant *
+make_individual_event (gint choice)
+{
+  GVariantBuilder builder;
+  g_variant_builder_init (&builder, G_VARIANT_TYPE ("ay"));
+  gint64 x;
+  GVariant *mv;
+  if (choice <= 0)
+  {
+    g_variant_builder_add (&builder, "y", 0xde);
+    g_variant_builder_add (&builder, "y", 0xad);
+    g_variant_builder_add (&builder, "y", 0xbe);
+    g_variant_builder_add (&builder, "y", 0xef);
+    x = G_GINT64_CONSTANT (42);
+    mv = g_variant_new_string ("murphy");
+  }
+  else if (choice == 1)
+  {
+    g_variant_builder_add (&builder, "y", 0x01);
+    g_variant_builder_add (&builder, "y", 0x23);
+    g_variant_builder_add (&builder, "y", 0x45);
+    g_variant_builder_add (&builder, "y", 0x67);
+    g_variant_builder_add (&builder, "y", 0x89);
+    x = G_GINT64_CONSTANT (999);
+    mv = g_variant_new_int32 (404);
+  }
+  else if (choice == 2)
+  {
+    g_variant_builder_add (&builder, "y", 0x4b);
+    x = G_GINT64_CONSTANT (12012);
+    mv = g_variant_new_string ("I am a banana!");
+  }
+  else if (choice == 3)
+  {
+    g_variant_builder_add (&builder, "y", 0x55);
+    g_variant_builder_add (&builder, "y", 0x2c);
+    x = G_GINT64_CONSTANT (-128);
+    mv = g_variant_new_int32 (64);
+  }
+  else
+  {
+    g_error ("Tried to use a choice for make_individual_event that hasn't been programmed.\n");
+  }
+  return g_variant_new (INDIVIDUAL_TYPE, &builder, x, mv);
+}
+
+static GVariant *
+make_aggregate_event (gint choice)
+{
+  GVariantBuilder builder;
+  g_variant_builder_init (&builder, G_VARIANT_TYPE ("ay"));
+  gint64 x1;
+  gint64 x2;
+  GVariant *mv;
+  if (choice <= 0)
+  {
+    g_variant_builder_add (&builder, "y", 0xde);
+    g_variant_builder_add (&builder, "y", 0xaf);
+    g_variant_builder_add (&builder, "y", 0x00);
+    g_variant_builder_add (&builder, "y", 0x01);
+    x1 = G_GINT64_CONSTANT (9876);
+    x2 = G_GINT64_CONSTANT (111);
+    mv = g_variant_new_string ("meepo");
+  }
+  else if (choice == 1)
+  {
+    g_variant_builder_add (&builder, "y", 0x33);
+    g_variant_builder_add (&builder, "y", 0x44);
+    g_variant_builder_add (&builder, "y", 0x95);
+    g_variant_builder_add (&builder, "y", 0x2a);
+    x1 = G_GINT64_CONSTANT (-333);
+    x2 = G_GINT64_CONSTANT (1);
+    mv = g_variant_new_string ("My spoon is too big.");
+  }
+  else if (choice == 2)
+  {
+    g_variant_builder_add (&builder, "y", 0x33);
+    g_variant_builder_add (&builder, "y", 0x44);
+    g_variant_builder_add (&builder, "y", 0x95);
+    g_variant_builder_add (&builder, "y", 0x2a);
+    g_variant_builder_add (&builder, "y", 0xb4);
+    g_variant_builder_add (&builder, "y", 0x9c);
+    g_variant_builder_add (&builder, "y", 0x2d);
+    g_variant_builder_add (&builder, "y", 0x14);
+    g_variant_builder_add (&builder, "y", 0x45);
+    g_variant_builder_add (&builder, "y", 0xaa);
+    x1 = G_GINT64_CONSTANT (5965);
+    x2 = G_GINT64_CONSTANT (-3984);
+    mv = g_variant_new_string ("!^@#@#^#$");
+  }
+  else
+  {
+    g_error ("Tried to use a choice for make_aggregate_event that hasn't been programmed.\n");
+  }
+  
+  return g_variant_new (AGGREGATE_TYPE, &builder, x1, x2, mv);
+}
+
+static GVariant *
+make_sequence_event (gint choice)
+{
+  GVariantBuilder builder_of_ay;
+  g_variant_builder_init (&builder_of_ay, G_VARIANT_TYPE ("ay"));
+  GVariantBuilder builder_of_axmv;
+  g_variant_builder_init (&builder_of_axmv, G_VARIANT_TYPE ("a(xmv)"));
+
+  if (choice <= 0)
+  {
+    g_variant_builder_add (&builder_of_ay, "y", 0x13);
+    g_variant_builder_add (&builder_of_ay, "y", 0x37);
+    gint64 x1 = G_GINT64_CONSTANT (1876);
+    GVariant *mv1 = g_variant_new_double (3.14159);
+    gint64 x2 = G_GINT64_CONSTANT (0);
+    GVariant *mv2 = g_variant_new_string ("negative-1-point-steve");
+    gint64 x3 = G_GINT64_CONSTANT (-1);
+    GVariant *mv3 = NULL;
+    g_variant_builder_add (&builder_of_axmv, "(xmv)", x1, mv1);
+    g_variant_builder_add (&builder_of_axmv, "(xmv)", x2, mv2);
+    g_variant_builder_add (&builder_of_axmv, "(xmv)", x3, mv3);
+  }
+  else if (choice == 1)
+  {
+    g_variant_builder_add (&builder_of_ay, "y", 0x13);
+    g_variant_builder_add (&builder_of_ay, "y", 0x37);
+    g_variant_builder_add (&builder_of_ay, "y", 0xd0);
+    g_variant_builder_add (&builder_of_ay, "y", 0x0d);
+    gint64 x1 = G_GINT64_CONSTANT (7);
+    GVariant *mv1 = g_variant_new_double (2.71828); // Guess this number!
+    gint64 x2 = G_GINT64_CONSTANT (67352);
+    GVariant *mv2 = g_variant_new_string ("Help! I'm trapped in a testing string!");
+    g_variant_builder_add (&builder_of_axmv, "(xmv)", x1, mv1);
+    g_variant_builder_add (&builder_of_axmv, "(xmv)", x2, mv2);
+  }
+  else if (choice == 2)
+  {
+    g_variant_builder_add (&builder_of_ay, "y", 0xe1);
+    gint64 x1 = G_GINT64_CONSTANT (747);
+    GVariant *mv1 = NULL;
+    gint64 x2 = G_GINT64_CONSTANT (57721);
+    GVariant *mv2 = g_variant_new_string ("Secret message to the Russians: The 'rooster' has 'laid' an 'egg'.\n");
+    gint64 x3 = G_GINT64_CONSTANT (-100);
+    GVariant *mv3 = g_variant_new_double (120.20569);
+    gint64 x4 = G_GINT64_CONSTANT (127384);
+    GVariant *mv4 = g_variant_new_double (-2.685452);
+
+    g_variant_builder_add (&builder_of_axmv, "(xmv)", x1, mv1);
+    g_variant_builder_add (&builder_of_axmv, "(xmv)", x2, mv2);
+    g_variant_builder_add (&builder_of_axmv, "(xmv)", x3, mv3);
+    g_variant_builder_add (&builder_of_axmv, "(xmv)", x4, mv4);
+  }
+  else
+  {
+    g_error ("Tried to use a choice for make_sequence_event that hasn't been programmed.\n");
+  }
+  
+  return g_variant_new (SEQUENCE_TYPE, &builder_of_ay, &builder_of_axmv);
+}
+
+static gboolean
+store_single_individual_event (Emtr_Persistent_Cache *cache, 
+                               capacity_t            *capacity)
+{
+  GVariant *var = make_individual_event (0);
+  GVariant *var_array[] = {var, NULL};
+  GVariant *empty_array[] = {NULL};
+  gboolean success = emtr_persistent_cache_store_metrics (cache, var_array, empty_array, empty_array, capacity);
+  g_variant_unref (var);
+  return success;
+}
+
+static gboolean
+store_single_aggregate_event (Emtr_Persistent_Cache *cache,
+                              capacity_t            *capacity)
+{
+  GVariant *var = make_aggregate_event (0);
+  GVariant *var_array[] = {var, NULL};
+  GVariant *empty_array[] = {NULL};
+  gboolean success = emtr_persistent_cache_store_metrics (cache, empty_array, var_array, empty_array, capacity);
+  g_variant_unref (var);
+  return success;
+}
+
+static gboolean
+store_single_sequence_event (Emtr_Persistent_Cache *cache,
+                             capacity_t            *capacity)
+{
+  GVariant *var = make_sequence_event (0);
+  GVariant *var_array[] = {var, NULL};
+  GVariant *empty_array[] = {NULL};
+  gboolean success = emtr_persistent_cache_store_metrics (cache, empty_array, empty_array, var_array, capacity);
+  g_variant_unref (var);
+  return success;
+}
+
+static void
+make_many_events (GVariant ***inds, 
+                  GVariant ***aggs,
+                  GVariant ***seqs)
+{
+  *inds = g_new (GVariant *, 5 * sizeof (GVariant *));
+  for (int i = 0; i < 4; i++)
+  {
+    (*inds)[i] = make_individual_event (i);
+  }
+  (*inds)[4] = NULL;
+
+  *aggs = g_new (GVariant *, 4 * sizeof (GVariant *));
+  for (int i = 0; i < 3; i++)
+  {
+    (*aggs)[i] = make_aggregate_event (i);
+  }
+  (*aggs)[3] = NULL;
+
+  *seqs = g_new (GVariant *, 4 * sizeof (GVariant *));
+  for (int i = 0; i < 3; i++)
+  {
+    (*seqs)[i] = make_sequence_event (i);
+  }
+  (*seqs)[3] = NULL;
+}
+
+static void
+free_variant_c_array (GVariant **array)
+{
+  g_return_if_fail (array != NULL);
+
+  for (int i = 0; array[i] != NULL; i++)
+  {
+    g_variant_unref (array[i]);
+  }
+  g_free (array);
+}
+
+static gboolean
+store_many (Emtr_Persistent_Cache *cache, 
+            capacity_t            *capacity)
+{
+  GVariant **var_ind_array;
+  GVariant **var_agg_array;
+  GVariant **var_seq_array;
+  make_many_events (&var_ind_array, &var_agg_array, &var_seq_array);
+  gboolean success = emtr_persistent_cache_store_metrics (cache, 
+                                                          var_ind_array, 
+                                                          var_agg_array, 
+                                                          var_seq_array, 
+                                                          capacity);
+  free_variant_c_array (var_ind_array);
+  free_variant_c_array (var_agg_array);
+  free_variant_c_array (var_seq_array);
+
+  return success;
+}
+
+static gboolean
+check_all_gvariants_equal (GVariant **this_array, 
+                           GVariant **other_array)
+{
+  g_assert (this_array != NULL);
+  g_assert (other_array != NULL);
+
+  for (int i = 0; this_array[i] != NULL || other_array[i] != NULL; i++)
+  {
+    if (this_array[i] == NULL || other_array[i] == NULL)
+    {
+      g_error ("Array lengths are not equal.\n");
+    }
+    if (!g_variant_equal (this_array[i], other_array[i]))
+    {
+      gchar *this_one = g_variant_print (this_array[i], TRUE);
+      gchar *other_one = g_variant_print (other_array[i], TRUE);
+      g_error ("%s is not equal to %s\n", this_one, other_one);
+    }
+  }
+  return TRUE;
+}
+
+// ----- Actual Test Cases below ------
+
+static void
+test_persistent_cache_new_succeeds (void)
+{
+  tear_down_files (TEST_DIRECTORY);
+  GError *error = NULL;
+  Emtr_Persistent_Cache *cache = emtr_persistent_cache_new (NULL, &error, TEST_DIRECTORY, TEST_SIZE);
+  g_assert (cache != NULL);
+  if (error != NULL)
+    g_error_free (error);
+  g_assert (error == NULL);
+  g_object_unref (cache);
+}
+
+static void
+test_persistent_cache_store_one_individual_event_succeeds (void)
+{
+  tear_down_files (TEST_DIRECTORY);
+  Emtr_Persistent_Cache *cache = emtr_persistent_cache_new (NULL, NULL, TEST_DIRECTORY, TEST_SIZE);
+  capacity_t capacity;
+  gboolean success = store_single_individual_event (cache, &capacity);
+  g_object_unref (cache);
+  g_assert (success);
+  g_assert (capacity == CAPACITY_LOW);
+}
+
+static void
+test_persistent_cache_store_one_aggregate_event_succeeds (void)
+{
+  tear_down_files (TEST_DIRECTORY);
+  Emtr_Persistent_Cache *cache = emtr_persistent_cache_new (NULL, NULL, TEST_DIRECTORY, TEST_SIZE);
+  capacity_t capacity;
+  gboolean success = store_single_aggregate_event (cache, &capacity);
+  g_object_unref (cache);
+  g_assert (success);
+  g_assert (capacity == CAPACITY_LOW);
+}
+
+static void
+test_persistent_cache_store_one_sequence_event_succeeds (void)
+{
+  tear_down_files (TEST_DIRECTORY);
+  Emtr_Persistent_Cache *cache = emtr_persistent_cache_new (NULL, NULL, TEST_DIRECTORY, TEST_SIZE);
+  capacity_t capacity;
+  gboolean success = store_single_sequence_event (cache, &capacity);
+  g_object_unref (cache);
+  g_assert (success);
+  g_assert (capacity == CAPACITY_LOW);
+}
+
+static void
+test_persistent_cache_store_one_of_each_succeeds (void)
+{
+  tear_down_files (TEST_DIRECTORY);
+  Emtr_Persistent_Cache *cache = emtr_persistent_cache_new (NULL, NULL, TEST_DIRECTORY, TEST_SIZE);
+  GVariant *ind = make_individual_event (0);
+  GVariant *agg = make_aggregate_event (0);
+  GVariant *seq = make_sequence_event (0);
+  GVariant *ind_a[] = {ind, NULL};
+  GVariant *agg_a[] = {agg, NULL};
+  GVariant *seq_a[] = {seq, NULL};
+  capacity_t capacity;
+  gboolean success = emtr_persistent_cache_store_metrics (cache, ind_a, agg_a, seq_a, &capacity);
+  g_object_unref (cache);
+  g_variant_unref (ind);
+  g_variant_unref (agg);
+  g_variant_unref (seq);
+  g_assert (success);
+  g_assert (capacity == CAPACITY_LOW);
+}
+
+static void
+test_persistent_cache_store_many_succeeds (void)
+{
+  tear_down_files (TEST_DIRECTORY);
+  Emtr_Persistent_Cache *cache = emtr_persistent_cache_new (NULL, NULL, TEST_DIRECTORY, TEST_SIZE);
+  capacity_t capacity;
+  gboolean success = store_many (cache, &capacity);
+  g_object_unref (cache);
+  g_assert (success);
+}
+
+static void
+test_persistent_cache_store_when_full_succeeds (void)
+{
+  guint space_in_bytes = 3000;
+  tear_down_files (TEST_DIRECTORY);
+  Emtr_Persistent_Cache *cache = emtr_persistent_cache_new (NULL, 
+                                                            NULL,
+                                                            TEST_DIRECTORY,
+                                                            space_in_bytes);
+  capacity_t capacity;
+  gboolean success = TRUE;
+
+  // Store a ton, until it is full.
+  // Update when storing functions return bytes stored.  TODO
+  int iterations = space_in_bytes / 150;
+  for (int i = 0; i < iterations; i++)
+  {
+    success &= store_many (cache, &capacity);
+  }
+  g_object_unref (cache);
+  g_assert (success);
+  g_assert (capacity == CAPACITY_MAX);
+}
+
+static void
+test_persistent_cache_drain_one_individual_succeeds (void)
+{
+  tear_down_files (TEST_DIRECTORY);
+  Emtr_Persistent_Cache *cache = emtr_persistent_cache_new (NULL, NULL, TEST_DIRECTORY, TEST_SIZE);
+  capacity_t capacity;
+  GVariant *var = make_individual_event (1);
+  GVariant *var_array[] = {var, NULL};
+  GVariant *empty_array[] = {NULL};
+  emtr_persistent_cache_store_metrics (cache, var_array, empty_array, empty_array, &capacity);
+
+  GVariant **ind_array = NULL;
+  GVariant **agg_array = NULL;
+  GVariant **seq_array = NULL;
+  gboolean success = emtr_persistent_cache_drain_metrics (cache, &ind_array, &agg_array, &seq_array);
+  g_object_unref (cache);
+  g_assert (success);
+  g_assert (check_all_gvariants_equal (var_array, ind_array));
+  g_assert (check_all_gvariants_equal (empty_array, agg_array));
+  g_assert (check_all_gvariants_equal (empty_array, seq_array));
+  g_variant_unref (var);
+  free_variant_c_array (ind_array);
+  free_variant_c_array (agg_array);
+  free_variant_c_array (seq_array);
+}
+
+static void
+test_persistent_cache_drain_one_aggregate_succeeds (void)
+{
+  tear_down_files (TEST_DIRECTORY);
+  Emtr_Persistent_Cache *cache = emtr_persistent_cache_new (NULL, NULL, TEST_DIRECTORY, TEST_SIZE);
+  capacity_t capacity;
+  GVariant *var = make_aggregate_event (1);
+  GVariant *var_array[] = {var, NULL};
+  GVariant *empty_array[] = {NULL};
+  emtr_persistent_cache_store_metrics (cache, empty_array, var_array, empty_array, &capacity);
+
+  GVariant **ind_array = NULL;
+  GVariant **agg_array = NULL;
+  GVariant **seq_array = NULL;
+  gboolean success = emtr_persistent_cache_drain_metrics (cache, &ind_array, &agg_array, &seq_array);
+  g_object_unref (cache);
+  g_assert (success);
+  g_assert (check_all_gvariants_equal (empty_array, ind_array));
+  g_assert (check_all_gvariants_equal (var_array, agg_array));
+  g_assert (check_all_gvariants_equal (empty_array, seq_array));
+  g_variant_unref (var);
+  free_variant_c_array (ind_array);
+  free_variant_c_array (agg_array);
+  free_variant_c_array (seq_array);
+}
+
+static void
+test_persistent_cache_drain_one_sequence_succeeds (void)
+{
+  tear_down_files (TEST_DIRECTORY);
+  Emtr_Persistent_Cache *cache = emtr_persistent_cache_new (NULL, NULL, TEST_DIRECTORY, TEST_SIZE);
+  capacity_t capacity;
+  GVariant *var = make_sequence_event (1);
+  GVariant *var_array[] = {var, NULL};
+  GVariant *empty_array[] = {NULL};
+  emtr_persistent_cache_store_metrics (cache, empty_array, empty_array, var_array, &capacity);
+
+  GVariant **ind_array = NULL;
+  GVariant **agg_array = NULL;
+  GVariant **seq_array = NULL;
+  gboolean success = emtr_persistent_cache_drain_metrics (cache, &ind_array, &agg_array, &seq_array);
+  g_object_unref (cache);
+  g_assert (success);
+  g_assert (check_all_gvariants_equal (empty_array, ind_array));
+  g_assert (check_all_gvariants_equal (empty_array, agg_array));
+  g_assert (check_all_gvariants_equal (var_array, seq_array));
+  g_variant_unref (var);
+  free_variant_c_array (ind_array);
+  free_variant_c_array (agg_array);
+  free_variant_c_array (seq_array);
+}
+
+static void
+test_persistent_cache_drain_many_succeeds (void)
+{
+  tear_down_files (TEST_DIRECTORY);
+  Emtr_Persistent_Cache *cache = emtr_persistent_cache_new (NULL, NULL, TEST_DIRECTORY, TEST_SIZE);
+  capacity_t capacity;
+
+  // Fill it up first.
+  GVariant **ind_array;
+  GVariant **agg_array;
+  GVariant **seq_array;
+  make_many_events (&ind_array, &agg_array, &seq_array);
+  emtr_persistent_cache_store_metrics (cache, ind_array, agg_array, seq_array, &capacity);
+
+  // Check if we get the same things back.
+  GVariant **new_ind_array = NULL;
+  GVariant **new_agg_array = NULL;
+  GVariant **new_seq_array = NULL;
+  gboolean success = emtr_persistent_cache_drain_metrics (cache, &new_ind_array, &new_agg_array, &new_seq_array);
+  g_assert (success);
+  g_assert (check_all_gvariants_equal (ind_array, new_ind_array));
+  g_assert (check_all_gvariants_equal (agg_array, new_agg_array));
+  g_assert (check_all_gvariants_equal (seq_array, new_seq_array));
+  free_variant_c_array (ind_array);
+  free_variant_c_array (agg_array);
+  free_variant_c_array (seq_array);
+  free_variant_c_array (new_ind_array);
+  free_variant_c_array (new_agg_array);
+  free_variant_c_array (new_seq_array);
+  g_object_unref (cache);
+}
+
+static void
+test_persistent_cache_drain_empty_succeeds (void)
+{
+  tear_down_files (TEST_DIRECTORY);
+  // Don't store anything.
+  Emtr_Persistent_Cache *cache = emtr_persistent_cache_new (NULL, NULL, TEST_DIRECTORY, TEST_SIZE);
+  GVariant **ind_array;
+  GVariant **agg_array;
+  GVariant **seq_array;
+  gboolean success = emtr_persistent_cache_drain_metrics (cache, &ind_array, &agg_array, &seq_array);
+  g_assert (success);
+
+  // Should contain logically empty arrays.
+  GVariant *empty_array[] = {NULL};
+  g_assert (check_all_gvariants_equal (ind_array, empty_array));
+  g_assert (check_all_gvariants_equal (agg_array, empty_array));
+  g_assert (check_all_gvariants_equal (seq_array, empty_array));
+  g_object_unref (cache);
+}
+
+static void
+test_persistent_cache_purges_when_out_of_date_succeeds (void)
+{
+  tear_down_files (TEST_DIRECTORY);
+  Emtr_Persistent_Cache *cache = emtr_persistent_cache_new (NULL, NULL, TEST_DIRECTORY, TEST_SIZE);
+  capacity_t capacity;
+  store_many (cache, &capacity);
+  gboolean success = emtr_persistent_cache_set_different_version_for_testing (cache);
+  g_object_unref (cache);
+  g_assert (success);
+
+  Emtr_Persistent_Cache *cache2 = emtr_persistent_cache_new (NULL, NULL, TEST_DIRECTORY, TEST_SIZE);
+  // Metrics should all be purged now.
+  GVariant **ind_array;
+  GVariant **agg_array;
+  GVariant **seq_array;
+  emtr_persistent_cache_drain_metrics (cache2, &ind_array, &agg_array, &seq_array);
+  GVariant *empty_array[] = {NULL};
+  g_assert (check_all_gvariants_equal (ind_array, empty_array));
+  g_assert (check_all_gvariants_equal (agg_array, empty_array));
+  g_assert (check_all_gvariants_equal (seq_array, empty_array));
+  g_object_unref (cache2);
+}
+
+void
+add_persistent_cache_tests (void)
+{
+  g_test_add_func ("/persistent-cache/new-succeeds",
+                   test_persistent_cache_new_succeeds);
+  g_test_add_func ("/persistent-cache/store-one-individual-event-succeeds",
+                   test_persistent_cache_store_one_individual_event_succeeds);
+  g_test_add_func ("/persistent-cache/store-one-aggregate-event-succeeds",
+                   test_persistent_cache_store_one_aggregate_event_succeeds);
+  g_test_add_func ("/persistent-cache/store-one-sequence-event-succeeds",
+                   test_persistent_cache_store_one_sequence_event_succeeds);
+  g_test_add_func ("/persistent-cache/store-one-of-each-succeeds",
+                   test_persistent_cache_store_one_of_each_succeeds);
+  g_test_add_func ("/persistent-cache/store-many-succeeds",
+                   test_persistent_cache_store_many_succeeds);
+  g_test_add_func ("/persistent-cache/store-when-full-succeeds",
+                   test_persistent_cache_store_when_full_succeeds);
+  g_test_add_func ("/persistent-cache/drain-one-individual-succeeds",
+                   test_persistent_cache_drain_one_individual_succeeds);
+  g_test_add_func ("/persistent-cache/drain-one-aggregate-succeeds",
+                   test_persistent_cache_drain_one_aggregate_succeeds);
+  g_test_add_func ("/persistent-cache/drain-one-sequence-succeeds",
+                   test_persistent_cache_drain_one_sequence_succeeds);
+  g_test_add_func ("/persistent-cache/drain-many-succeeds",
+                   test_persistent_cache_drain_many_succeeds);
+  g_test_add_func ("/persistent-cache/drain-empty-succeeds",
+                   test_persistent_cache_drain_empty_succeeds);
+  g_test_add_func ("/persistent-cache/purges-when-out-of-date-succeeds",
+                   test_persistent_cache_purges_when_out_of_date_succeeds);
+}


### PR DESCRIPTION
This is code for the Persistent Cache library which will be called by an event recorder/daemon yet to be written.  (The issue should probably be renamed and a followup issue generated as a consequence.)

[endlessm/eos-sdk#592]
