### PR TITLE
DBus interface for metrics event recorder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ eos-metrics-0.0.0
 /EosMetrics-0.typelib
 /docs/reference/eosmetrics/version.xml
 /tools/eos-send-metrics
+/emer-event-recorder-server.[ch]
+/eos-metrics-event-recorder
+/data/eos-metrics-event-recorder.service
 
 # Test products
 *.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,15 +22,19 @@ AM_CFLAGS = @STRICT_CFLAGS@
 
 # Make sure to run Gtk-doc tests and build the documentation when doing
 # 'make distcheck'
-DISTCHECK_CONFIGURE_FLAGS = \
+AM_DISTCHECK_CONFIGURE_FLAGS = \
 	--enable-gtk-doc \
 	--enable-gir-doc \
 	--enable-strict-flags \
+	--with-systemdsystemunitdir=$(libdir)/systemd \
 	$(NULL)
 
 # Generated files that 'make clean' should erase
 CLEANFILES =
 DISTCLEANFILES =
+
+# Generated sources that should be built before other sources
+BUILT_SOURCES =
 
 # Make sure that 'make dist' includes documentation
 if CAN_MAKE_DIST
@@ -43,6 +47,10 @@ dist-hook:
 	@echo "***"
 	@false
 endif
+
+# # # DATA # # #
+
+include $(top_srcdir)/data/Makefile.am.inc
 
 # # # LIBRARY # # #
 
@@ -60,6 +68,10 @@ nobase_eosmetricsinclude_HEADERS = \
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = @EMTR_API_NAME@.pc
 DISTCLEANFILES += @EMTR_API_NAME@.pc
+
+# # # DBUS DAEMON ("EVENT RECORDER SERVER") # # #
+
+include $(top_srcdir)/daemon/Makefile.am.inc
 
 # # # INTROSPECTION FILES # # #
 

--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,8 @@ AC_SUBST(EMTR_LT_VERSION_INFO)
 # Required versions of libraries
 # Update these whenever you use a function that requires a certain API version
 GLIB_REQUIREMENT="glib-2.0 >= 2.40"
-GIO_REQUIREMENT="gio-2.0"
+GIO_REQUIREMENT="gio-2.0 >= 2.30
+    gio-unix-2.0"
 GOBJECT_REQUIREMENT="gobject-2.0"
 JSON_REQUIREMENT="json-glib-1.0 >= 0.16"
 SOUP_REQUIREMENT="libsoup-2.4 >= 2.42"
@@ -108,6 +109,10 @@ AC_PATH_PROG([GIRDOCTOOL], [g-ir-doc-tool], [notfound])
 AC_ARG_VAR([GIRDOCTOOL], [Path to g-ir-doc-tool])
 AC_PATH_PROG([YELPBUILD], [yelp-build], [notfound])
 AC_ARG_VAR([YELPBUILD], [Path to yelp-build])
+AC_PATH_PROG([GDBUS_CODEGEN], [gdbus-codegen], [notfound])
+AS_IF([test "x$GDBUS_CODEGEN" = "xnotfound"],
+    [AC_MSG_ERROR([Could not find gdbus-codegen])])
+AC_ARG_VAR([GDBUS_CODEGEN], [Path to gdbus-codegen])
 
 AC_CACHE_SAVE
 
@@ -175,9 +180,22 @@ AM_COND_IF([ENABLE_GIR_DOC], [], [can_make_dist=no])
 AM_CONDITIONAL([CAN_MAKE_DIST], [test "x$can_make_dist" = "xyes"])
 AC_MSG_RESULT([$can_make_dist])
 
+systemdsystemunitdir="$($PKG_CONFIG systemd --variable=systemdsystemunitdir)"
+dnl Allow overriding systemdsystemunitdir during distcheck in order to trick
+dnl Automake into allowing an install outside of $prefix
+AC_ARG_WITH([systemdsystemunitdir],
+    [AS_HELP_STRING([--with-systemdsystemunitdir=PATH], [directory for systemd service files])],
+    [systemdsystemunitdir="$withval"])
+AC_SUBST([systemdsystemunitdir])
+
 # Required libraries
 # ------------------
 PKG_CHECK_MODULES([EOSMETRICS], [
+    $EMTR_REQUIRED_MODULES
+    $EMTR_REQUIRED_MODULES_PRIVATE])
+dnl These requirements are the same for now, until the functionality is
+dnl separated from one into the other
+PKG_CHECK_MODULES([EOSMETRICS_EVENT_RECORDER], [
     $EMTR_REQUIRED_MODULES
     $EMTR_REQUIRED_MODULES_PRIVATE])
 

--- a/daemon/Makefile.am.inc
+++ b/daemon/Makefile.am.inc
@@ -1,0 +1,11 @@
+# Copyright 2014 Endless Mobile, Inc.
+
+libexec_PROGRAMS = eos-metrics-event-recorder
+
+## emer-event-recorder-server.[ch] are generated in ../data/Makefile.am.inc.
+eos_metrics_event_recorder_SOURCES = \
+	daemon/emer-main.c \
+	emer-event-recorder-server.c emer-event-recorder-server.h \
+	$(NULL)
+eos_metrics_event_recorder_CPPFLAGS = $(EOSMETRICS_EVENT_RECORDER_CFLAGS)
+eos_metrics_event_recorder_LDADD = $(EOSMETRICS_EVENT_RECORDER_LIBS)

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -1,0 +1,128 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#include <glib.h>
+#include <glib-object.h>
+#include <glib-unix.h>
+#include <gio/gio.h>
+
+#include "emer-event-recorder-server.h"
+
+static gboolean
+on_record_singular_event (EmerEventRecorderServer *server,
+                          GDBusMethodInvocation   *invocation,
+                          guint32                  user_id,
+                          GVariant                *event_id,
+                          gint64                   relative_timestamp,
+                          gboolean                 has_payload,
+                          GVariant                *payload)
+{
+  emer_event_recorder_server_complete_record_singular_event (server,
+                                                             invocation);
+  return TRUE;
+}
+
+static gboolean
+on_record_aggregate_event (EmerEventRecorderServer *server,
+                           GDBusMethodInvocation   *invocation,
+                           guint32                  user_id,
+                           GVariant                *event_id,
+                           gint64                   count,
+                           gint64                   relative_timestamp,
+                           gboolean                 has_payload,
+                           GVariant                *payload)
+{
+  emer_event_recorder_server_complete_record_aggregate_event (server,
+                                                              invocation);
+  return TRUE;
+}
+
+static gboolean
+on_record_event_sequence (EmerEventRecorderServer *server,
+                          GDBusMethodInvocation   *invocation,
+                          guint32                  user_id,
+                          GVariant                *event_id,
+                          GVariant                *events)
+{
+  emer_event_recorder_server_complete_record_event_sequence (server,
+                                                             invocation);
+  return TRUE;
+}
+
+static gboolean
+quit_main_loop (GMainLoop *main_loop)
+{
+  g_main_loop_quit (main_loop);
+  return G_SOURCE_REMOVE;
+}
+
+/* Called when a reference to the system bus is acquired. This is where you are
+supposed to export your well-known name, confusingly not in name_acquired; that
+is too late. */
+static void
+on_bus_acquired (GDBusConnection *system_bus,
+                 const gchar     *name)
+{
+  EmerEventRecorderServer *server = emer_event_recorder_server_skeleton_new ();
+  g_signal_connect (server, "handle-record-singular-event",
+                    G_CALLBACK (on_record_singular_event), NULL);
+  g_signal_connect (server, "handle-record-aggregate-event",
+                    G_CALLBACK (on_record_aggregate_event), NULL);
+  g_signal_connect (server, "handle-record-event-sequence",
+                    G_CALLBACK (on_record_event_sequence), NULL);
+
+  GError *error = NULL;
+  if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (server),
+                                         system_bus,
+                                         "/com/endlessm/Metrics",
+                                         &error))
+    {
+      g_error ("Could not export metrics interface on system bus: %s",
+               error->message);
+    }
+}
+
+/* This is called if ownership of the well-known name is lost. Since this
+service doesn't own and un-own the name during its lifetime, this is only called
+if there is an error acquiring it in the first place. */
+static void
+on_name_lost (GDBusConnection *system_bus,
+              const gchar     *name)
+{
+  /* This handler is called with a NULL connection if the bus could not be
+  acquired. */
+  if (system_bus == NULL)
+    {
+      g_error ("Could not get connection to system bus.");
+    }
+  g_error ("Could not acquire name '%s' on system bus.", name);
+}
+
+int
+main (int                argc,
+      const char * const argv[])
+{
+  GMainLoop *main_loop = g_main_loop_new (NULL, TRUE);
+
+  /* Shut down on any of these signals */
+  g_unix_signal_add (SIGHUP, (GSourceFunc)quit_main_loop, main_loop);
+  g_unix_signal_add (SIGINT, (GSourceFunc)quit_main_loop, main_loop);
+  g_unix_signal_add (SIGTERM, (GSourceFunc)quit_main_loop, main_loop);
+  g_unix_signal_add (SIGUSR1, (GSourceFunc)quit_main_loop, main_loop);
+  g_unix_signal_add (SIGUSR2, (GSourceFunc)quit_main_loop, main_loop);
+
+  guint name_id = g_bus_own_name (G_BUS_TYPE_SYSTEM, "com.endlessm.Metrics",
+                                  G_BUS_NAME_OWNER_FLAGS_NONE,
+                                  (GBusAcquiredCallback)on_bus_acquired,
+                                  NULL, /* name_acquired_callback */
+                                  (GBusNameLostCallback)on_name_lost,
+                                  NULL, NULL);
+
+  g_main_loop_run (main_loop);
+
+  g_bus_unown_name(name_id);
+  g_main_loop_unref (main_loop);
+
+  return 0;
+}

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -1,0 +1,36 @@
+# Copyright 2014 Endless Mobile, Inc.
+
+daemon_dbus_name = emer-event-recorder-server
+daemon_dbus_sources = $(daemon_dbus_name).c $(daemon_dbus_name).h
+BUILT_SOURCES += $(daemon_dbus_sources)
+$(daemon_dbus_sources): data/com.endlessm.Metrics.xml
+	$(AM_V_GEN)$(GDBUS_CODEGEN) --generate-c-code $(daemon_dbus_name) \
+		--c-namespace Emer \
+		--interface-prefix com.endlessm.Metrics. \
+		$<
+
+# Defined as systemdsystemunitdir in ../configure.ac.
+systemdsystemunit_DATA = data/eos-metrics-event-recorder.service
+
+data/eos-metrics-event-recorder.service: data/eos-metrics-event-recorder.service.in
+	$(AM_V_GEN)mkdir -p data && \
+	rm -f $@ $@.tmp && \
+	$(edit) $< >$@.tmp && \
+	mv $@.tmp $@
+
+edit = sed \
+	-e 's|@libexecdir[@]|$(libexecdir)|g' \
+	$(NULL)
+
+systembussecuritypolicydir = ${sysconfdir}/dbus-1/system.d
+dist_systembussecuritypolicy_DATA = data/com.endlessm.Metrics.conf
+
+EXTRA_DIST += \
+	data/com.endlessm.Metrics.xml \
+	data/eos-metrics-event-recorder.service.in \
+	$(NULL)
+
+CLEANFILES += \
+	$(daemon_dbus_sources) \
+	data/eos-metrics-event-recorder.service \
+	$(NULL)

--- a/data/com.endlessm.Metrics.conf
+++ b/data/com.endlessm.Metrics.conf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+
+  <!-- The service can only be provided by root, but anyone can send messages to
+  it. -->
+  <policy user="root">
+    <allow own="com.endlessm.Metrics"/>
+  </policy>
+
+  <policy context="default">
+    <allow send_destination="com.endlessm.Metrics" send_interface="com.endlessm.Metrics.EventRecorderServer"/>
+    <!-- This is to allow debugging with d-feet, for example. -->
+    <allow send_destination="com.endlessm.Metrics" send_interface="org.freedesktop.DBus.Introspectable"/>
+  </policy>
+</busconfig>

--- a/data/eos-metrics-event-recorder.service.in
+++ b/data/eos-metrics-event-recorder.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=EndlessOS Metrics Event Recorder Server
+Requires=dbus.service
+After=dbus.service
+
+[Service]
+User=root
+Type=dbus
+BusName=com.endlessm.Metrics
+ExecStart=@libexecdir@/eos-metrics-event-recorder
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Provides a DBus service on the system bus that exports more or less the
same methods as EmtrEventRecorder. This service does nothing yet, but
eventually the EmtrEventRecorder functionality will be moved to the
service and EmtrEventRecorder will become a very thin layer.

[endlessm/eos-sdk#581]
