### PR TITLE
Sdk/1049

### DIFF
--- a/docs/reference/eosmetrics/eosmetrics-docs.xml
+++ b/docs/reference/eosmetrics/eosmetrics-docs.xml
@@ -23,6 +23,7 @@
     <xi:include href="xml/emtr-connection.xml"/>
     <xi:include href="xml/emtr-sender.xml"/>
     <xi:include href="xml/emtr-event-recorder.xml"/>
+    <xi:include href="xml/emtr-machine-id-provider.xml"/>
     <xi:include href="xml/emtr-event-types.xml" />
   </chapter>
 

--- a/docs/reference/eosmetrics/eosmetrics-sections.txt
+++ b/docs/reference/eosmetrics/eosmetrics-sections.txt
@@ -74,6 +74,7 @@ emtr_sender_get_type
 <TITLE>EmtrEventRecorder</TITLE>
 EmtrEventRecorder
 EmtrEventRecorderClass
+emtr_event_recorder_get_default
 emtr_event_recorder_new
 <SUBSECTION Methods>
 emtr_event_recorder_record_event
@@ -99,4 +100,23 @@ EMTR_EVENT_USER_IS_LOGGED_IN
 EMTR_EVENT_NETWORK_STATUS_CHANGED
 EMTR_EVENT_SHELL_APP_IS_OPEN
 EMTR_EVENT_SOCIAL_BAR_IS_VISIBLE
+</SECTION>
+
+<SECTION>
+<FILE>emtr-machine-id-provider</FILE>
+<TITLE>EmtrMachineIdProvider</TITLE>
+EmtrMachineIdProvider
+EmtrMachineIdProviderClass
+emtr_machine_id_provider_get_default
+emtr_machine_id_provider_new
+<SUBSECTION Methods>
+emtr_machine_id_provider_get_id
+<SUBSECTION Standard>
+EMTR_MACHINE_ID_PROVIDER
+EMTR_MACHINE_ID_PROVIDER_CLASS
+EMTR_MACHINE_ID_PROVIDER_GET_CLASS
+EMTR_IS_MACHINE_ID_PROVIDER
+EMTR_IS_MACHINE_ID_PROVIDER_CLASS
+EMTR_TYPE_MACHINE_ID_PROVIDER
+emtr_machine_id_provider_get_type
 </SECTION>

--- a/eosmetrics/Makefile.am.inc
+++ b/eosmetrics/Makefile.am.inc
@@ -12,6 +12,9 @@ eosmetrics_private_installed_headers = \
 	eosmetrics/emtr-types.h \
 	eosmetrics/emtr-util.h \
 	eosmetrics/emtr-version.h \
+	eosmetrics/emtr-connection.h \
+	eosmetrics/emtr-sender.h \
+	eosmetrics/emtr-machine-id-provider.h \
 	$(NULL)
 
 eosmetrics_library_sources = \
@@ -24,6 +27,7 @@ eosmetrics_library_sources = \
 	eosmetrics/emtr-util.c eosmetrics/emtr-util-private.h \
 	eosmetrics/emtr-uuid.c eosmetrics/emtr-uuid-private.h \
 	eosmetrics/emtr-web.c eosmetrics/emtr-web-private.h \
+	eosmetrics/emtr-machine-id-provider.c
 	$(NULL)
 
 lib_LTLIBRARIES = libeosmetrics-@EMTR_API_VERSION@.la

--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -13,77 +13,13 @@
 #include <glib/gprintf.h>
 #include <glib/gstdio.h>
 #include <libsoup/soup.h>
+#include <uuid/uuid.h>
 #include <time.h>
 #include <stdio.h>
 #include <string.h>
-#include <uuid/uuid.h>
 
 /* Convenience macro to check that @ptr is a #GVariant */
 #define _IS_VARIANT(ptr) (g_variant_is_of_type ((ptr), G_VARIANT_TYPE_ANY))
-
-/*
- * Must be incremented every time the network protocol is changed so that the
- * proxy server can correctly handle both old and new clients while the updated
- * metrics package rolls out to all clients.
- */
-#define CLIENT_VERSION 0
-
-/*
- * Filepath at which the random UUID that persistently identifies this machine
- * is stored.
- * In order to protect the anonymity of our users, the ID stored in this file
- * must be randomly generated and not traceable back to the user's device.
- * See http://www.freedesktop.org/software/systemd/man/machine-id.html for more
- * details.
- */
-#define MACHINE_ID_FILEPATH "/etc/machine-id"
-
-/*
- * The expected size in bytes of the file located at MACHINE_ID_FILEPATH.
- * According to http://www.freedesktop.org/software/systemd/man/machine-id.html
- * the file should be 32 lower-case hexadecimal characters followed by a
- * newline character.
- */
-#define MACHINE_ID_FILE_SIZE 33
-
-/*
- * Specifies whether the metrics come from regular users in production,
- * employees/contractors developing EndlessOS, or automated tests. For now, we
- * consider all metrics to come from a development environment until we build
- * some confidence in the metrics system.
- */
-#define ENVIRONMENT "dev"
-
-/*
- * The maximum frequency with which an attempt to send metrics over the network
- * is made.
- */
-#define NETWORK_SEND_INTERVAL_SECONDS (60 * 60)
-
-/*
- * The number of elements in a uuid_t. uuid_t is assumed to be a fixed-length
- * array of guchar.
- */
-#define UUID_LENGTH (sizeof (uuid_t) / sizeof (guchar))
-
-/*
- * The maximum number of ordinary events that may be stored in RAM in the buffer
- * of events waiting to be sent to the metrics server.
- */
-#define EVENT_BUFFER_LENGTH 2000
-
-/*
- * The maximum number of aggregated events that may be stored in RAM in the
- * buffer of events waiting to be sent to the metrics server.
- */
-#define AGGREGATE_BUFFER_LENGTH 2000
-
-/*
- * The maximum number of event sequences that may be stored in RAM in the buffer
- * of event sequences waiting to be sent to the metrics server. Does not include
- * unstopped event sequences.
- */
-#define SEQUENCE_BUFFER_LENGTH 2000
 
 // The number of nanoseconds in one second.
 #define NANOSECONDS_PER_SECOND 1000000000L
@@ -91,21 +27,15 @@
 // TODO: Once we have a production proxy server, update this constant
 // accordingly.
 // The URI of the metrics production proxy server.
-#define PROXY_PROD_SERVER_URI "http://metrics-test.endlessm-sf.com:8080/"
-
-// The URI of the metrics test proxy server.
-#define PROXY_TEST_SERVER_URI "http://metrics-test.endlessm-sf.com:8080/"
+// Is kept in a #define to prevent testing code from sending metrics to the
+// production server.
+#define PRODUCTION_SERVER_URI "http://metrics-test.endlessm-sf.com:8080/"
 
 /*
- * Caches a random UUID stored in a file that persistently identifies this
- * machine. In order to protect the anonymity of our users, this ID must be
- * randomly generated and not traceable back to the user's device.
+ * The number of elements in a uuid_t. uuid_t is assumed to be a fixed-length
+ * array of guchar.
  */
-static uuid_t machine_id;
-
-// TODO: Re-evaluate whether this is necessary, or a GOnce (or nothing) would be
-// more appropriate.
-G_LOCK_DEFINE_STATIC (machine_id);
+#define UUID_LENGTH (sizeof (uuid_t) / sizeof (guchar))
 
 /**
  * SECTION:emtr-event-recorder
@@ -128,20 +58,20 @@ G_LOCK_DEFINE_STATIC (machine_id);
  * const MEANINGLESS_EVENT_WITH_AUX_DATA =
  *   "9f26029e-8085-42a7-903e-10fcd1815e03";
  *
- * let eventRecorder = EosMetrics.EventRecorder.new();
+ * let eventRecorder = EosMetrics.EventRecorder.get_default();
  *
  * // Records a single instance of MEANINGLESS_EVENT along with the current
  * // time.
- * eventRecorder.prototype.record_event(MEANINGLESS_EVENT, null);
+ * eventRecorder.record_event(MEANINGLESS_EVENT, null);
  *
  * // Records the fact that MEANINGLESS_AGGREGATED_EVENT occurred 23
  * // times since the last time it was recorded.
- * eventRecorder.prototype.record_events(MEANINGLESS_AGGREGATED_EVENT,
+ * eventRecorder.record_events(MEANINGLESS_AGGREGATED_EVENT,
  *   23, null);
  *
  * // Records MEANINGLESS_EVENT_WITH_AUX_DATA along with some auxiliary data and
  * // the current time.
- * eventRecorder.prototype.record_event(MEANINGLESS_EVENT_WITH_AUX_DATA,
+ * eventRecorder.record_event(MEANINGLESS_EVENT_WITH_AUX_DATA,
  *   new GLib.Variant('a{sv}', {
  *     units_of_smoke_ground: new GLib.Variant('u', units),
  *     grinding_time: new GLib.Variant('u', time)
@@ -186,6 +116,20 @@ typedef struct EventSequence
 
 typedef struct EmtrEventRecorderPrivate
 {
+  gint client_version;
+
+  gchar *environment;
+
+  guint network_send_interval_seconds;
+
+  gint individual_buffer_length;
+  gint aggregate_buffer_length;
+  gint sequence_buffer_length;
+
+  gchar *proxy_server_uri;
+
+  EmtrMachineIdProvider *machine_id_provider;
+
   Event * volatile event_buffer;
   volatile gint num_events_buffered;
   GMutex event_buffer_lock;
@@ -240,6 +184,10 @@ emtr_event_recorder_finalize (GObject *object)
   EmtrEventRecorder *self = EMTR_EVENT_RECORDER (object);
   EmtrEventRecorderPrivate *priv =
     emtr_event_recorder_get_instance_private (self);
+  g_free (priv->environment);
+  g_free (priv->proxy_server_uri);
+  if (priv->machine_id_provider != NULL)
+    g_object_unref (priv->machine_id_provider);
 
   if (priv->recording_enabled)
     {
@@ -278,12 +226,7 @@ emtr_event_recorder_finalize (GObject *object)
   G_OBJECT_CLASS (emtr_event_recorder_parent_class)->finalize (object);
 }
 
-static void
-emtr_event_recorder_class_init (EmtrEventRecorderClass *klass)
-{
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
-  object_class->finalize = emtr_event_recorder_finalize;
-}
+
 
 /*
  * https://developer.gnome.org/glib/2.40/glib-GVariant.html#g-variant-hash
@@ -307,12 +250,6 @@ general_variant_hash (gconstpointer key)
   return hash_value;
 }
 
-static gboolean
-use_prod_server (void)
-{
-  return FALSE;
-}
-
 // Handles HTTP or HTTPS responses.
 static void
 handle_https_response (GObject      *source_object,
@@ -329,7 +266,7 @@ handle_https_response (GObject      *source_object,
 
   if (G_UNLIKELY (response_stream == NULL))
     {
-      g_warning ("Error receiving metric HTTPS response: %s\n", error->message);
+      g_warning ("Error receiving metric HTTPS response: %s", error->message);
       g_error_free (error);
       return;
     }
@@ -358,7 +295,7 @@ get_current_time (clockid_t clock_id, gint64 *current_time)
   if (G_UNLIKELY (gettime_failed != 0))
     {
       int error_code = errno;
-      g_critical ("Attempt to get current time failed with error code: %d.\n",
+      g_critical ("Attempt to get current time failed with error code: %d.",
                   error_code);
       return FALSE;
     }
@@ -472,10 +409,11 @@ static GVariant *
 create_request_body (EmtrEventRecorderPrivate *priv)
 {
   GVariantBuilder machine_id_builder;
-
-  G_LOCK (machine_id);
+  uuid_t machine_id;
+  gboolean read_id = emtr_machine_id_provider_get_id (priv->machine_id_provider, machine_id);
+  if (!read_id)
+    return NULL;
   get_uuid_builder (machine_id, &machine_id_builder);
-  G_UNLOCK (machine_id);
 
   GVariantBuilder user_events_builder;
   g_variant_builder_init (&user_events_builder,
@@ -501,9 +439,9 @@ create_request_body (EmtrEventRecorderPrivate *priv)
 
   GVariant *request_body =
     g_variant_new ("(ixxaysa(aya(ayxmv)a(ayxxmv)a(aya(xmv)))"
-                   "a(ayxmv)a(ayxxmv)a(aya(xmv)))", CLIENT_VERSION,
+                   "a(ayxmv)a(ayxxmv)a(aya(xmv)))", priv->client_version,
                    relative_time, absolute_time, &machine_id_builder,
-                   ENVIRONMENT, &user_events_builder, &system_events_builder,
+                   priv->environment, &user_events_builder, &system_events_builder,
                    &system_aggregates_builder, &system_event_sequences_builder);
 
   GVariant *little_endian_request_body = request_body;
@@ -521,13 +459,13 @@ create_request_body (EmtrEventRecorderPrivate *priv)
 }
 
 static gchar *
-get_https_request_uri (const guchar *data, gsize length)
+get_https_request_uri (EmtrEventRecorder *self, const guchar *data, gsize length)
 {
-  const gchar *proxy_server_uri = (use_prod_server ()) ?
-    PROXY_PROD_SERVER_URI : PROXY_TEST_SERVER_URI;
   gchar *checksum_string = g_compute_checksum_for_data (G_CHECKSUM_SHA512, data,
                                                         length);
-  gchar *https_request_uri = g_strconcat (proxy_server_uri, checksum_string,
+  EmtrEventRecorderPrivate *priv =
+    emtr_event_recorder_get_instance_private (self);
+  gchar *https_request_uri = g_strconcat (priv->proxy_server_uri, checksum_string,
                                           NULL);
   g_free (checksum_string);
   return https_request_uri;
@@ -547,14 +485,14 @@ upload_events (gpointer user_data)
   g_object_ref (self);
 
   GVariant *request_body = create_request_body (priv);
-  if (G_UNLIKELY (request_body == NULL))
+  if (request_body == NULL)
     return G_SOURCE_CONTINUE;
 
   gconstpointer serialized_request_body = g_variant_get_data (request_body);
   g_assert (serialized_request_body != NULL);
   gsize request_body_length = g_variant_get_size (request_body);
   gchar *https_request_uri =
-    get_https_request_uri (serialized_request_body, request_body_length);
+    get_https_request_uri (self, serialized_request_body, request_body_length);
 
   GError *error = NULL;
   SoupRequestHTTP *https_request =
@@ -563,7 +501,7 @@ upload_events (gpointer user_data)
   g_free (https_request_uri);
   if (G_UNLIKELY (https_request == NULL))
     {
-      g_warning ("Error creating metric HTTPS request: %s\n", error->message);
+      g_warning ("Error creating metric HTTPS request: %s", error->message);
       g_error_free (error);
       return G_SOURCE_CONTINUE;
     }
@@ -595,76 +533,409 @@ get_user_agent (void)
                           libsoup_minor_version, libsoup_micro_version);
 }
 
-/*
- * Returns a newly-allocated copy of uuid_sans_hyphens with hyphens inserted at
- * the appropriate positions as defined by uuid_unparse(3).
- * uuid_sans_hyphens is expected to be exactly 32 bytes, excluding the terminal
- * null byte.
- * Any extra bytes are ignored.
- * The returned string is guaranteed to be null-terminated.
- */
-static gchar *
-hyphenate_uuid (gchar *uuid_sans_hyphens)
+enum {
+  PROP_0,
+  PROP_NETWORK_SEND_INTERVAL,
+  PROP_CLIENT_VERSION_NUMBER,
+  PROP_ENVIRONMENT,
+  PROP_PROXY_SERVER_URI,
+  PROP_INDIVIDUAL_BUFFER_LENGTH,
+  PROP_AGGREGATE_BUFFER_LENGTH,
+  PROP_SEQUENCE_BUFFER_LENGTH,
+  PROP_MACHINE_ID_PROVIDER,
+  NPROPS
+};
+
+static GParamSpec *emtr_event_recorder_props[NPROPS] = { NULL, };
+
+static void 
+set_network_send_interval (EmtrEventRecorder *self,
+                           guint              seconds)
 {
-  return g_strdup_printf ("%.8s-%.4s-%.4s-%.4s-%.12s", uuid_sans_hyphens,
-                          uuid_sans_hyphens + 8, uuid_sans_hyphens + 12,
-                          uuid_sans_hyphens + 16, uuid_sans_hyphens + 20);
+  EmtrEventRecorderPrivate *priv =
+    emtr_event_recorder_get_instance_private (self);
+  priv->network_send_interval_seconds = seconds;
 }
 
-static gboolean
-read_machine_id (void)
+/*
+ * get_network_send_interval:
+ * @self: the event recorder
+ *
+ * See #EmtrEventRecorder:network-send-interval.
+ *
+ * Returns: the number of seconds between network request
+ * send attempts. On invalid input returns 0 instead.
+ */
+static guint
+get_network_send_interval (EmtrEventRecorder *self)
 {
-  // The machine ID has already been read from disk; no need to read it again.
-  if (machine_id != NULL)
-    return TRUE;
+  g_return_val_if_fail (self != NULL && EMTR_IS_EVENT_RECORDER (self), 0);
+  EmtrEventRecorderPrivate *priv = emtr_event_recorder_get_instance_private (self);
+  return priv->network_send_interval_seconds;
+}
 
-  gchar *machine_id_sans_hyphens;
-  gsize machine_id_sans_hyphens_length;
-  GError *error = NULL;
-  gboolean read_succeeded =
-    g_file_get_contents (MACHINE_ID_FILEPATH, &machine_id_sans_hyphens,
-                         &machine_id_sans_hyphens_length, &error);
-  if (!read_succeeded)
+static void
+set_client_version_number (EmtrEventRecorder *self,
+                           gint               number)
+{
+  EmtrEventRecorderPrivate *priv =
+    emtr_event_recorder_get_instance_private (self);
+  priv->client_version = number;
+}
+
+/*
+ * get_client_version_number:
+ * @self: the event recorder
+ *
+ * Returns: the client version number. On invalid
+ * input, returns -1.
+ */
+static gint
+get_client_version_number (EmtrEventRecorder *self)
+{
+  g_return_val_if_fail (self != NULL && EMTR_IS_EVENT_RECORDER (self), -1);
+  EmtrEventRecorderPrivate *priv = emtr_event_recorder_get_instance_private (self);
+  return priv->client_version;
+}
+
+static void
+set_environment (EmtrEventRecorder *self,
+                 const gchar       *env)
+{
+  EmtrEventRecorderPrivate *priv =
+    emtr_event_recorder_get_instance_private (self);
+  priv->environment = g_strdup (env);
+}
+
+/*
+ * get_environment:
+ * @self: the event recorder
+ *
+ * See #EmtrEventRecorder:environment.
+ *
+ * Returns: the metric user environment. On invalid input,
+ * will return the empty string.
+ */
+static gchar*
+get_environment (EmtrEventRecorder *self)
+{
+  g_return_val_if_fail (self != NULL && EMTR_IS_EVENT_RECORDER (self), "");
+  EmtrEventRecorderPrivate *priv = emtr_event_recorder_get_instance_private (self);
+  return priv->environment;
+}
+
+static void
+set_proxy_server_uri (EmtrEventRecorder *self,
+                      const gchar       *uri)
+{
+  EmtrEventRecorderPrivate *priv =
+    emtr_event_recorder_get_instance_private (self);
+  priv->proxy_server_uri = g_strdup (uri);
+}
+
+/*
+ * get_proxy_server_uri:
+ * @self: the event recorder
+ *
+ * See #EmtrEventRecorder:proxy-server-uri.
+ *
+ * Returns: the URI of the proxy server. On invalid input,
+ * will return the empty string.
+ */
+static gchar*
+get_proxy_server_uri (EmtrEventRecorder *self)
+{
+  g_return_val_if_fail (self != NULL && EMTR_IS_EVENT_RECORDER (self), "");
+  EmtrEventRecorderPrivate *priv = emtr_event_recorder_get_instance_private (self);
+  return priv->proxy_server_uri;
+}
+
+static void
+set_individual_buffer_length (EmtrEventRecorder *self,
+                              gint               length)
+{
+  EmtrEventRecorderPrivate *priv =
+    emtr_event_recorder_get_instance_private (self);
+  priv->individual_buffer_length = length;
+}
+
+/*
+ * get_individual_buffer_length:
+ * @self: the event recorder
+ *
+ * See #EmtrEventRecorder:individual-buffer-length.
+ *
+ * Returns: the number of metrics that may fit in the individual buffer.
+ * On invalid input, returns -1. 
+ */
+static gint
+get_individual_buffer_length (EmtrEventRecorder *self)
+{
+  g_return_val_if_fail (self != NULL && EMTR_IS_EVENT_RECORDER (self), -1);
+  EmtrEventRecorderPrivate *priv = emtr_event_recorder_get_instance_private (self);
+  return priv->individual_buffer_length;
+}
+
+static void
+set_aggregate_buffer_length (EmtrEventRecorder *self,
+                             gint               length)
+{
+  EmtrEventRecorderPrivate *priv =
+    emtr_event_recorder_get_instance_private (self);
+  priv->aggregate_buffer_length = length;
+}
+
+/*
+ * get_aggregate_buffer_length:
+ * @self: the event recorder
+ *
+ * See #EmtrEventRecorder:aggregate-buffer-length.
+ *
+ * Returns: the number of metrics that may fit in the aggregate buffer.
+ * On invalid input, returns -1.
+ */
+static gint
+get_aggregate_buffer_length (EmtrEventRecorder *self)
+{
+  g_return_val_if_fail (self != NULL && EMTR_IS_EVENT_RECORDER (self), -1);
+  EmtrEventRecorderPrivate *priv = emtr_event_recorder_get_instance_private (self);
+  return priv->aggregate_buffer_length;
+}
+
+static void
+set_sequence_buffer_length (EmtrEventRecorder *self,
+                            gint               length)
+{
+  EmtrEventRecorderPrivate *priv =
+    emtr_event_recorder_get_instance_private (self);
+  priv->sequence_buffer_length = length;
+}
+
+/*
+ * get_sequence_buffer_length:
+ * @self: the event recorder
+ *
+ * See #EmtrEventRecorder:sequence-buffer-length.
+ *
+ * Returns: the number of metrics that may fit in the sequence buffer.
+ * On invalid input, returns -1.
+ */
+static gint
+get_sequence_buffer_length (EmtrEventRecorder *self)
+{
+  g_return_val_if_fail (self != NULL && EMTR_IS_EVENT_RECORDER (self), -1);
+  EmtrEventRecorderPrivate *priv = emtr_event_recorder_get_instance_private (self);
+  return priv->sequence_buffer_length;
+}
+
+static void
+set_machine_id_provider (EmtrEventRecorder     *self,
+                         EmtrMachineIdProvider *machine_id_prov)
+{
+  EmtrEventRecorderPrivate *priv =
+    emtr_event_recorder_get_instance_private (self);
+  priv->machine_id_provider = machine_id_prov;
+}
+
+/*
+ * get_machine_id_provider
+ * @self: the event recorder
+ *
+ * See #EmtrEventRecorder:machine-id-provider.
+ *
+ * Returns: the EmtrMachineIdProvider providing a uuid for this object
+ */
+static EmtrMachineIdProvider *
+get_machine_id_provider (EmtrEventRecorder *self)
+{
+  g_return_val_if_fail (self != NULL && EMTR_IS_EVENT_RECORDER (self), NULL);
+  EmtrEventRecorderPrivate *priv = emtr_event_recorder_get_instance_private (self);
+  return priv->machine_id_provider;
+}
+
+static void
+emtr_event_recorder_set_property (GObject      *object,
+                                  guint         property_id,
+                                  const GValue *value,
+                                  GParamSpec   *pspec)
+{
+  EmtrEventRecorder *self = EMTR_EVENT_RECORDER (object);
+  switch (property_id)
     {
-      g_critical ("Failed to read machine ID file (%s). Disabled metric "
-                  "recording.\n", MACHINE_ID_FILEPATH);
-      return FALSE;
-    }
+    case PROP_NETWORK_SEND_INTERVAL:
+      set_network_send_interval (self, g_value_get_uint (value));
+      break;
 
-  if (strlen (machine_id_sans_hyphens) != machine_id_sans_hyphens_length)
+    case PROP_CLIENT_VERSION_NUMBER:
+      set_client_version_number (self, g_value_get_int (value));
+      break;
+
+    case PROP_ENVIRONMENT:
+      set_environment (self, g_value_get_string (value));
+      break;
+
+    case PROP_PROXY_SERVER_URI:
+      set_proxy_server_uri (self, g_value_get_string (value));
+      break;
+
+    case PROP_INDIVIDUAL_BUFFER_LENGTH:
+      set_individual_buffer_length (self, g_value_get_int (value));
+      break;
+
+    case PROP_AGGREGATE_BUFFER_LENGTH:
+      set_aggregate_buffer_length (self, g_value_get_int (value));
+      break;
+
+    case PROP_SEQUENCE_BUFFER_LENGTH:
+      set_sequence_buffer_length (self, g_value_get_int (value));
+      break;
+
+    case PROP_MACHINE_ID_PROVIDER:
+      set_machine_id_provider (self, g_value_get_object (value));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    }
+}
+
+static void
+emtr_event_recorder_get_property (GObject    *object,
+                                  guint       property_id,
+                                  GValue     *value,
+                                  GParamSpec *pspec)
+{
+  EmtrEventRecorder *self = EMTR_EVENT_RECORDER (object);
+  switch (property_id)
     {
-      g_critical ("Machine ID file (%s) contained null byte, but should be "
-                  "hexadecimal. Disabled metric recording.\n",
-                  MACHINE_ID_FILEPATH);
-      return FALSE;
+    case PROP_NETWORK_SEND_INTERVAL:
+      g_value_set_uint (value, get_network_send_interval (self));
+      break;
+
+    case PROP_CLIENT_VERSION_NUMBER:
+      g_value_set_int (value, get_client_version_number (self));
+      break;
+    
+    case PROP_ENVIRONMENT:
+      g_value_set_string (value, get_environment (self));
+      break;
+
+    case PROP_PROXY_SERVER_URI:
+      g_value_set_string (value, get_proxy_server_uri (self));
+      break;
+
+    case PROP_INDIVIDUAL_BUFFER_LENGTH:
+      g_value_set_int (value, get_individual_buffer_length (self));
+      break;
+
+    case PROP_AGGREGATE_BUFFER_LENGTH:
+      g_value_set_int (value, get_aggregate_buffer_length (self));
+      break;
+
+    case PROP_SEQUENCE_BUFFER_LENGTH:
+      g_value_set_int (value, get_sequence_buffer_length (self));
+      break;
+
+    case PROP_MACHINE_ID_PROVIDER:
+      g_value_set_object (value, get_machine_id_provider (self));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
     }
+}
 
-  if (machine_id_sans_hyphens_length != MACHINE_ID_FILE_SIZE)
-    {
-      g_critical ("Machine ID file (%s) contained %" G_GSIZE_FORMAT " bytes, "
-                  "but expected %d bytes. Disabled metric recording.\n",
-                  MACHINE_ID_FILEPATH, machine_id_sans_hyphens_length,
-                  MACHINE_ID_FILE_SIZE);
-      return FALSE;
-    }
+static void
+emtr_event_recorder_class_init (EmtrEventRecorderClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  object_class->get_property = emtr_event_recorder_get_property;
+  object_class->set_property = emtr_event_recorder_set_property;
+  object_class->finalize = emtr_event_recorder_finalize;
 
-  gchar *hyphenated_machine_id = hyphenate_uuid (machine_id_sans_hyphens);
-  g_free (machine_id_sans_hyphens);
+  /**
+   * EmtrEventRecorder:network-send-interval:
+   *
+   * The frequency with which the client will attempt a network send request, in
+   * seconds.
+   */
+  emtr_event_recorder_props[PROP_NETWORK_SEND_INTERVAL] =
+    g_param_spec_uint ("network-send-interval", "Network Send Interval",
+                       "Number of seconds until a network request is attempted.",
+                       0, G_MAXUINT, (60 * 60), 
+                       G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS);
 
-  G_LOCK (machine_id);
-  int parse_failed = uuid_parse (hyphenated_machine_id, machine_id);
-  G_UNLOCK (machine_id);
+  /**
+   * EmtrEventRecorder:client-version-number:
+   *
+   * Network protocol version of the metrics client.
+   */
+  emtr_event_recorder_props[PROP_CLIENT_VERSION_NUMBER] =
+    g_param_spec_int ("client-version-number", "Client Version Number",
+                      "Client network protocol version.",
+                      -1, G_MAXINT, 0,
+                      G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS);
 
-  g_free (hyphenated_machine_id);
+  /**
+   * EmtrEventRecorder:environment:
+   *
+   * Specifies what kind of user or system the metrics come from, so that data
+   * analysis can exclude metrics from tests or developers' systems.
+   *
+   * Valid values are "dev", "test", and "prod".
+   * The "prod" value, indicating production, should not be used outside of
+   * a production system.
+   */
+  emtr_event_recorder_props[PROP_ENVIRONMENT] =
+    g_param_spec_string ("environment", "Environment",
+                         "Specifies what kind of user the metrics come from.",
+                         "dev",
+                         G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS);
 
-  if (parse_failed != 0)
-    {
-      g_critical ("Machine ID file (%s) did not contain UUID. Disabled metric "
-                  "recording.\n", MACHINE_ID_FILEPATH);
-      return FALSE;
-    }
+  /* Blurb string is good enough default documentation for this */
+  emtr_event_recorder_props[PROP_PROXY_SERVER_URI] =
+    g_param_spec_string ("proxy-server-uri", "Proxy Server URI",
+                         "The URI to send metrics to.",
+                         PRODUCTION_SERVER_URI,
+                         G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS);
 
-  return TRUE;
+  /* Blurb string is good enough default documentation for this */
+  emtr_event_recorder_props[PROP_INDIVIDUAL_BUFFER_LENGTH] =
+    g_param_spec_int ("individual-buffer-length", "Buffer Length Individual",
+                       "The number of metrics allowed to be stored in the individual metric buffer.",
+                       -1, G_MAXINT, 2000,
+                       G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS);
+
+  /* Blurb string is good enough default documentation for this */
+  emtr_event_recorder_props[PROP_AGGREGATE_BUFFER_LENGTH] =
+    g_param_spec_int ("aggregate-buffer-length", "Buffer Length Aggregate",
+                      "The number of metrics allowed to be stored in the aggregate metric buffer.",
+                      -1, G_MAXINT, 2000,
+                      G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS);
+
+  /* Blurb string is good enough default documentation for this */
+  emtr_event_recorder_props[PROP_SEQUENCE_BUFFER_LENGTH] =
+    g_param_spec_int ("sequence-buffer-length", "Buffer Length Sequence",
+                      "The number of metrics allowed to be stored in the sequence metric buffer.",
+                      -1, G_MAXINT, 2000,
+                      G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS);
+
+  /**
+   * EmtrEventRecorder:machine-id-provider:
+   *
+   * An #EmtrMachineIdProvider for retrieving the unique UUID of this machine.
+   * If this property is not specified, the default machine ID provider (from
+   * emtr_machine_id_provider_get_default()) will be used.
+   * You should only set this property to something else for testing purposes.
+   */
+  emtr_event_recorder_props[PROP_MACHINE_ID_PROVIDER] = 
+    g_param_spec_object ("machine-id-provider", "Machine ID provider",
+                         "Object providing unique machine ID",
+                         EMTR_TYPE_MACHINE_ID_PROVIDER,
+                         G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class, NPROPS,
+                                     emtr_event_recorder_props);
 }
 
 static void
@@ -673,23 +944,15 @@ emtr_event_recorder_init (EmtrEventRecorder *self)
   EmtrEventRecorderPrivate *priv =
     emtr_event_recorder_get_instance_private (self);
 
-  /*
-   * If we can't read the machine ID, mark self a no-op event recorder, and
-   * don't even initialize the rest of the private state.
-   */
-  priv->recording_enabled = read_machine_id ();
-  if (!priv->recording_enabled)
-    return;
-
-  priv->event_buffer = g_new (Event, EVENT_BUFFER_LENGTH);
+  priv->event_buffer = g_new (Event, priv->individual_buffer_length);
   priv->num_events_buffered = 0;
   g_mutex_init (&(priv->event_buffer_lock));
 
-  priv->aggregate_buffer = g_new (Aggregate, AGGREGATE_BUFFER_LENGTH);
+  priv->aggregate_buffer = g_new (Aggregate, priv->aggregate_buffer_length);
   priv->num_aggregates_buffered = 0;
   g_mutex_init (&(priv->aggregate_buffer_lock));
 
-  priv->event_sequence_buffer = g_new (EventSequence, SEQUENCE_BUFFER_LENGTH);
+  priv->event_sequence_buffer = g_new (EventSequence, priv->sequence_buffer_length);
   priv->num_event_sequences_buffered = 0;
   g_mutex_init (&(priv->event_sequence_buffer_lock));
 
@@ -712,7 +975,7 @@ emtr_event_recorder_init (EmtrEventRecorder *self)
   g_free (user_agent);
 
   priv->upload_events_timeout_source_id =
-    g_timeout_add_seconds (NETWORK_SEND_INTERVAL_SECONDS, upload_events, self);
+    g_timeout_add_seconds (priv->network_send_interval_seconds, upload_events, self);
 }
 
 static gboolean
@@ -724,7 +987,7 @@ parse_event_id (const gchar *unparsed_event_id,
     {
       g_warning ("Attempt to parse UUID \"%s\" failed. Make sure you created "
                  "this UUID with uuidgen -r. You may need to sudo apt-get "
-                 "install uuid-runtime first.\n", unparsed_event_id);
+                 "install uuid-runtime first.", unparsed_event_id);
       return FALSE;
     }
 
@@ -773,7 +1036,7 @@ append_event_sequence_to_buffer (EmtrEventRecorderPrivate *priv,
                                  GArray                   *event_values)
 {
   g_mutex_lock (&(priv->event_sequence_buffer_lock));
-  if (G_LIKELY (priv->num_event_sequences_buffered < SEQUENCE_BUFFER_LENGTH))
+  if (priv->num_event_sequences_buffered < priv->sequence_buffer_length)
     {
       EventSequence *event_sequence =
         priv->event_sequence_buffer + priv->num_event_sequences_buffered;
@@ -799,16 +1062,88 @@ append_event_sequence_to_buffer (EmtrEventRecorderPrivate *priv,
 
 /**
  * emtr_event_recorder_new:
+ * @network_send_interval: frequency with which the client will attempt a
+ * network send request; see #EmtrEventRecorder:network-send-interval
+ * @version_number: client version of the network protocol; see
+ * #EmtrEventRecorder:client-version-number
+ * @environment: environment of the machine; see #EmtrEventRecorder:environment
+ * @proxy_server_uri: URI to use; see #EmtrEventRecorder:proxy-server-uri
+ * @buffer_length: The maximum size of the buffers to be used for in-memory
+ * storage of metrics; see #EmtrEventRecorder:individual-buffer-length,
+ * #EmtrEventRecorder:aggregate-buffer-length, and
+ * #EmtrEventRecorder:sequence-buffer-length
+ * @machine_id_provider: (allow-none): The #EmtrMachineIdProvider to supply the
+ * machine ID, or %NULL to use the default; see
+ * #EmtrEventRecorder:machine-id-provider
  *
- * Convenience function for creating a new #EmtrEventRecorder in the C API.
+ * Testing function for creating a new #EmtrEventRecorder in the C API.
+ * You only need to use this if you are creating an event recorder with
+ * nonstandard parameters for use in unit testing.
+ *
+ * Make sure to pass "test" for @environment if using in a test, and never pass
+ * a live metrics proxy server URI for @proxy_server_uri.
+ *
+ * For all normal uses, you should use emtr_event_recorder_get_default()
+ * instead.
  *
  * Returns: (transfer full): a new #EmtrEventRecorder.
- * Free with g_object_unref() when done if using C.
+ * Free with g_object_unref() if using C when done with it.
  */
 EmtrEventRecorder *
-emtr_event_recorder_new (void)
+emtr_event_recorder_new (guint                  network_send_interval,
+                         gint                   version_number,
+                         const gchar           *environment,
+                         const gchar           *proxy_server_uri,
+                         gint                   buffer_length,
+                         EmtrMachineIdProvider *machine_id_provider)
+                         
 {
-  return g_object_new (EMTR_TYPE_EVENT_RECORDER, NULL);
+  if (environment == NULL)
+    g_error ("'environment' parameter was NULL. This is not allowed. No cookie for you.");
+  if (proxy_server_uri == NULL)
+    g_error ("'proxy_server_uri' parameter was NULL. This is not allowed. Go to your room.");
+
+  const gchar *proxy_to_use = g_strdup (proxy_server_uri);
+  const gchar *env_to_use = g_strdup (environment);
+  g_object_ref (machine_id_provider);
+  return g_object_new (EMTR_TYPE_EVENT_RECORDER,
+                       "network-send-interval", network_send_interval,
+                       "client-version-number", version_number,
+                       "environment", env_to_use,
+                       "proxy-server-uri", proxy_to_use,
+                       "individual-buffer-length", buffer_length,
+                       "aggregate-buffer-length", buffer_length,
+                       "sequence-buffer-length", buffer_length,
+                       "machine-id-provider", machine_id_provider,
+                       NULL);
+}
+
+/**
+ * emtr_event_recorder_get_default:
+ *
+ * Gets the event recorder object that you should use to record all metrics.
+ *
+ * Returns: (transfer none): the default #EmtrEventRecorder.
+ * This object is owned by the metrics library; do not free it.
+ */
+EmtrEventRecorder *
+emtr_event_recorder_get_default (void)
+{
+  static EmtrEventRecorder *singleton;
+  G_LOCK_DEFINE_STATIC (singleton);
+
+  G_LOCK (singleton);
+  if (singleton == NULL)
+    {
+      EmtrMachineIdProvider *machine_provider = emtr_machine_id_provider_get_default ();
+      singleton = g_object_new (EMTR_TYPE_EVENT_RECORDER, 
+                                "machine-id-provider", machine_provider,
+                                NULL);
+      g_object_unref (machine_provider);
+    }
+  G_UNLOCK (singleton);
+
+  return singleton;
 }
 
 /**
@@ -868,7 +1203,7 @@ emtr_event_recorder_record_event (EmtrEventRecorder *self,
 
   g_mutex_lock (&(priv->event_buffer_lock));
 
-  if (G_LIKELY (priv->num_events_buffered < EVENT_BUFFER_LENGTH))
+  if (priv->num_events_buffered < priv->individual_buffer_length)
     {
       Event *event_buffer = priv->event_buffer;
       gint num_events_buffered = priv->num_events_buffered;
@@ -950,7 +1285,7 @@ emtr_event_recorder_record_events (EmtrEventRecorder *self,
 
   g_mutex_lock (&(priv->aggregate_buffer_lock));
 
-  if (G_LIKELY (priv->num_aggregates_buffered < AGGREGATE_BUFFER_LENGTH))
+  if (priv->num_aggregates_buffered < priv->aggregate_buffer_length)
     {
       Aggregate *aggregate_buffer = priv->aggregate_buffer;
       gint num_aggregates_buffered = priv->num_aggregates_buffered;
@@ -1077,7 +1412,7 @@ emtr_event_recorder_record_start (EmtrEventRecorder *self,
           // event as opposed to its UUID.
           g_warning ("Ignoring request to start event of type %s with key %s "
                      "because there is already an unstopped start event with this "
-                     "type and key.\n", event_id, key_as_string);
+                     "type and key.", event_id, key_as_string);
 
           g_free (key_as_string);
         }
@@ -1087,7 +1422,7 @@ emtr_event_recorder_record_start (EmtrEventRecorder *self,
           // event as opposed to its UUID.
           g_warning ("Ignoring request to start event of type %s with NULL key "
                      "because there is already an unstopped start event with "
-                     "this type and key.\n", event_id);
+                     "this type and key.", event_id);
         }
       goto finally;
     }
@@ -1169,7 +1504,7 @@ emtr_event_recorder_record_progress (EmtrEventRecorder *self,
           // event as opposed to its UUID.
           g_warning ("Ignoring request to record progress for event of type %s "
                      "with key %s because there is no corresponding unstopped "
-                     "start event.\n", event_id, key_as_string);
+                     "start event.", event_id, key_as_string);
 
           g_free (key_as_string);
         }
@@ -1179,7 +1514,7 @@ emtr_event_recorder_record_progress (EmtrEventRecorder *self,
           // event as opposed to its UUID.
           g_warning ("Ignoring request to record progress for event of type %s "
                      "with NULL key because there is no corresponding "
-                     "unstopped start event.\n", event_id);
+                     "unstopped start event.", event_id);
         }
       goto finally;
     }
@@ -1264,7 +1599,7 @@ emtr_event_recorder_record_stop (EmtrEventRecorder *self,
           // event as opposed to its UUID.
           g_warning ("Ignoring request to stop event of type %s with key %s "
                      "because there is no corresponding unstopped start "
-                     "event.\n", event_id, key_as_string);
+                     "event.", event_id, key_as_string);
 
           g_free (key_as_string);
         }
@@ -1274,7 +1609,7 @@ emtr_event_recorder_record_stop (EmtrEventRecorder *self,
           // event as opposed to its UUID.
           g_warning ("Ignoring request to stop event of type %s with NULL key "
                      "because there is no corresponding unstopped start "
-                     "event.\n", event_id);
+                     "event.", event_id);
         }
       goto finally;
     }

--- a/eosmetrics/emtr-event-recorder.h
+++ b/eosmetrics/emtr-event-recorder.h
@@ -13,6 +13,8 @@
 #include <glib-object.h>
 #include <gio/gio.h>
 
+#include "emtr-machine-id-provider.h"
+
 G_BEGIN_DECLS
 
 #define EMTR_TYPE_EVENT_RECORDER emtr_event_recorder_get_type()
@@ -67,7 +69,15 @@ EMTR_ALL_API_VERSIONS
 GType              emtr_event_recorder_get_type        (void) G_GNUC_CONST;
 
 EMTR_ALL_API_VERSIONS
-EmtrEventRecorder *emtr_event_recorder_new             (void);
+EmtrEventRecorder *emtr_event_recorder_new             (guint                  network_send_interval,
+                                                        gint                   version_number,
+                                                        const gchar           *environment,
+                                                        const gchar           *proxy_server_uri,
+                                                        gint                   buffer_length,
+                                                        EmtrMachineIdProvider *machine_id_provider);
+
+EMTR_ALL_API_VERSIONS
+EmtrEventRecorder *emtr_event_recorder_get_default     (void);
 
 EMTR_ALL_API_VERSIONS
 void               emtr_event_recorder_record_event    (EmtrEventRecorder *self,

--- a/eosmetrics/emtr-machine-id-provider.c
+++ b/eosmetrics/emtr-machine-id-provider.c
@@ -1,0 +1,299 @@
+/* emtr-machine-id-provider.c */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#include "emtr-machine-id-provider.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <uuid/uuid.h>
+#include <glib/gprintf.h>
+#include <glib/gstdio.h>
+
+typedef struct EmtrMachineIdProviderPrivate
+{
+  gchar *path;
+  uuid_t id;
+} EmtrMachineIdProviderPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (EmtrMachineIdProvider, emtr_machine_id_provider, G_TYPE_OBJECT)
+
+/*
+ * The number of elements in a uuid_t. uuid_t is assumed to be a fixed-length
+ * array of guchar.
+ */
+#define UUID_LENGTH (sizeof (uuid_t) / sizeof (guchar))
+
+/*
+ * The expected size in bytes of the file located at
+ * #EmtrMachineIdProvider:path.
+ * According to http://www.freedesktop.org/software/systemd/man/machine-id.html
+ * the file should be 32 lower-case hexadecimal characters followed by a
+ * newline character.
+ */
+#define FILE_LENGTH 33
+
+/*
+ * Filepath at which the random UUID that persistently identifies this machine
+ * is stored.
+ * In order to protect the anonymity of our users, the ID stored in this file
+ * must be randomly generated and not traceable back to the user's device.
+ * See http://www.freedesktop.org/software/systemd/man/machine-id.html for more
+ * details.
+ */
+#define DEFAULT_MACHINE_ID_FILEPATH "/etc/machine-id"
+
+enum {
+  PROP_0,
+  PROP_PATH,
+  NPROPS
+};
+
+static GParamSpec *emtr_machine_id_provider_props[NPROPS] = { NULL, };
+
+/**
+ * SECTION:emtr-machine-id-provider
+ * @title: Machine ID Provider
+ * @short_description: Provides unique machine identifiers.
+ * @include: eosmetrics/eosmetrics.h
+ *
+ * The machine ID provider supplies UUIDs which anonymously identify the
+ * machine (not the user) sending metrics.
+ * This class abstracts away how and where UUIDs are generated from by providing
+ * a simple interface via emtr_machine_id_provider_get_id() to whatever calling
+ * code needs it.
+ */
+
+static const gchar *
+get_id_path (EmtrMachineIdProvider *self)
+{
+  EmtrMachineIdProviderPrivate *priv = emtr_machine_id_provider_get_instance_private (self);
+  return priv->path;
+}
+
+static void
+set_id_path (EmtrMachineIdProvider *self,
+             const gchar           *given_path)
+{
+  EmtrMachineIdProviderPrivate *priv = emtr_machine_id_provider_get_instance_private (self);
+  priv->path = g_strdup (given_path);
+}
+
+static void
+emtr_machine_id_provider_get_property (GObject    *object,
+                                       guint       property_id,
+                                       GValue     *value,
+                                       GParamSpec *pspec)
+{
+  EmtrMachineIdProvider *self = EMTR_MACHINE_ID_PROVIDER (object);
+  switch (property_id)
+    {
+    case PROP_PATH:
+      g_value_set_string (value, get_id_path (self));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    }
+}
+
+static void
+emtr_machine_id_provider_set_property (GObject      *object,
+                                       guint         property_id,
+                                       const GValue *value,
+                                       GParamSpec   *pspec)
+{
+  EmtrMachineIdProvider *self = EMTR_MACHINE_ID_PROVIDER (object);
+  switch (property_id)
+    {
+      case PROP_PATH:
+        set_id_path (self, g_value_get_string (value));
+        break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    }
+}
+
+static void
+emtr_machine_id_provider_finalize (GObject *object)
+{
+  EmtrMachineIdProvider *self = EMTR_MACHINE_ID_PROVIDER (object);
+  EmtrMachineIdProviderPrivate *priv = emtr_machine_id_provider_get_instance_private (self);
+  g_free (priv->path);
+
+  G_OBJECT_CLASS (emtr_machine_id_provider_parent_class)->finalize (object);
+}
+
+static void
+emtr_machine_id_provider_class_init (EmtrMachineIdProviderClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->get_property = emtr_machine_id_provider_get_property;
+  object_class->set_property = emtr_machine_id_provider_set_property;
+  object_class->finalize = emtr_machine_id_provider_finalize;
+
+  /* Blurb string is good enough default documentation for this */
+  emtr_machine_id_provider_props[PROP_PATH] =
+    g_param_spec_string ("path", "Path",
+                         "The path to the file where the unique identifier is stored.",
+                         DEFAULT_MACHINE_ID_FILEPATH,
+                         G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class, NPROPS,
+                                     emtr_machine_id_provider_props);
+}
+
+// Mandatory empty function.
+static void
+emtr_machine_id_provider_init (EmtrMachineIdProvider *self)
+{
+}
+
+/**
+ * emtr_machine_id_provider_new:
+ * @machine_id_file_path: path to a file; see #EmtrMachineIdProvider:path
+ *
+ * Testing function for creating a new #EmtrMachineIdProvider in the C API.
+ * You only need to use this if you are creating a mock ID provider for unit
+ * testing.
+ *
+ * For all normal uses, you should use emtr_machine_id_provider_get_default()
+ * instead.
+ *
+ * Returns: (transfer full): A new #EmtrMachineIdProvider.
+ * Free with g_object_unref() when done if using C.
+ */
+EmtrMachineIdProvider *
+emtr_machine_id_provider_new (const gchar *machine_id_file_path)
+{ 
+  return g_object_new (EMTR_TYPE_MACHINE_ID_PROVIDER, 
+                       "path", machine_id_file_path,
+                       NULL);
+}
+
+/**
+ * emtr_machine_id_provider_get_default:
+ *
+ * Gets the ID provider that you should use for obtaining a unique machine ID.
+ *
+ * Returns: (transfer none): the default #EmtrMachineIdProvider.
+ * This object is owned by the metrics library; do not free it.
+ */
+EmtrMachineIdProvider *
+emtr_machine_id_provider_get_default (void)
+{
+  static EmtrMachineIdProvider *singleton;
+  G_LOCK_DEFINE_STATIC (singleton);
+
+  G_LOCK (singleton);
+  if (singleton == NULL)
+      singleton = g_object_new (EMTR_TYPE_MACHINE_ID_PROVIDER, NULL);
+  G_UNLOCK (singleton);
+  return singleton;
+}
+
+/*
+ * Returns a newly-allocated copy of uuid_sans_hyphens with hyphens inserted at
+ * the appropriate positions as defined by uuid_unparse(3).
+ * uuid_sans_hyphens is expected to be exactly 32 bytes, excluding the terminal
+ * null byte.
+ * Any extra bytes are ignored.
+ * The returned string is guaranteed to be null-terminated.
+ */
+static gchar *
+hyphenate_uuid (gchar *uuid_sans_hyphens)
+{
+  return g_strdup_printf ("%.8s-%.4s-%.4s-%.4s-%.12s", uuid_sans_hyphens,
+                          uuid_sans_hyphens + 8, uuid_sans_hyphens + 12,
+                          uuid_sans_hyphens + 16, uuid_sans_hyphens + 20);
+}
+
+static gboolean
+read_machine_id (EmtrMachineIdProvider *self)
+{
+  EmtrMachineIdProviderPrivate *priv = emtr_machine_id_provider_get_instance_private (self);
+
+  gchar *machine_id_sans_hyphens;
+  gsize machine_id_sans_hyphens_length;
+  GError *error = NULL;
+  gboolean read_succeeded =
+    g_file_get_contents (priv->path, &machine_id_sans_hyphens,
+                         &machine_id_sans_hyphens_length, &error);
+  if (!read_succeeded)
+    {
+      g_critical ("Failed to read machine ID file (%s).", priv->path);
+      return FALSE;
+    }
+
+  if (strlen (machine_id_sans_hyphens) != machine_id_sans_hyphens_length)
+    {
+      g_critical ("Machine ID file (%s) contained null byte, but should be "
+                  "hexadecimal.",
+                  priv->path);
+      return FALSE;
+    }
+
+  if (machine_id_sans_hyphens_length != FILE_LENGTH)
+    {
+      g_critical ("Machine ID file (%s) contained %" G_GSIZE_FORMAT " bytes, "
+                  "but expected %d bytes.",
+                  priv->path, machine_id_sans_hyphens_length,
+                  FILE_LENGTH);
+      return FALSE;
+    }
+
+  gchar *hyphenated_machine_id = hyphenate_uuid (machine_id_sans_hyphens);
+  g_free (machine_id_sans_hyphens);
+
+  int parse_failed = uuid_parse (hyphenated_machine_id, priv->id);
+  g_free (hyphenated_machine_id);
+
+  if (parse_failed != 0)
+    {
+      g_critical ("Machine ID file (%s) did not contain UUID.", priv->path);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+/**
+ * emtr_machine_id_provider_get_id:
+ * @self: the machine ID provider
+ * @uuid: (out caller-allocates) (array fixed-size=16) (element-type guchar):
+ * allocated 16-byte return location for a UUID.
+ *
+ * Retrieves an ID (in the form of a UUID) that is unique to this machine, for
+ * use in anonymously identifying metrics data.
+ *
+ * Returns: a boolean indicating success or failure of retrieval.
+ * If this returns %FALSE, the UUID cannot be trusted to be valid.
+ */
+gboolean
+emtr_machine_id_provider_get_id (EmtrMachineIdProvider *self,
+                                 uuid_t                 uuid)
+{
+  EmtrMachineIdProviderPrivate *priv = emtr_machine_id_provider_get_instance_private (self);
+  static gboolean id_is_valid = FALSE;
+  G_LOCK_DEFINE_STATIC (id_is_valid);
+
+  G_LOCK (id_is_valid);
+  if (!id_is_valid)
+    {
+      if (read_machine_id (self))
+        {
+          id_is_valid = TRUE;
+        }
+      else
+        {
+          G_UNLOCK (id_is_valid);
+          return FALSE;
+        }
+    }
+  G_UNLOCK (id_is_valid);
+
+  memcpy(uuid, priv->id, UUID_LENGTH);
+  return TRUE;
+}

--- a/eosmetrics/emtr-machine-id-provider.h
+++ b/eosmetrics/emtr-machine-id-provider.h
@@ -1,0 +1,83 @@
+/* emtr-machine-id-provider.h */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#ifndef __EMTR_MACHINE_ID_PROVIDER_H__
+#define __EMTR_MACHINE_ID_PROVIDER_H__
+
+#if !(defined(_EMTR_INSIDE_EOSMETRICS_H) || defined(COMPILING_EOS_METRICS))
+#error "Please do not include this header file directly."
+#endif
+
+#include "emtr-types.h"
+#include <glib-object.h>
+#include <gio/gio.h>
+#include <string.h>
+
+G_BEGIN_DECLS
+
+#define EMTR_TYPE_MACHINE_ID_PROVIDER emtr_machine_id_provider_get_type()
+
+#define EMTR_MACHINE_ID_PROVIDER(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST ((obj), \
+  EMTR_TYPE_MACHINE_ID_PROVIDER, EmtrMachineIdProvider))
+
+#define EMTR_MACHINE_ID_PROVIDER_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST ((klass), \
+  EMTR_TYPE_MACHINE_ID_PROVIDER, EmtrMachineIdProviderClass))
+
+#define EMTR_IS_MACHINE_ID_PROVIDER(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), \
+  EMTR_TYPE_MACHINE_ID_PROVIDER))
+
+#define EMTR_IS_MACHINE_ID_PROVIDER_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE ((klass), \
+  EMTR_TYPE_MACHINE_ID_PROVIDER))
+
+#define EMTR_MACHINE_ID_PROVIDER_GET_CLASS(obj) \
+  (G_TYPE_INSTANCE_GET_CLASS ((obj), \
+  EMTR_TYPE_MACHINE_ID_PROVIDER, EmtrMachineIdProviderClass))
+
+/**
+ * EmtrMachineIdProvider:
+ *
+ * This instance structure contains no public members.
+ */
+typedef struct _EmtrMachineIdProvider EmtrMachineIdProvider;
+
+/**
+ * EmtrMachineIdProviderClass:
+ *
+ * This class structure contains no public members.
+ */
+typedef struct _EmtrMachineIdProviderClass EmtrMachineIdProviderClass;
+
+
+struct _EmtrMachineIdProvider
+{
+  /*< private >*/
+  GObject parent;
+};
+
+struct _EmtrMachineIdProviderClass
+{
+  /*< private >*/
+  GObjectClass parent_class;
+};
+
+EMTR_ALL_API_VERSIONS
+GType emtr_machine_id_provider_get_type (void) G_GNUC_CONST;
+
+EMTR_ALL_API_VERSIONS
+EmtrMachineIdProvider *emtr_machine_id_provider_new         (const gchar           *machine_id_file_path);
+
+EMTR_ALL_API_VERSIONS
+EmtrMachineIdProvider *emtr_machine_id_provider_get_default (void);
+
+EMTR_ALL_API_VERSIONS
+gboolean               emtr_machine_id_provider_get_id      (EmtrMachineIdProvider *self,
+                                                             guchar                 uuid[16]);
+
+G_END_DECLS
+
+#endif /* __EMTR_MACHINE_ID_PROVIDER_H__ */

--- a/eosmetrics/eosmetrics.h
+++ b/eosmetrics/eosmetrics.h
@@ -16,6 +16,7 @@ G_BEGIN_DECLS
 #include "emtr-sender.h"
 #include "emtr-event-recorder.h"
 #include "emtr-event-types.h"
+#include "emtr-machine-id-provider.h"
 
 #undef _EMTR_INSIDE_EOSMETRICS_H
 

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -13,6 +13,7 @@ tests_run_tests_SOURCES = \
 	tests/test-event-recorder.c \
 	tests/test-persistent-cache.c \
 	tests/test-mac.c \
+	tests/test-machine-id-provider.c \
 	tests/test-osversion.c \
 	tests/test-uuid.c \
 	tests/test-web.c \

--- a/tests/run-tests.c
+++ b/tests/run-tests.c
@@ -100,6 +100,7 @@ main (int    argc,
   add_sender_tests ();
   add_event_recorder_tests ();
   add_persistent_cache_tests ();
+  add_machine_id_provider_tests ();
 
   return g_test_run ();
 }

--- a/tests/run-tests.h
+++ b/tests/run-tests.h
@@ -62,14 +62,15 @@ void      set_up_mock_version_file      (const gchar       *contents);
 
 /* Each module adds its own test cases: */
 
-void add_util_tests             (void);
-void add_osversion_tests        (void);
-void add_uuid_tests             (void);
-void add_mac_tests              (void);
-void add_web_tests              (void);
-void add_connection_tests       (void);
-void add_sender_tests           (void);
-void add_event_recorder_tests   (void);
-void add_persistent_cache_tests (void);
+void add_util_tests                (void);
+void add_osversion_tests           (void);
+void add_uuid_tests                (void);
+void add_mac_tests                 (void);
+void add_web_tests                 (void);
+void add_connection_tests          (void);
+void add_sender_tests              (void);
+void add_event_recorder_tests      (void);
+void add_persistent_cache_tests    (void);
+void add_machine_id_provider_tests (void);
 
 #endif /* RUN_TESTS_H */

--- a/tests/test-event-recorder.c
+++ b/tests/test-event-recorder.c
@@ -11,18 +11,67 @@
 #define MEANINGLESS_EVENT "350ac4ff-3026-4c25-9e7e-e8103b4fd5d8"
 #define MEANINGLESS_EVENT_2 "d936cd5c-08de-4d4e-8a87-8df1f4a33cba"
 
+#define TESTING_FILE_PATH "/tmp/testing-machine-id"
+#define TESTING_ID        "04448f74fde24bd7a16f8da17869d5c3\n"
+/*
+ * The expected size in bytes of the file located at
+ * #EmtrMachineIdProvider:path.
+ * According to http://www.freedesktop.org/software/systemd/man/machine-id.html
+ * the file should be 32 lower-case hexadecimal characters followed by a
+ * newline character.
+ */
+#define FILE_LENGTH 33
+
+static gboolean
+write_testing_machine_id ()
+{
+  GFile *file = g_file_new_for_path (TESTING_FILE_PATH);
+  gboolean success = g_file_replace_contents (file,
+                                              TESTING_ID,
+                                              FILE_LENGTH,
+                                              NULL, 
+                                              FALSE, 
+                                              G_FILE_CREATE_REPLACE_DESTINATION | G_FILE_CREATE_PRIVATE,
+                                              NULL, 
+                                              NULL, 
+                                              NULL);
+  if (!success)
+    g_critical ("Testing code failed to write testing machine id.\n");
+  g_object_unref (file);
+  return success;
+}
+
+static EmtrEventRecorder *
+make_standard_event_recorder_for_testing ()
+{
+  return emtr_event_recorder_new (2, 0, "test", "http://localhost:8080", 2000,
+                                  emtr_machine_id_provider_new (TESTING_FILE_PATH));
+}
+
 static void
 test_event_recorder_new_succeeds (void)
 {
-  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  write_testing_machine_id ();
+  EmtrEventRecorder *event_recorder = make_standard_event_recorder_for_testing ();
   g_assert (event_recorder != NULL);
   g_object_unref (event_recorder);
 }
 
 static void
+test_event_recorder_get_default_is_singleton (void)
+{
+  write_testing_machine_id ();
+  EmtrEventRecorder *event_recorder1 = emtr_event_recorder_get_default ();
+  EmtrEventRecorder *event_recorder2 = emtr_event_recorder_get_default ();
+  g_assert (event_recorder1 == event_recorder2);
+  // A singleton shouldn't be unref'd.
+}
+
+static void
 test_event_recorder_record_event (void)
 {
-  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  write_testing_machine_id ();
+  EmtrEventRecorder *event_recorder = make_standard_event_recorder_for_testing ();
   emtr_event_recorder_record_event (event_recorder, MEANINGLESS_EVENT, NULL);
   g_object_unref (event_recorder);
 }
@@ -30,7 +79,8 @@ test_event_recorder_record_event (void)
 static void
 test_event_recorder_record_events (void)
 {
-  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  write_testing_machine_id ();
+  EmtrEventRecorder *event_recorder = make_standard_event_recorder_for_testing ();
   emtr_event_recorder_record_events (event_recorder, MEANINGLESS_EVENT,
                                      G_GINT64_CONSTANT (12), NULL);
   g_object_unref (event_recorder);
@@ -39,7 +89,8 @@ test_event_recorder_record_events (void)
 static void
 test_event_recorder_record_start_stop (void)
 {
-  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  write_testing_machine_id ();
+  EmtrEventRecorder *event_recorder = make_standard_event_recorder_for_testing ();
   emtr_event_recorder_record_start (event_recorder, MEANINGLESS_EVENT, NULL,
                                     NULL);
   emtr_event_recorder_record_stop (event_recorder, MEANINGLESS_EVENT, NULL,
@@ -50,7 +101,8 @@ test_event_recorder_record_start_stop (void)
 static void
 test_event_recorder_record_progress (void)
 {
-  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  write_testing_machine_id ();
+  EmtrEventRecorder *event_recorder = make_standard_event_recorder_for_testing ();
   emtr_event_recorder_record_start (event_recorder, MEANINGLESS_EVENT, NULL,
                                     NULL);
   emtr_event_recorder_record_progress (event_recorder, MEANINGLESS_EVENT, NULL,
@@ -63,7 +115,8 @@ test_event_recorder_record_progress (void)
 static void
 test_event_recorder_record_start_stop_with_key (void)
 {
-  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  write_testing_machine_id ();
+  EmtrEventRecorder *event_recorder = make_standard_event_recorder_for_testing ();
   GVariant *key = g_variant_new ("{sd}", "Power Level", 9320.73);
   g_variant_ref_sink (key);
   emtr_event_recorder_record_start (event_recorder, MEANINGLESS_EVENT, key,
@@ -77,7 +130,8 @@ test_event_recorder_record_start_stop_with_key (void)
 static void
 test_event_recorder_record_progress_with_key (void)
 {
-  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  write_testing_machine_id ();
+  EmtrEventRecorder *event_recorder = make_standard_event_recorder_for_testing ();
   GVariant *key =
     g_variant_new ("s", "NaNNaNNaNNaNNaNNaNNaNNaNNaNNaNNaNNaNNaN BATMAN!!!");
   g_variant_ref_sink (key);
@@ -97,7 +151,8 @@ test_event_recorder_record_progress_with_key (void)
 static void
 test_event_recorder_record_start_stop_with_floating_key (void)
 {
-  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  write_testing_machine_id ();
+  EmtrEventRecorder *event_recorder = make_standard_event_recorder_for_testing ();
   emtr_event_recorder_record_start (event_recorder, MEANINGLESS_EVENT,
                                     g_variant_new ("i", 6170), NULL);
   emtr_event_recorder_record_stop (event_recorder, MEANINGLESS_EVENT,
@@ -108,7 +163,8 @@ test_event_recorder_record_start_stop_with_floating_key (void)
 static void
 test_event_recorder_record_progress_with_floating_key (void)
 {
-  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  write_testing_machine_id ();
+  EmtrEventRecorder *event_recorder = make_standard_event_recorder_for_testing ();
   emtr_event_recorder_record_start (event_recorder, MEANINGLESS_EVENT,
                                     g_variant_new ("mv", NULL), NULL);
   emtr_event_recorder_record_progress (event_recorder, MEANINGLESS_EVENT,
@@ -121,7 +177,8 @@ test_event_recorder_record_progress_with_floating_key (void)
 static void
 test_event_recorder_record_auxiliary_payload (void)
 {
-  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  write_testing_machine_id ();
+  EmtrEventRecorder *event_recorder = make_standard_event_recorder_for_testing ();
   emtr_event_recorder_record_event (event_recorder, MEANINGLESS_EVENT,
                                     g_variant_new ("b", TRUE));
   emtr_event_recorder_record_events (event_recorder, MEANINGLESS_EVENT,
@@ -141,7 +198,8 @@ test_event_recorder_record_auxiliary_payload (void)
 static void
 test_event_recorder_record_multiple_metric_sequences (void)
 {
-  EmtrEventRecorder *event_recorder = emtr_event_recorder_new ();
+  write_testing_machine_id ();
+  EmtrEventRecorder *event_recorder = make_standard_event_recorder_for_testing ();
   GVariant *key = g_variant_new ("^ay", "Anna Breytenbach, Animal Whisperer");
   g_variant_ref_sink (key);
   emtr_event_recorder_record_start (event_recorder, MEANINGLESS_EVENT, key,
@@ -165,6 +223,8 @@ add_event_recorder_tests (void)
 {
   g_test_add_func ("/event-recorder/new-succeeds",
                    test_event_recorder_new_succeeds);
+  g_test_add_func ("/event-recorder/get-default-is-singleton", 
+                   test_event_recorder_get_default_is_singleton);
   g_test_add_func ("/event-recorder/record-event",
                    test_event_recorder_record_event);
   g_test_add_func ("/event-recorder/record-events",

--- a/tests/test-machine-id-provider.c
+++ b/tests/test-machine-id-provider.c
@@ -1,0 +1,101 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#include "run-tests.h"
+
+#include "eosmetrics/emtr-machine-id-provider.h"
+
+#include <glib.h>
+#include <stdio.h>
+#include <uuid/uuid.h>
+
+#define HYPHENS_IN_ID 4
+
+#define TESTING_FILE_PATH "/tmp/testing-machine-id"
+#define TESTING_ID        "04448f74fde24bd7a16f8da17869d5c3\n"
+/*
+ * The expected size in bytes of the file located at
+ * #EmtrMachineIdProvider:path.
+ * According to http://www.freedesktop.org/software/systemd/man/machine-id.html
+ * the file should be 32 lower-case hexadecimal characters followed by a
+ * newline character.
+ */
+#define FILE_LENGTH 33
+
+
+// Helper Functiobns
+
+static gboolean
+write_testing_machine_id ()
+{
+  GFile *file = g_file_new_for_path (TESTING_FILE_PATH);
+  gboolean success = g_file_replace_contents (file,
+                                              TESTING_ID,
+                                              FILE_LENGTH,
+                                              NULL,
+                                              FALSE,
+                                              G_FILE_CREATE_REPLACE_DESTINATION | G_FILE_CREATE_PRIVATE,
+                                              NULL, 
+                                              NULL, 
+                                              NULL);
+  if (!success)
+    g_critical ("Testing code failed to write testing machine id.");
+  g_object_unref (file);
+  return success;
+}
+
+static gchar *
+unhyphenate_uuid (gchar *uuid_with_hyphens)
+{
+  return g_strdup_printf ("%.8s%.4s%.4s%.4s%.12s\n", uuid_with_hyphens,
+                          uuid_with_hyphens + 9, uuid_with_hyphens + 14,
+                          uuid_with_hyphens + 19, uuid_with_hyphens + 24);
+}
+
+// Testing Cases
+
+static void
+test_machine_id_provider_new_succeeds (void)
+{
+  write_testing_machine_id ();
+  EmtrMachineIdProvider *prov = emtr_machine_id_provider_new (TESTING_FILE_PATH);
+  g_assert (prov != NULL);
+  g_object_unref (prov);
+}
+
+static void
+test_machine_id_provider_get_default_is_singleton (void)
+{
+  write_testing_machine_id ();
+  EmtrMachineIdProvider *m1 = emtr_machine_id_provider_get_default ();
+  EmtrMachineIdProvider *m2 = emtr_machine_id_provider_get_default ();
+  g_assert (m1 == m2);
+  // A singleton shouldn't be unref'd.
+}
+
+static void
+test_machine_id_provider_can_get_id (void)
+{
+  write_testing_machine_id ();
+  EmtrMachineIdProvider *prov = emtr_machine_id_provider_new (TESTING_FILE_PATH);
+  uuid_t id;
+  g_assert (emtr_machine_id_provider_get_id (prov, id));
+  gchar unparsed_id[HYPHENS_IN_ID + FILE_LENGTH];
+  uuid_unparse_lower (id, unparsed_id);
+  gchar* unhypenated_id = unhyphenate_uuid (unparsed_id);
+  g_assert_cmpstr (TESTING_ID, ==, unhypenated_id);
+  g_free (unhypenated_id);
+  g_object_unref (prov);
+}
+
+void
+add_machine_id_provider_tests (void)
+{
+  g_test_add_func ("/machine-id-provider/new-succeeds",
+                   test_machine_id_provider_new_succeeds);
+  g_test_add_func ("/machine-id-provider/get-default-is-singleton",
+                   test_machine_id_provider_get_default_is_singleton);
+  g_test_add_func ("/machine-id-provider/can-get-id",
+                   test_machine_id_provider_can_get_id);
+}


### PR DESCRIPTION
Issue: https://github.com/endlessm/eos-sdk/issues/1049

Support for testing via modifiable constructor and singleton default constructor for production.  Also abstracted away a fixed UUID generation behind a `EmtrMachineIdProvider`.

Also fixed little-endian reversal in second (tiny) commit.
