### PR TITLE
Add python-dbusmock build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Build-Depends: autotools-dev,
                libjson-glib-dev (>= 0.16),
                libsoup2.4-dev (>= 2.42),
                pkg-config,
+               python-dbusmock,
                uuid-dev,
                yelp-tools,
                yelp-xsl


### PR DESCRIPTION
Needed for running tests that verify that metrics are posted to the
DBus service.

[endlessm/eos-sdk#1087]
