### PR TITLE
Changed from /etc to /var for cache

### DIFF
--- a/eosmetrics/emtr-persistent-cache.c
+++ b/eosmetrics/emtr-persistent-cache.c
@@ -131,7 +131,7 @@ static guint64 MAX_CACHE_SIZE = 102400; // 100 kB
  * it were immutable by production code.  Only testing code should
  * ever alter this variable.
  */
-static gchar* CACHE_DIRECTORY = "/etc/metrics_cache/";
+static gchar* CACHE_DIRECTORY = "/var/cache/metrics/";
 
 static void
 emtr_persistent_cache_class_init (Emtr_Persistent_CacheClass *klass)


### PR DESCRIPTION
The cache will now be saved (in production) to /var/cache/metrics_cache
instead of /etc/metrics_cache as it won't have permissions to write
to /etc but should have permissions to write to /var.

[endlessm/eos-sdk#1172]
