### PR TITLE
Allowing singletons to be unref'd and recreated

### DIFF
--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -50,6 +50,8 @@ enum {
 };
 
 static GParamSpec *emer_machine_id_provider_props[NPROPS] = { NULL, };
+static EmerMachineIdProvider *singleton;
+G_LOCK_DEFINE_STATIC (singleton);
 
 /*
  * SECTION:emer-machine-id-provider
@@ -119,6 +121,11 @@ static void
 emer_machine_id_provider_finalize (GObject *object)
 {
   EmerMachineIdProvider *self = EMER_MACHINE_ID_PROVIDER (object);
+  G_LOCK (singleton);
+  if (self == singleton)
+    singleton = NULL;
+  G_UNLOCK (singleton);
+
   EmerMachineIdProviderPrivate *priv = emer_machine_id_provider_get_instance_private (self);
   g_free (priv->path);
 
@@ -184,9 +191,6 @@ emer_machine_id_provider_new (const gchar *machine_id_file_path)
 EmerMachineIdProvider *
 emer_machine_id_provider_get_default (void)
 {
-  static EmerMachineIdProvider *singleton;
-  G_LOCK_DEFINE_STATIC (singleton);
-
   G_LOCK (singleton);
   if (singleton == NULL)
     singleton = g_object_new (EMER_TYPE_MACHINE_ID_PROVIDER, NULL);

--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -81,12 +81,19 @@ typedef struct EmtrEventRecorderPrivate
   EmerEventRecorderServer *dbus_proxy;
 } EmtrEventRecorderPrivate;
 
-G_DEFINE_TYPE_WITH_PRIVATE (EmtrEventRecorder, emtr_event_recorder, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (EmtrEventRecorder, emtr_event_recorder, G_TYPE_OBJECT);
+static EmtrEventRecorder *singleton;
+G_LOCK_DEFINE_STATIC (singleton);
 
 static void
 emtr_event_recorder_finalize (GObject *object)
 {
   EmtrEventRecorder *self = EMTR_EVENT_RECORDER (object);
+  G_LOCK (singleton);
+  if (self == singleton)
+    singleton = NULL;
+  G_UNLOCK (singleton);
+
   EmtrEventRecorderPrivate *priv =
     emtr_event_recorder_get_instance_private (self);
 
@@ -300,9 +307,6 @@ emtr_event_recorder_new (void)
 EmtrEventRecorder *
 emtr_event_recorder_get_default (void)
 {
-  static EmtrEventRecorder *singleton;
-  G_LOCK_DEFINE_STATIC (singleton);
-
   G_LOCK (singleton);
   if (singleton == NULL)
     singleton = g_object_new (EMTR_TYPE_EVENT_RECORDER, NULL);

--- a/tests/daemon/test-machine-id-provider.c
+++ b/tests/daemon/test-machine-id-provider.c
@@ -70,7 +70,17 @@ test_machine_id_provider_get_default_is_singleton (void)
   EmerMachineIdProvider *m1 = emer_machine_id_provider_get_default ();
   EmerMachineIdProvider *m2 = emer_machine_id_provider_get_default ();
   g_assert (m1 == m2);
-  // A singleton shouldn't be unref'd.
+  g_object_unref (m1);
+}
+
+static void
+test_machine_id_provider_singleton_call_after_unref (void)
+{
+  write_testing_machine_id ();
+  EmerMachineIdProvider *p1 = emer_machine_id_provider_get_default ();
+  g_object_unref (p1);
+  EmerMachineIdProvider *p2 = emer_machine_id_provider_get_default ();
+  g_object_unref (p2);
 }
 
 static void
@@ -99,6 +109,8 @@ main (int                argc,
                    test_machine_id_provider_new_succeeds);
   g_test_add_func ("/machine-id-provider/get-default-is-singleton",
                    test_machine_id_provider_get_default_is_singleton);
+  g_test_add_func ("/machine-id-provider/singleton-call-after-unref",
+                   test_machine_id_provider_singleton_call_after_unref);
   g_test_add_func ("/machine-id-provider/can-get-id",
                    test_machine_id_provider_can_get_id);
 

--- a/tests/test-event-recorder.c
+++ b/tests/test-event-recorder.c
@@ -75,8 +75,19 @@ test_event_recorder_get_default_is_singleton (void)
   EmtrEventRecorder *event_recorder1 = emtr_event_recorder_get_default ();
   EmtrEventRecorder *event_recorder2 = emtr_event_recorder_get_default ();
   g_assert (event_recorder1 == event_recorder2);
-  // A singleton shouldn't be unref'd.
+  g_object_unref (event_recorder1);
 }
+
+static void
+test_event_recorder_singleton_call_after_unref (void)
+{
+  write_testing_machine_id ();
+  EmtrEventRecorder *p1 = emtr_event_recorder_get_default ();
+  g_object_unref (p1);
+  EmtrEventRecorder *p2 = emtr_event_recorder_get_default ();
+  g_object_unref (p2);
+}
+
 
 static void
 test_event_recorder_record_event (struct RecorderFixture *fixture,
@@ -219,6 +230,8 @@ add_event_recorder_tests (void)
                           test_event_recorder_new_succeeds);
   g_test_add_func ("/event-recorder/get-default-is-singleton", 
                    test_event_recorder_get_default_is_singleton);
+  g_test_add_func ("/event-recorder/singleton-call-after-unref",
+                   test_event_recorder_singleton_call_after_unref);
   ADD_RECORDER_TEST_FUNC ("/event-recorder/record-event",
                           test_event_recorder_record_event);
   ADD_RECORDER_TEST_FUNC ("/event-recorder/record-events",


### PR DESCRIPTION
Allow singletons to be unref'd and recreated, and add tests.
[endlessm/eos-sdk#1160]
