### PR TITLE
Create a permissions provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ eos-metrics-0.0.0
 /tests/daemon/test-machine-id-provider
 /tests/daemon/test-boot-id-provider
 /tests/daemon/test-daemon
+/tests/daemon/test-permissions-provider
 /tests/daemon/test-persistent-cache
 /EosMetrics-0.gir
 /EosMetrics-0.typelib

--- a/daemon/Makefile.am.inc
+++ b/daemon/Makefile.am.inc
@@ -8,6 +8,7 @@ eos_metrics_event_recorder_SOURCES = \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
 	daemon/emer-daemon.c daemon/emer-daemon.h \
 	daemon/emer-machine-id-provider.c daemon/emer-machine-id-provider.h \
+	daemon/emer-permissions-provider.c daemon/emer-permissions-provider.h \
 	daemon/emer-persistent-cache.c daemon/emer-persistent-cache.h \
 	emer-event-recorder-server.c emer-event-recorder-server.h \
 	shared/metrics-util.c shared/metrics-util.h \
@@ -15,5 +16,6 @@ eos_metrics_event_recorder_SOURCES = \
 eos_metrics_event_recorder_CPPFLAGS = \
     $(EOSMETRICS_EVENT_RECORDER_CFLAGS) \
     -D_POSIX_C_SOURCE=200112L \
+    -DSYSCONFDIR="\"$(sysconfdir)\"" \
     $(NULL)
 eos_metrics_event_recorder_LDADD = $(EOSMETRICS_EVENT_RECORDER_LIBS)

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -1,0 +1,262 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#include "emer-permissions-provider.h"
+
+#include <glib.h>
+#include <gio/gio.h>
+
+typedef struct _EmerPermissionsProviderPrivate
+{
+  /* Permissions, cached from config file */
+  GKeyFile *permissions;
+
+  /* For reading the config file */
+  GFile *config_file;
+} EmerPermissionsProviderPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (EmerPermissionsProvider, emer_permissions_provider, G_TYPE_OBJECT)
+
+#define DEFAULT_CONFIG_FILE_PATH SYSCONFDIR "/eos-metrics-permissions.conf"
+
+#define DAEMON_ENABLED_GROUP_NAME "global"
+#define DAEMON_ENABLED_KEY_NAME "enabled"
+
+#define FALLBACK_CONFIG_FILE_DATA \
+  "[" DAEMON_ENABLED_GROUP_NAME "]\n" \
+  DAEMON_ENABLED_KEY_NAME "=false\n"
+
+enum
+{
+  PROP_0,
+  PROP_CONFIG_FILE_PATH,
+  PROP_DAEMON_ENABLED,
+  NPROPS
+};
+
+static GParamSpec *emer_permissions_provider_props[NPROPS] = { NULL, };
+
+/* Replaces the in-memory permissions config data with the fallback values */
+static void
+load_fallback_data (EmerPermissionsProvider *self)
+{
+  EmerPermissionsProviderPrivate *priv =
+    emer_permissions_provider_get_instance_private (self);
+
+  if (g_key_file_load_from_data (priv->permissions, FALLBACK_CONFIG_FILE_DATA,
+                                 -1, G_KEY_FILE_NONE, NULL))
+    return;
+
+  /* Time to panic! Programmer error, fallback config data could not be parsed
+  properly. Could probably only happen if the fallback data is malformed. */
+  g_assert_not_reached ();
+}
+
+/* Read config values from the config file, and if that fails assume the
+default. Also emits a property notification. */
+static void
+read_config_file_sync (EmerPermissionsProvider *self)
+{
+  EmerPermissionsProviderPrivate *priv =
+    emer_permissions_provider_get_instance_private (self);
+
+  GError *error = NULL;
+
+  gchar *path = g_file_get_path (priv->config_file);
+  gboolean success = g_key_file_load_from_file (priv->permissions, path,
+                                                G_KEY_FILE_NONE, &error);
+  if (!success)
+    {
+      load_fallback_data (self);
+
+      if (!g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT) &&
+          !g_error_matches (error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_NOT_FOUND))
+        g_critical ("Permissions config file '%s' was invalid or could not be "
+                    "read. Loading fallback data. Message: %s.", path,
+                    error->message);
+      /* but if the config file was simply not there, fail silently and stick
+      with the defaults */
+
+      g_clear_error (&error);
+    }
+
+  g_object_notify_by_pspec (G_OBJECT (self),
+                            emer_permissions_provider_props[PROP_DAEMON_ENABLED]);
+
+  g_free (path);
+}
+
+static void
+emer_permissions_provider_constructed (GObject *object)
+{
+  EmerPermissionsProvider *self = EMER_PERMISSIONS_PROVIDER (object);
+
+  /* One blocking call on daemon startup (usually once per boot) */
+  read_config_file_sync (self);
+
+  G_OBJECT_CLASS (emer_permissions_provider_parent_class)->constructed (object);
+}
+
+/* Construct-only setter */
+static void
+set_config_file_path (EmerPermissionsProvider *self,
+                      const gchar             *path)
+{
+  EmerPermissionsProviderPrivate *priv =
+    emer_permissions_provider_get_instance_private (self);
+
+  priv->config_file = g_file_new_for_path (path);
+}
+
+static void
+emer_permissions_provider_get_property (GObject    *object,
+                                        guint       property_id,
+                                        GValue     *value,
+                                        GParamSpec *pspec)
+{
+  EmerPermissionsProvider *self = EMER_PERMISSIONS_PROVIDER (object);
+
+  switch (property_id)
+    {
+    case PROP_DAEMON_ENABLED:
+      g_value_set_boolean (value,
+                           emer_permissions_provider_get_daemon_enabled (self));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    }
+}
+
+static void
+emer_permissions_provider_set_property (GObject      *object,
+                                        guint         property_id,
+                                        const GValue *value,
+                                        GParamSpec   *pspec)
+{
+  EmerPermissionsProvider *self = EMER_PERMISSIONS_PROVIDER (object);
+
+  switch (property_id)
+    {
+    case PROP_CONFIG_FILE_PATH:
+      set_config_file_path (self, g_value_get_string (value));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    }
+}
+
+static void
+emer_permissions_provider_finalize (GObject *object)
+{
+  EmerPermissionsProvider *self = EMER_PERMISSIONS_PROVIDER (object);
+  EmerPermissionsProviderPrivate *priv =
+    emer_permissions_provider_get_instance_private (self);
+
+  g_key_file_unref (priv->permissions);
+  g_clear_object (&priv->config_file);
+
+  G_OBJECT_CLASS (emer_permissions_provider_parent_class)->finalize (object);
+}
+
+static void
+emer_permissions_provider_class_init (EmerPermissionsProviderClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->constructed = emer_permissions_provider_constructed;
+  object_class->get_property = emer_permissions_provider_get_property;
+  object_class->set_property = emer_permissions_provider_set_property;
+  object_class->finalize = emer_permissions_provider_finalize;
+
+  emer_permissions_provider_props[PROP_CONFIG_FILE_PATH] =
+    g_param_spec_string ("config-file-path", "Config file path",
+                         "Path to permissions configuration file",
+                         DEFAULT_CONFIG_FILE_PATH,
+                         G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+  emer_permissions_provider_props[PROP_DAEMON_ENABLED] =
+    g_param_spec_boolean ("daemon-enabled", "Daemon enabled",
+                          "Whether to enable the metrics daemon system-wide",
+                          FALSE,
+                          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class, NPROPS,
+                                     emer_permissions_provider_props);
+}
+
+static void
+emer_permissions_provider_init (EmerPermissionsProvider *self)
+{
+  EmerPermissionsProviderPrivate *priv =
+    emer_permissions_provider_get_instance_private (self);
+
+  priv->permissions = g_key_file_new ();
+}
+
+/* PUBLIC API */
+
+/*
+ * emer_permissions_provider_new:
+ *
+ * Creates a new permissions provider with the default config file path.
+ * This object controls whether the metrics event recorder server should record
+ * events or not.
+ *
+ * Returns: (transfer full): a new permissions provider.
+ *   Free with g_object_unref() when done.
+ */
+EmerPermissionsProvider *
+emer_permissions_provider_new (void)
+{
+  return g_object_new (EMER_TYPE_PERMISSIONS_PROVIDER, NULL);
+}
+
+/*
+ * emer_permissions_provider_new_full:
+ *
+ * Creates a new permissions provider with a custom config file path.
+ * Use this function only for testing purposes.
+ *
+ * Returns: (transfer full): a new permissions provider.
+ *   Free with g_object_unref() when done.
+ */
+EmerPermissionsProvider *
+emer_permissions_provider_new_full (const char *config_file_path)
+{
+  return g_object_new (EMER_TYPE_PERMISSIONS_PROVIDER,
+                       "config-file-path", config_file_path,
+                       NULL);
+}
+
+/*
+ * emer_permissions_provider_get_daemon_enabled:
+ * @self: the permissions provider
+ *
+ * Tells whether the event recorder should record events.
+ *
+ * Returns: %TRUE if the event recorder is allowed to record events, %FALSE if
+ *   the user has opted out or the user's preference is unknown.
+ */
+gboolean
+emer_permissions_provider_get_daemon_enabled (EmerPermissionsProvider *self)
+{
+  EmerPermissionsProviderPrivate *priv =
+    emer_permissions_provider_get_instance_private (self);
+
+  GError *error = NULL;
+  gboolean retval = g_key_file_get_boolean (priv->permissions,
+                                            DAEMON_ENABLED_GROUP_NAME,
+                                            DAEMON_ENABLED_KEY_NAME, &error);
+  if (error != NULL)
+    {
+      g_critical ("Couldn't find key '%s:%s' in permissions config file. "
+                  "Returning default value. Message: %s.",
+                  DAEMON_ENABLED_GROUP_NAME, DAEMON_ENABLED_KEY_NAME,
+                  error->message);
+      /* retval is FALSE in case of error */
+    }
+
+  return retval;
+}

--- a/daemon/emer-permissions-provider.h
+++ b/daemon/emer-permissions-provider.h
@@ -1,0 +1,57 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#ifndef EMER_PERMISSIONS_PROVIDER_H
+#define EMER_PERMISSIONS_PROVIDER_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define EMER_TYPE_PERMISSIONS_PROVIDER emer_permissions_provider_get_type()
+
+#define EMER_PERMISSIONS_PROVIDER(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST ((obj), \
+  EMER_TYPE_PERMISSIONS_PROVIDER, EmerPermissionsProvider))
+
+#define EMER_PERMISSIONS_PROVIDER_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST ((klass), \
+  EMER_TYPE_PERMISSIONS_PROVIDER, EmerPermissionsProviderClass))
+
+#define EMER_IS_PERMISSIONS_PROVIDER(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), \
+  EMER_TYPE_PERMISSIONS_PROVIDER))
+
+#define EMER_IS_PERMISSIONS_PROVIDER_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE ((klass), \
+  EMER_TYPE_PERMISSIONS_PROVIDER))
+
+#define EMER_PERMISSIONS_PROVIDER_GET_CLASS(obj) \
+  (G_TYPE_INSTANCE_GET_CLASS ((obj), \
+  EMER_TYPE_PERMISSIONS_PROVIDER, EmerPermissionsProviderClass))
+
+typedef struct _EmerPermissionsProvider EmerPermissionsProvider;
+typedef struct _EmerPermissionsProviderClass EmerPermissionsProviderClass;
+
+struct _EmerPermissionsProvider
+{
+  GObject parent;
+};
+
+struct _EmerPermissionsProviderClass
+{
+  GObjectClass parent_class;
+};
+
+GType                    emer_permissions_provider_get_type           (void) G_GNUC_CONST;
+
+EmerPermissionsProvider *emer_permissions_provider_new                (void);
+
+EmerPermissionsProvider *emer_permissions_provider_new_full           (const gchar             *config_file_path);
+
+gboolean                 emer_permissions_provider_get_daemon_enabled (EmerPermissionsProvider *self);
+
+G_END_DECLS
+
+#endif /* EMER_PERMISSIONS_PROVIDER_H */

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -5,6 +5,7 @@ noinst_PROGRAMS = \
 	tests/daemon/test-boot-id-provider \
 	tests/daemon/test-daemon \
 	tests/daemon/test-machine-id-provider \
+	tests/daemon/test-permissions-provider \
 	tests/daemon/test-persistent-cache \
 	$(NULL)
 
@@ -37,6 +38,7 @@ DAEMON_TEST_FLAGS = \
 	@EOSMETRICS_EVENT_RECORDER_CFLAGS@ \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/daemon \
+	-DSYSCONFDIR="\"$(sysconfdir)\"" \
 	$(NULL)
 DAEMON_TEST_LIBS = @EOSMETRICS_EVENT_RECORDER_LIBS@
 
@@ -66,6 +68,13 @@ tests_daemon_test_machine_id_provider_SOURCES = \
 tests_daemon_test_machine_id_provider_CPPFLAGS = $(DAEMON_TEST_FLAGS)
 tests_daemon_test_machine_id_provider_LDADD = $(DAEMON_TEST_LIBS)
 
+tests_daemon_test_permissions_provider_SOURCES = \
+	tests/daemon/test-permissions-provider.c \
+	daemon/emer-permissions-provider.c daemon/emer-permissions-provider.h \
+	$(NULL)
+tests_daemon_test_permissions_provider_CPPFLAGS = $(DAEMON_TEST_FLAGS)
+tests_daemon_test_permissions_provider_LDADD = $(DAEMON_TEST_LIBS)
+
 tests_daemon_test_persistent_cache_SOURCES = \
 	tests/daemon/test-persistent-cache.c \
 	daemon/emer-persistent-cache.c daemon/emer-persistent-cache.h \
@@ -87,6 +96,7 @@ TESTS = \
 	tests/daemon/test-daemon \
 	tests/daemon/test-machine-id-provider \
 	tests/daemon/test-persistent-cache \
+	tests/daemon/test-permissions-provider \
 	$(javascript_tests) \
 	$(NULL)
 TEST_EXTENSIONS = .js .py

--- a/tests/daemon/test-permissions-provider.c
+++ b/tests/daemon/test-permissions-provider.c
@@ -1,0 +1,153 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#include "emer-permissions-provider.h"
+
+#include <string.h>
+
+#include <glib.h>
+#include <gio/gio.h>
+
+#define CONFIG_FILE_ENABLED_CONTENTS \
+  "[global]\n" \
+  "enabled=true\n"
+#define CONFIG_FILE_DISABLED_CONTENTS \
+  "[global]\n" \
+  "enabled=false\n"
+#define CONFIG_FILE_INVALID_CONTENTS "lavubeu;f'w943ty[jdn;fbl\n"
+
+typedef struct {
+  GFile *temp_file;
+  EmerPermissionsProvider *test_object;
+} Fixture;
+
+/* Pass NULL to config_file_contents if you don't want to create a file on disk.
+A file name will be created in any case and passed to the object's constructor.
+*/
+static void
+setup (Fixture      *fixture,
+       gconstpointer data)
+{
+  const gchar *config_file_contents = (const gchar *)data;
+
+  GFileIOStream *stream = NULL;
+  fixture->temp_file = g_file_new_tmp ("test-permissions-providerXXXXXX",
+                                       &stream, NULL);
+  g_assert (fixture->temp_file != NULL);
+
+  GOutputStream *ostream = g_io_stream_get_output_stream (G_IO_STREAM (stream));
+
+  if (config_file_contents != NULL)
+    {
+      g_assert (g_output_stream_write_all (ostream, config_file_contents,
+                                           strlen (config_file_contents),
+                                           NULL /* bytes written */,
+                                           NULL, NULL));
+      g_object_unref (stream);
+    }
+  else
+    {
+      g_object_unref (stream);
+      g_assert (g_file_delete (fixture->temp_file, NULL, NULL));
+    }
+
+  gchar *config_file_path = g_file_get_path (fixture->temp_file);
+  fixture->test_object = emer_permissions_provider_new_full (config_file_path);
+  g_free (config_file_path);
+}
+
+static void
+setup_invalid_file (Fixture      *fixture,
+                    gconstpointer contents)
+{
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL,
+                         "*Permissions config file*was invalid or could not be "
+                         "read. Loading fallback data*");
+  setup (fixture, contents);
+}
+
+static void
+teardown (Fixture      *fixture,
+          gconstpointer unused)
+{
+  g_file_delete (fixture->temp_file, NULL, NULL); /* might not exist */
+  g_clear_object (&fixture->temp_file);
+  g_clear_object (&fixture->test_object);
+}
+
+/* This test is run several times with different data; once with a config file,
+once with NULL. */
+static void
+test_permissions_provider_new (Fixture      *fixture,
+                               gconstpointer unused)
+{
+  g_assert (fixture->test_object != NULL);
+}
+
+static void
+test_permissions_provider_new_invalid_file (Fixture      *fixture,
+                                            gconstpointer unused)
+{
+  g_assert (fixture->test_object != NULL);
+  g_test_assert_expected_messages ();
+}
+
+static void
+test_permissions_provider_get_daemon_enabled (Fixture      *fixture,
+                                              gconstpointer unused)
+{
+  g_assert (emer_permissions_provider_get_daemon_enabled (fixture->test_object));
+}
+
+static void
+test_permissions_provider_get_daemon_enabled_false (Fixture      *fixture,
+                                                    gconstpointer unused)
+{
+  g_assert_false (emer_permissions_provider_get_daemon_enabled (fixture->test_object));
+}
+
+static void
+test_permissions_provider_get_daemon_enabled_fallback (Fixture      *fixture,
+                                                       gconstpointer unused)
+{
+  g_assert_false (emer_permissions_provider_get_daemon_enabled (fixture->test_object));
+  g_test_assert_expected_messages ();
+}
+
+int
+main (int                argc,
+      const char * const argv[])
+{
+  g_test_init (&argc, (char ***) &argv, NULL);
+
+#define ADD_PERMISSIONS_PROVIDER_TEST(path, file_contents, setup, test_func) \
+  g_test_add ((path), Fixture, (file_contents), (setup), (test_func), teardown);
+
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/new/existing-config-file",
+                                 CONFIG_FILE_ENABLED_CONTENTS, setup,
+                                 test_permissions_provider_new);
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/new/absent-config-file",
+                                 NULL, setup, test_permissions_provider_new);
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/new/invalid-config-file",
+                                 CONFIG_FILE_INVALID_CONTENTS,
+                                 setup_invalid_file,
+                                 test_permissions_provider_new_invalid_file);
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/get-daemon-enabled/existing-config-file-yes",
+                                 CONFIG_FILE_ENABLED_CONTENTS, setup,
+                                 test_permissions_provider_get_daemon_enabled);
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/get-daemon-enabled/existing-config-file-no",
+                                 CONFIG_FILE_DISABLED_CONTENTS, setup,
+                                 test_permissions_provider_get_daemon_enabled_false);
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/get-daemon-enabled/absent-config-file",
+                                 NULL, setup,
+                                 test_permissions_provider_get_daemon_enabled_fallback);
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/get-daemon-enabled/invalid-config-file",
+                                 CONFIG_FILE_INVALID_CONTENTS,
+                                 setup_invalid_file,
+                                 test_permissions_provider_get_daemon_enabled_fallback);
+
+#undef ADD_PERMISSIONS_PROVIDER_TEST
+
+  return g_test_run ();
+}


### PR DESCRIPTION
This adds an EmerPermissionsProvider to the daemon, not yet hooked up.
It reads a configuration file, /var/eosmetrics/metrics-permissions by
default, and monitors it for changes. The file is a key-value file
controlling whether the event recorder server should record metrics or
not (in the case that the user has opted out.)

(Devin & Philip)

[endlessm/eos-sdk#1324]
