### PR TITLE
Added network retries and user IDs to event recorder daemon

### DIFF
--- a/daemon/emer-daemon.h
+++ b/daemon/emer-daemon.h
@@ -49,7 +49,8 @@ GType       emer_daemon_get_type               (void) G_GNUC_CONST;
 
 EmerDaemon *emer_daemon_new                    (void);
 
-EmerDaemon *emer_daemon_new_full               (gint                   version_number,
+EmerDaemon *emer_daemon_new_full               (GRand                 *rand,
+                                                gint                   version_number,
                                                 const gchar           *environment,
                                                 guint                  network_send_interval,
                                                 const gchar           *proxy_server_uri,

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -22,7 +22,8 @@ make_daemon_for_testing (void)
 {
   EmerMachineIdProvider *id_prov =
     emer_machine_id_provider_new (MACHINE_ID_PATH);
-  return emer_daemon_new_full (42, // Version number
+  return emer_daemon_new_full (g_rand_new_with_seed (18),
+                               42, // Version number
                                "test", // Environment
                                5,  // Network Send Interval
                                "http://localhost:8080", // uri, (port TBD) TODO


### PR DESCRIPTION
Support network retries using randomized exponential backoff and updating the
current time with each attempt.

Supported multiple users by adding user ID to the GVariant type of each event
and setting it to the value received via DBus.

Fixed various bugs in the event recorder daemon.

[endlessm/eos-sdk#607]
[endlessm/eos-sdk#1255]
