### PR TITLE
Update production metrics server URI

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -17,11 +17,9 @@
 #include "emer-machine-id-provider.h"
 #include "shared/metrics-util.h"
 
-// TODO: Once we have a production proxy server, update this constant
-// accordingly.
 /* The URI of the metrics production proxy server. Is kept in a #define to
 prevent testing code from sending metrics to the production server. */
-#define PRODUCTION_SERVER_URI "http://metrics-test.endlessm-sf.com:8080/"
+#define PRODUCTION_SERVER_URI "https://metrics.endlessm.com/"
 
 /*
  * The minimum number of seconds to wait before attempting the first retry of a


### PR DESCRIPTION
This is the real thing! The uri is http://metrics.endlessm.com/, port
80 (the default).

[endlessm/eos-sdk#966]
