### PR TITLE
Boot Id Provider created.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ eos-metrics-0.0.0
 /eosmetrics-0.pc
 /tests/run-tests
 /tests/daemon/test-machine-id-provider
+/tests/daemon/test-boot-id-provider
 /tests/daemon/test-daemon
 /tests/daemon/test-persistent-cache
 /EosMetrics-0.gir

--- a/daemon/Makefile.am.inc
+++ b/daemon/Makefile.am.inc
@@ -5,6 +5,7 @@ libexec_PROGRAMS = eos-metrics-event-recorder
 ## emer-event-recorder-server.[ch] are generated in ../data/Makefile.am.inc.
 eos_metrics_event_recorder_SOURCES = \
 	daemon/emer-main.c \
+	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
 	daemon/emer-daemon.c daemon/emer-daemon.h \
 	daemon/emer-machine-id-provider.c daemon/emer-machine-id-provider.h \
 	daemon/emer-persistent-cache.c daemon/emer-persistent-cache.h \

--- a/daemon/emer-boot-id-provider.c
+++ b/daemon/emer-boot-id-provider.c
@@ -1,0 +1,263 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#include "emer-boot-id-provider.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <uuid/uuid.h>
+
+typedef struct EmerBootIdProviderPrivate
+{
+  gchar *path;
+  uuid_t id;
+} EmerBootIdProviderPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (EmerBootIdProvider, emer_boot_id_provider, G_TYPE_OBJECT)
+
+#define BOOT_ID_PROVIDER_PRIVATE(o) \
+  (G_TYPE_INSTANCE_GET_PRIVATE ((o), EMER_TYPE_BOOT_ID_PROVIDER, EmerBootIdProviderPrivate))
+
+/*
+ * The expected size in bytes of the file located at
+ * /proc/sys/kernel/random/boot_id. The file should be 32 lower-case hexadecimal
+ * characters interspersed with 4 hyphens and terminated with a newline
+ * character.
+ *
+ * Exact format: "%08x-%04x-%04x-%04x-%012x\n"
+ */
+#define FILE_LENGTH 37
+
+/*
+ * The filepath to the system file containing a statistically unique identifier
+ * (uuid) for the current boot of the machine. Will vary from boot to boot.
+ */
+#define DEFAULT_BOOT_ID_FILEPATH "/proc/sys/kernel/random/boot_id"
+
+enum {
+  PROP_0,
+  PROP_PATH,
+  NPROPS
+};
+
+static GParamSpec *emer_boot_id_provider_props[NPROPS] = { NULL, };
+
+/*
+ * SECTION:emer-boot-id-provider
+ * @title: Boot ID Provider
+ * @short_description: Provides unique boot identifiers.
+ * @include: eosmetrics/eosmetrics.h
+ *
+ * The boot ID provider supplies UUIDs which uniquely identify each boot of the
+ * computer.
+ *
+ * This class abstracts away how and where UUIDs are generated from by providing
+ * a simple interface via emer_boot_id_provider_get_id() to whatever calling
+ * code needs it.
+ */
+
+static const gchar *
+get_id_path (EmerBootIdProvider *self)
+{
+  EmerBootIdProviderPrivate *priv =
+    emer_boot_id_provider_get_instance_private (self);
+  return priv->path;
+}
+
+static void
+set_id_path (EmerBootIdProvider *self,
+             const gchar        *given_path)
+{
+  EmerBootIdProviderPrivate *priv =
+    emer_boot_id_provider_get_instance_private (self);
+  priv->path = g_strdup (given_path);
+}
+
+static void
+emer_boot_id_provider_get_property (GObject    *object,
+                                    guint       property_id,
+                                    GValue     *value,
+                                    GParamSpec *pspec)
+{
+  EmerBootIdProvider *self = EMER_BOOT_ID_PROVIDER (object);
+
+  switch (property_id)
+    {
+    case PROP_PATH:
+      g_value_set_string (value, get_id_path (self));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    }
+}
+
+static void
+emer_boot_id_provider_set_property (GObject      *object,
+                                    guint         property_id,
+                                    const GValue *value,
+                                    GParamSpec   *pspec)
+{
+  EmerBootIdProvider *self = EMER_BOOT_ID_PROVIDER (object);
+
+  switch (property_id)
+    {
+    case PROP_PATH:
+        set_id_path (self, g_value_get_string (value));
+        break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    }
+}
+
+static void
+emer_boot_id_provider_finalize (GObject *object)
+{
+  EmerBootIdProvider *self = EMER_BOOT_ID_PROVIDER (object);
+  EmerBootIdProviderPrivate *priv =
+    emer_boot_id_provider_get_instance_private (self);
+  g_free (priv->path);
+
+  G_OBJECT_CLASS (emer_boot_id_provider_parent_class)->finalize (object);
+}
+
+static void
+emer_boot_id_provider_class_init (EmerBootIdProviderClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->get_property = emer_boot_id_provider_get_property;
+  object_class->set_property = emer_boot_id_provider_set_property;
+  object_class->finalize = emer_boot_id_provider_finalize;
+
+  /* Blurb string is good enough default documentation for this */
+  emer_boot_id_provider_props[PROP_PATH] =
+    g_param_spec_string ("path", "Path",
+                         "The path to the file where the unique identifier is stored.",
+                         DEFAULT_BOOT_ID_FILEPATH,
+                         G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class, NPROPS,
+                                     emer_boot_id_provider_props);
+}
+
+// Mandatory empty function.
+static void
+emer_boot_id_provider_init (EmerBootIdProvider *self)
+{
+}
+
+/*
+ * emer_boot_id_provider_new:
+ *
+ * Gets the ID provider used to obtain a unique boot ID via the default
+ * filepath.
+ *
+ * Returns: (transfer full): A new #EmerBootIdProvider.
+ * Free with g_object_unref().
+ */
+EmerBootIdProvider *
+emer_boot_id_provider_new (void)
+{
+  return g_object_new (EMER_TYPE_BOOT_ID_PROVIDER,
+                       "path", DEFAULT_BOOT_ID_FILEPATH,
+                       NULL);
+}
+
+/*
+ * emer_boot_id_provider_new_full:
+ * @boot_id_file_path: path to a file; see #EmerBootIdProvider:path
+ *
+ * Gets the ID provider used to obtain a unique boot ID via a given filepath.
+ *
+ * Returns: (transfer full): A new #EmerBootIdProvider.
+ * Free with g_object_unref().
+ */
+EmerBootIdProvider *
+emer_boot_id_provider_new_full (const gchar *boot_id_file_path)
+{
+  return g_object_new (EMER_TYPE_BOOT_ID_PROVIDER,
+                       "path", boot_id_file_path,
+                       NULL);
+}
+
+static gboolean
+read_boot_id (EmerBootIdProvider *self)
+{
+  EmerBootIdProviderPrivate *priv =
+    emer_boot_id_provider_get_instance_private (self);
+
+  gchar *boot_id_string;
+  gsize boot_id_length;
+  GError *error = NULL;
+  gboolean read_succeeded =
+    g_file_get_contents (priv->path, &boot_id_string, &boot_id_length, &error);
+
+  if (!read_succeeded)
+    {
+      g_critical ("Failed to read boot ID file (%s).", priv->path);
+      return FALSE;
+    }
+
+  if (strlen (boot_id_string) != boot_id_length)
+    {
+      g_critical ("Boot ID file (%s) contained null byte, but should be "
+                  "hexadecimal.", priv->path);
+      return FALSE;
+    }
+
+  if (boot_id_length != FILE_LENGTH)
+    {
+      g_critical ("Boot ID file (%s) contained %" G_GSIZE_FORMAT " bytes, "
+                  "but expected %d bytes.", priv->path, boot_id_length,
+                  FILE_LENGTH);
+      return FALSE;
+    }
+
+  // Remove newline.
+  g_strchomp (boot_id_string);
+
+  int parse_failed = uuid_parse (boot_id_string, priv->id);
+  g_free (boot_id_string);
+
+  if (parse_failed != 0)
+    {
+      g_critical ("Boot ID file (%s) did not contain UUID.", priv->path);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+/*
+ * emer_boot_id_provider_get_id:
+ * @self: the boot ID provider
+ * @uuid: (out caller-allocates) (array fixed-size=16) (element-type guchar):
+ * allocated 16-byte return location for a UUID.
+ *
+ * Retrieves an ID (in the form of a UUID) that is unique to this boot, for
+ * use in anonymously identifying metrics data.
+ *
+ * Returns: a boolean indicating success or failure of retrieval.
+ * If this returns %FALSE, the UUID cannot be trusted to be valid.
+ */
+gboolean
+emer_boot_id_provider_get_id (EmerBootIdProvider *self,
+                              uuid_t              uuid)
+{
+  EmerBootIdProviderPrivate *priv =
+    emer_boot_id_provider_get_instance_private (self);
+  static gboolean id_is_valid = FALSE;
+
+  if (!id_is_valid)
+    {
+      if (!read_boot_id (self))
+        return FALSE;
+    }
+
+  uuid_copy (uuid, priv->id);
+  id_is_valid = TRUE;
+  return TRUE;
+}

--- a/daemon/emer-boot-id-provider.h
+++ b/daemon/emer-boot-id-provider.h
@@ -1,0 +1,71 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#ifndef EMER_BOOT_ID_PROVIDER_H
+#define EMER_BOOT_ID_PROVIDER_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define EMER_TYPE_BOOT_ID_PROVIDER emer_boot_id_provider_get_type()
+
+#define EMER_BOOT_ID_PROVIDER(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST ((obj), \
+  EMER_TYPE_BOOT_ID_PROVIDER, EmerBootIdProvider))
+
+#define EMER_BOOT_ID_PROVIDER_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST ((klass), \
+  EMER_TYPE_BOOT_ID_PROVIDER, EmerBootIdProviderClass))
+
+#define EMER_IS_BOOT_ID_PROVIDER(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), \
+  EMER_TYPE_BOOT_ID_PROVIDER))
+
+#define EMER_IS_BOOT_ID_PROVIDER_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE ((klass), \
+  EMER_TYPE_BOOT_ID_PROVIDER))
+
+#define EMER_BOOT_ID_PROVIDER_GET_CLASS(obj) \
+  (G_TYPE_INSTANCE_GET_CLASS ((obj), \
+  EMER_TYPE_BOOT_ID_PROVIDER, EmerBootIdProviderClass))
+
+/*
+ * EmerBootIdProvider:
+ *
+ * This instance structure contains no public members.
+ */
+typedef struct _EmerBootIdProvider EmerBootIdProvider;
+
+/*
+ * EmerBootIdProviderClass:
+ *
+ * This class structure contains no public members.
+ */
+typedef struct _EmerBootIdProviderClass EmerBootIdProviderClass;
+
+struct _EmerBootIdProvider
+{
+  /*< private >*/
+  GObject parent;
+};
+
+struct _EmerBootIdProviderClass
+{
+  /*< private >*/
+  GObjectClass parent_class;
+};
+
+GType               emer_boot_id_provider_get_type (void) G_GNUC_CONST;
+
+EmerBootIdProvider *emer_boot_id_provider_new      (void);
+
+EmerBootIdProvider *emer_boot_id_provider_new_full (const gchar        *boot_id_file_path);
+
+gboolean            emer_boot_id_provider_get_id   (EmerBootIdProvider *self,
+                                                    guchar              uuid[16]);
+
+G_END_DECLS
+
+#endif /* EMER_BOOT_ID_PROVIDER_H */

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -2,8 +2,9 @@
 
 noinst_PROGRAMS = \
 	tests/run-tests \
-	tests/daemon/test-machine-id-provider \
+	tests/daemon/test-boot-id-provider \
 	tests/daemon/test-daemon \
+	tests/daemon/test-machine-id-provider \
 	tests/daemon/test-persistent-cache \
 	$(NULL)
 
@@ -38,6 +39,13 @@ DAEMON_TEST_FLAGS = \
 	-I$(top_srcdir)/daemon \
 	$(NULL)
 DAEMON_TEST_LIBS = @EOSMETRICS_EVENT_RECORDER_LIBS@
+
+tests_daemon_test_boot_id_provider_SOURCES = \
+	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
+	tests/daemon/test-boot-id-provider.c \
+	$(NULL)
+tests_daemon_test_boot_id_provider_CPPFLAGS = $(DAEMON_TEST_FLAGS)
+tests_daemon_test_boot_id_provider_LDADD = $(DAEMON_TEST_LIBS)
 
 tests_daemon_test_daemon_SOURCES = \
 	daemon/emer-daemon.c daemon/emer-daemon.h \
@@ -75,6 +83,7 @@ dist_bin_SCRIPTS = tests/launch-mock-dbus-tests.sh
 TESTS = \
 	tests/run-tests \
 	tests/test-daemon-integration.py \
+	tests/daemon/test-boot-id-provider \
 	tests/daemon/test-daemon \
 	tests/daemon/test-machine-id-provider \
 	tests/daemon/test-persistent-cache \

--- a/tests/daemon/test-boot-id-provider.c
+++ b/tests/daemon/test-boot-id-provider.c
@@ -1,0 +1,129 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#include "emer-boot-id-provider.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+#include <uuid/uuid.h>
+
+#define TESTING_FILE_PATH "testing_boot_id_XXXXXX"
+#define FIRST_TESTING_ID  "67ba25f5-b7af-48f9-a746-d1421a7e49de\n"
+#define SECOND_TESTING_ID "1a4f1bfe-262f-4800-826d-d8e5b9d60081\n"
+
+
+/*
+ * The expected size in bytes of the file located at
+ * /proc/sys/kernel/random/boot_id. The file should be 32 lower-case hexadecimal
+ * characters interspersed with 4 hyphens and terminated with a newline
+ * character.
+ *
+ * Exact format: "%08x-%04x-%04x-%04x-%012x\n"
+ */
+#define FILE_LENGTH 37
+
+// Helper Functions
+
+struct Fixture
+{
+  EmerBootIdProvider *id_provider;
+  GFile *tmp_file;
+};
+
+static void
+write_testing_boot_id (struct Fixture *fixture,
+                     const gchar    *testing_id)
+{
+  g_assert (g_file_replace_contents (fixture->tmp_file, testing_id, FILE_LENGTH,
+                                     NULL, FALSE,
+                                     G_FILE_CREATE_REPLACE_DESTINATION, NULL,
+                                     NULL, NULL));
+}
+
+static void
+setup (struct Fixture *fixture,
+       gconstpointer   unused)
+{
+  GFileIOStream *stream;
+  fixture->tmp_file = g_file_new_tmp (TESTING_FILE_PATH, &stream, NULL);
+  g_assert (fixture->tmp_file != NULL);
+  write_testing_boot_id (fixture, FIRST_TESTING_ID);
+  gchar *path = g_file_get_path (fixture->tmp_file);
+  fixture->id_provider = emer_boot_id_provider_new_full (path);
+  g_free (path);
+}
+
+static void
+teardown (struct Fixture *fixture,
+          gconstpointer   unused)
+{
+  g_object_unref (fixture->tmp_file);
+  g_object_unref (fixture->id_provider);
+}
+
+// Testing Cases
+
+static void
+test_boot_id_provider_new_succeeds (struct Fixture *fixture,
+                                    gconstpointer   unused)
+{
+  g_assert (fixture->id_provider != NULL);
+}
+
+static void
+test_boot_id_provider_can_get_id (struct Fixture *fixture,
+                                  gconstpointer   unused)
+{
+  uuid_t real_id;
+  g_assert (emer_boot_id_provider_get_id (fixture->id_provider, real_id));
+
+  gchar* testing_id_string = g_strdup (FIRST_TESTING_ID);
+  g_strchomp (testing_id_string);
+  uuid_t testing_id;
+  uuid_parse (testing_id_string, testing_id);
+  g_free (testing_id_string);
+
+  g_assert (uuid_compare (testing_id, real_id) == 0);
+}
+
+static void
+test_boot_id_provider_caches_id (struct Fixture *fixture,
+                                 gconstpointer   unused)
+{
+  uuid_t real_id;
+  g_assert (emer_boot_id_provider_get_id (fixture->id_provider, real_id));
+
+  // If the boot id provider isn't caching its value, it will read this instead.
+  write_testing_boot_id (fixture, SECOND_TESTING_ID);
+
+  gchar* testing_id_string = g_strdup (SECOND_TESTING_ID);
+  g_strchomp (testing_id_string);
+  uuid_t testing_id;
+  uuid_parse (testing_id_string, testing_id);
+  g_free (testing_id_string);
+
+  g_assert (uuid_compare (testing_id, real_id) != 0);
+}
+
+int
+main (int                argc,
+      const char * const argv[])
+{
+  g_test_init (&argc, (char ***) &argv, NULL);
+// gboolean is being used as a dummy fixture.
+#define ADD_BOOT_TEST_FUNC(path, func) \
+  g_test_add ((path), struct Fixture, NULL, setup, (func), teardown)
+
+  ADD_BOOT_TEST_FUNC ("/boot-id-provider/new-succeeds",
+                      test_boot_id_provider_new_succeeds);
+  ADD_BOOT_TEST_FUNC ("/boot-id-provider/can-get-id",
+                      test_boot_id_provider_can_get_id);
+  ADD_BOOT_TEST_FUNC ("/boot-id-provider/caches-id",
+                      test_boot_id_provider_caches_id);
+
+#undef ADD_BOOT_TEST_FUNC
+
+  return g_test_run ();
+}


### PR DESCRIPTION
The EmerBootIdProvider behaves VERY similarly to the MachineIdProvider.
It retrieves the system's boot ID from disk and caches it, when
successful. It also supports a testing constructor.
[endlessm/eos-sdk#1405]
