### PR TITLE
Add permissions config file

### DIFF
--- a/debian/eos-metrics-event-recorder.install
+++ b/debian/eos-metrics-event-recorder.install
@@ -1,4 +1,5 @@
 etc/dbus-1/system.d/com.endlessm.Metrics.conf
+etc/eos-metrics-permissions.conf
 lib/systemd/system/eos-metrics-event-recorder.service
 usr/lib/eos-metrics/eos-metrics-event-recorder
 usr/share/dbus-1/system-services/com.endlessm.Metrics.service

--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -1,0 +1,4 @@
+# The metrics permissions config file has a non-standard owner (root:metrics)
+# and a non-standard permissions (664).
+eos-metrics-event-recorder binary: wrong-file-owner-uid-or-gid
+eos-metrics-event-recorder binary: non-standard-file-perm

--- a/debian/rules
+++ b/debian/rules
@@ -18,3 +18,7 @@ override_dh_auto_configure:
 
 override_dh_auto_test:
 	dh_auto_test || ( find . -name '*.log' | xargs cat; false )
+
+# Avoid changing the owner of the permissions configuration file to root:root
+override_dh_fixperms:
+	dh_fixperms -Xeos-metrics-permissions.conf


### PR DESCRIPTION
And set the expected owner and permissions (root:metrics, 0664).

[endlessm/eos-sdk#1090]
