### PR TITLE
Added environment 2 config file default

### DIFF
--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -22,10 +22,12 @@ G_DEFINE_TYPE_WITH_PRIVATE (EmerPermissionsProvider, emer_permissions_provider, 
 
 #define DAEMON_ENABLED_GROUP_NAME "global"
 #define DAEMON_ENABLED_KEY_NAME "enabled"
+#define DAEMON_ENVIRONMENT_KEY_NAME "environment"
 
 #define FALLBACK_CONFIG_FILE_DATA \
   "[" DAEMON_ENABLED_GROUP_NAME "]\n" \
-  DAEMON_ENABLED_KEY_NAME "=false\n"
+  DAEMON_ENABLED_KEY_NAME "=false\n" \
+  DAEMON_ENVIRONMENT_KEY_NAME "=production\n"
 
 enum
 {

--- a/data/eos-metrics-permissions.conf
+++ b/data/eos-metrics-permissions.conf
@@ -1,2 +1,3 @@
 [global]
 enabled=false
+environment=production

--- a/tests/daemon/test-permissions-provider.c
+++ b/tests/daemon/test-permissions-provider.c
@@ -13,10 +13,12 @@
 
 #define CONFIG_FILE_ENABLED_CONTENTS \
   "[global]\n" \
-  "enabled=true\n"
+  "enabled=true\n" \
+  "environment=test\n"
 #define CONFIG_FILE_DISABLED_CONTENTS \
   "[global]\n" \
-  "enabled=false\n"
+  "enabled=false\n" \
+  "environment=test\n"
 #define CONFIG_FILE_INVALID_CONTENTS "lavubeu;f'w943ty[jdn;fbl\n"
 
 typedef struct {


### PR DESCRIPTION
The "fallback" or default config file for metrics now has an
environment key/value pair set to production. The testing code
has its default keyfiles with an environment set to test.
[endlessm/eos-sdk#1499]
