### PR TITLE
Prevent /var/cache/metrics from being chowned.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,6 +19,7 @@ override_dh_auto_configure:
 override_dh_auto_test:
 	dh_auto_test || ( find . -name '*.log' | xargs cat; false )
 
-# Avoid changing the owner of the permissions configuration file to root:root
+# Avoid changing the owner of the permissions configuration and persistent cache
+# directory to root:root.
 override_dh_fixperms:
-	dh_fixperms -Xeos-metrics-permissions.conf
+	dh_fixperms -Xeos-metrics-permissions.conf -Xcache/metrics


### PR DESCRIPTION
Left unchecked, dh_fixperms will chown /var/cache/metrics to be owned by the
root user and group. Add an exception to allow /var/cache/metrics to remain
owned by the metrics user and group.

[endlessm/eos-sdk#1506]
