### PR TITLE
Changed func signature for readability.

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -727,6 +727,9 @@ flush_to_persistent_cache (EmerDaemon *self)
   g_mutex_unlock (&priv->sequence_buffer_lock);
 }
 
+// Callbacks don't require the last parameter(s) to be included in the signature
+// if they aren't used. See:
+// http://stackoverflow.com/questions/22402597/
 static void
 upload_events (EmerDaemon   *self,
                GAsyncResult *res)


### PR DESCRIPTION
upload_events is/was a GAsyncCallback and used to make use of
a convention to drop off unused parameters from the end of the
parameter list. This is no longer done for purposes of
maintainability.
[endlessm/eos-sdk#1529]
