### PR TITLE
Moved MAX_CACHE_SIZE to priv struct.

### DIFF
--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -133,7 +133,7 @@ gboolean             emer_persistent_cache_store_metrics       (EmerPersistentCa
 EmerPersistentCache *emer_persistent_cache_new_full            (GCancellable             *cancellable,
                                                                 GError                  **error,
                                                                 gchar                    *custom_directory,
-                                                                gint                      custom_cache_size,
+                                                                guint64                   custom_cache_size,
                                                                 EmerBootIdProvider       *boot_id_provider,
                                                                 EmerCacheVersionProvider *version_provider,
                                                                 guint                     boot_offset_update_interval);

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -34,7 +34,7 @@ EmerPersistentCache *
 emer_persistent_cache_new_full (GCancellable             *cancellable,
                                 GError                  **error,
                                 gchar                    *custom_directory,
-                                gint                      custom_cache_size,
+                                guint64                   custom_cache_size,
                                 EmerBootIdProvider       *boot_id_provider,
                                 EmerCacheVersionProvider *version_provider,
                                 guint                     boot_offset_update_interval)

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -18,8 +18,8 @@
 #define FAKE_BOOT_ID "baccd4dd-9765-4eb2-a2a0-03c6623471e6\n"
 #define FAKE_BOOT_OFFSET 4000000000 // 4 seconds
 
-#define TEST_SIZE 1024000
 #define TEST_UPDATE_OFFSET_INTERVAL (60u * 60u) // 1 hour
+#define TEST_SIZE 1024000u
 
 /*
  * The expected size in bytes of the boot id file we want to mock, located at
@@ -1031,7 +1031,7 @@ static void
 test_persistent_cache_store_when_full_succeeds (gboolean     *unused,
                                                 gconstpointer dontuseme)
 {
-  gint space_in_bytes = 3000;
+  guint64 space_in_bytes = 3000u;
   EmerBootIdProvider *boot_id_provider =
     emer_boot_id_provider_new_full (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   EmerCacheVersionProvider *cache_version_provider =


### PR DESCRIPTION
The MAX_CACHE_SIZE is no longer global but is now private data.
It is a guint64 because it is compared against the cache_size
which is computed by a Glib function which returns a guint64.
[endlessm/eos-sdk#1547]
