### PR TITLE
Allow tests to be disabled.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS = \
 	--enable-gir-doc \
 	--enable-strict-flags \
 	--with-systemdsystemunitdir=$(libdir)/systemd \
+	--disable-login-tests \
 	$(NULL)
 
 # Generated files that 'make clean' should erase

--- a/configure.ac
+++ b/configure.ac
@@ -192,6 +192,14 @@ AC_ARG_WITH([systemdsystemunitdir],
     [systemdsystemunitdir="$withval"])
 AC_SUBST([systemdsystemunitdir])
 
+# --disable-login-tests: Tests that use systemd-logind are enabled by default, but we are temporarily
+# disabling them on distcheck to workaround issues on Jenkins.
+AC_ARG_ENABLE([login-tests],
+    [AS_HELP_STRING([--disable-login-tests], [prevent login tests from being run by "make check"])],
+        [],
+        [enable_login_tests=yes])
+AM_CONDITIONAL([ENABLE_LOGIN_TESTS], [test "x$enable_login_tests" = xyes])
+
 # Required libraries
 # ------------------
 PKG_CHECK_MODULES([EOSMETRICS], [

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -90,6 +90,7 @@ EXTRA_DIST += $(javascript_tests)
 dist_bin_SCRIPTS = tests/launch-mock-dbus-tests.sh
 
 # Run tests when running 'make check'
+if ENABLE_LOGIN_TESTS
 TESTS = \
 	tests/test-library.dbus \
 	tests/test-daemon-integration.py \
@@ -101,6 +102,18 @@ TESTS = \
 	tests/daemon/test-permissions-provider \
 	$(javascript_tests) \
 	$(NULL)
+else
+TESTS = \
+	tests/test-library.dbus \
+	tests/test-daemon-integration.py \
+	tests/daemon/test-boot-id-provider \
+	tests/daemon/test-machine-id-provider \
+	tests/daemon/test-persistent-cache \
+	tests/daemon/test-permissions-provider \
+	$(javascript_tests) \
+	$(NULL)
+endif
+
 TEST_EXTENSIONS = .dbus .js .py
 JS_LOG_COMPILER = eos-run-test
 AM_JS_LOG_FLAGS = \


### PR DESCRIPTION
Our Jenkins build is not handling the running of tests correctly. We are
temporarily disabling make check on Jenkins as a consequence. This change adds
support for disabling all non GTK-Doc tests at configure-time using a
--disable-tests flag.

[endlessm/eos-shell#2870]
