### PR TITLE
Disable login tests when making Debian package.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,7 @@
 
 # Build our documentation as well
 override_dh_auto_configure:
-	dh_auto_configure -- --enable-gtk-doc --enable-gir-doc
+	dh_auto_configure -- --enable-strict-flags --enable-gtk-doc --enable-gir-doc --disable-login-tests
 
 override_dh_auto_test:
 	dh_auto_test || ( find . -name '*.log' | xargs cat; false )


### PR DESCRIPTION
We succeeded at disabling the login tests on Jenkins, but not on OBS. This
change disables the login tests on OBS as well. By login tests, we mean those
that use systemd-logind (and don't mock it out using Python's dbusmock).

This change is temporary until we port the systemd-logind tests to use Python's
dbusmock.

[endlessm/eos-shell#2870]
