### PR TITLE
Give metrics group ownership of persistent cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ eos-metrics-0.0.0
 /data/com.endlessm.Metrics.service
 /data/eos-metrics-event-recorder.service
 /data/com.endlessm.Metrics.service
+/data/eos-metrics-persistent-cache.conf
 
 # Test products
 *.log

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -12,23 +12,33 @@ $(daemon_dbus_sources): data/com.endlessm.Metrics.xml
 # Defined as systemdsystemunitdir in ../configure.ac.
 systemdsystemunit_DATA = data/eos-metrics-event-recorder.service
 
-data/eos-metrics-event-recorder.service: data/eos-metrics-event-recorder.service.in
-	$(AM_V_GEN)mkdir -p data && \
-	rm -f $@ $@.tmp && \
-	$(edit) $< >$@.tmp && \
-	mv $@.tmp $@
-
-edit = sed \
+substitute_libexecdir = sed \
 	-e 's|@libexecdir[@]|$(libexecdir)|g' \
 	$(NULL)
+
+data/eos-metrics-event-recorder.service: data/eos-metrics-event-recorder.service.in
+	$(AM_V_GEN)$(MKDIR_P) data && \
+	rm -f $@ $@.tmp && \
+	$(substitute_libexecdir) $< >$@.tmp && \
+	mv $@.tmp $@
 
 dbusservicedir = ${datadir}/dbus-1/system-services
 dbusservice_DATA = data/com.endlessm.Metrics.service
 
 data/com.endlessm.Metrics.service: data/com.endlessm.Metrics.service.in
-	$(AM_V_GEN)mkdir -p data && \
+	$(AM_V_GEN)$(MKDIR_P) data && \
 	rm -f $@ $@.tmp && \
-	$(edit) $< >$@.tmp && \
+	$(substitute_libexecdir) $< >$@.tmp && \
+	mv $@.tmp $@
+
+substitute_persistent_cache_dir = sed \
+	-e 's|@PERSISTENT_CACHE_DIR[@]|$(PERSISTENT_CACHE_DIR)|g' \
+	$(NULL)
+
+data/eos-metrics-persistent-cache.conf: data/eos-metrics-persistent-cache.conf.in
+	$(AM_V_GEN)$(MKDIR_P) data && \
+	rm -f $@ $@.tmp && \
+	$(substitute_persistent_cache_dir) $< >$@.tmp && \
 	mv $@.tmp $@
 
 policydir = ${datadir}/polkit-1/actions
@@ -39,14 +49,19 @@ dist_systembussecuritypolicy_DATA = data/com.endlessm.Metrics.conf
 
 dist_sysconf_DATA = data/eos-metrics-permissions.conf
 
+tmpfilesddir = $(libdir)/tmpfiles.d/
+tmpfilesd_DATA = data/eos-metrics-persistent-cache.conf
+
 EXTRA_DIST += \
 	data/com.endlessm.Metrics.xml \
 	data/com.endlessm.Metrics.service.in \
 	data/eos-metrics-event-recorder.service.in \
+	data/eos-metrics-persistent-cache.conf.in \
 	$(NULL)
 
 CLEANFILES += \
 	$(daemon_dbus_sources) \
 	data/com.endlessm.Metrics.service \
 	data/eos-metrics-event-recorder.service \
+	data/eos-metrics-persistent-cache.conf \
 	$(NULL)

--- a/data/eos-metrics-persistent-cache.conf.in
+++ b/data/eos-metrics-persistent-cache.conf.in
@@ -1,0 +1,3 @@
+d @PERSISTENT_CACHE_DIR@ 2774 metrics metrics -
+Z @PERSISTENT_CACHE_DIR@ 0660 metrics metrics -
+z @PERSISTENT_CACHE_DIR@ 2774 metrics metrics -


### PR DESCRIPTION
Our previous attempt to ensure that the metrics user and group own the
persistent cache failed because OSTree mucks with file permissions in
/var/cache, where the persistent cache is located. This change adds a
tmpfiles.d conf file in hopes that systemd will correctly execute this
file after OSTree has marched through /var/cache leaving a trail of pain and
suffering.

[endlessm/eos-sdk#1506]
