### PR TITLE
Remove bad double quotes.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,8 +50,8 @@ dist-hook:
 endif
 
 
-PERSISTENT_CACHE_DIR="$(localstatedir)/cache/metrics/"
-PERMISSIONS_FILE="$(sysconfdir)/eos-metrics-permissions.conf"
+PERSISTENT_CACHE_DIR=$(localstatedir)/cache/metrics/
+PERMISSIONS_FILE=$(sysconfdir)/eos-metrics-permissions.conf
 
 # chown and chgrp are not allowed unless you are root or under some specific
 # other conditions that may not be met every time you run 'make'.


### PR DESCRIPTION
The double quotes around the persistent cache directory variable cause
systemd-tmpfiles to choke when parsing eos-metrics-persistent-cache.conf.

[endlessm/eos-sdk#1506]
