### PR TITLE
Resolve conflicting tmpfiles.d lines.

### DIFF
--- a/data/eos-metrics-persistent-cache.conf.in
+++ b/data/eos-metrics-persistent-cache.conf.in
@@ -1,3 +1,2 @@
 d @PERSISTENT_CACHE_DIR@ 2774 metrics metrics -
-Z @PERSISTENT_CACHE_DIR@ 0660 metrics metrics -
-z @PERSISTENT_CACHE_DIR@ 2774 metrics metrics -
+Z @PERSISTENT_CACHE_DIR@ 2774 metrics metrics -


### PR DESCRIPTION
systemd-tmpfiles doesn't march through each line in order, overwriting any
previous change as I initially assumed. Instead it requires all lines in a
given .conf file to be consistent. This is an attempt to remove a conflict
from eos-metrics-persistent-cache.conf that systemd-tmpfiles didn't like.

[endlessm/eos-sdk#1506]
