### PR TITLE
Permit metrics user and group to enable metrics.

### DIFF
--- a/data/com.endlessm.Metrics.policy
+++ b/data/com.endlessm.Metrics.policy
@@ -10,6 +10,7 @@
 
   <action id="com.endlessm.Metrics.SetEnabled">
     <description>Enable or disable the metrics system</description>
+    <annotate key="org.freedesktop.policykit.owner" value="unix-user:metrics unix-group:metrics">
     <defaults>
       <allow_any>no</allow_any>
       <allow_inactive>no</allow_inactive>


### PR DESCRIPTION
Currently metrics remain disabled even when the user requests that they
be enabled in the FBE. This may, at least in part, be because the
metrics user and group are not listed in the policy kit file. This
change lists the metrics user and group in the policy kit file in hopes
that this will allow the metrics system to be enabled.

[endlessm/eos-sdk#1573]
