### PR TITLE
Rename systemd-tempfiles conf file.

### DIFF
--- a/debian/eos-metrics-event-recorder.install
+++ b/debian/eos-metrics-event-recorder.install
@@ -2,6 +2,6 @@ etc/dbus-1/system.d/com.endlessm.Metrics.conf
 etc/eos-metrics-permissions.conf
 lib/systemd/system/eos-metrics-event-recorder.service
 usr/lib/eos-metrics/eos-metrics-event-recorder
-usr/lib/tmpfiles.d/eos-metrics-persistent-cache.conf
+usr/lib/tmpfiles.d/eos-metrics.conf
 usr/share/dbus-1/system-services/com.endlessm.Metrics.service
 usr/share/polkit-1/actions/com.endlessm.Metrics.policy


### PR DESCRIPTION
The file was renamed because it now affects not merely the persistent
cache, but also the permissions file.

[endlessm/eos-sdk#1573]
