### PR TITLE
chown /etc/eos-metrics-permissions.conf.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,7 @@ PERMISSIONS_FILE=$(sysconfdir)/eos-metrics-permissions.conf
 install-data-hook:
 	$(MKDIR_P) --mode=ug+rwX,g+s $(DESTDIR)$(PERSISTENT_CACHE_DIR)
 	@if id -u metrics 2> /dev/null; then \
-		if ! chgrp metrics $(DESTDIR)$(PERMISSIONS_FILE); then \
+		if ! chown metrics:metrics $(DESTDIR)$(PERMISSIONS_FILE); then \
 			echo "*************************************"; \
 			echo "Make sure to change the group of the"; \
 			echo "$(PERMISSIONS_FILE) file to 'metrics'."; \

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -31,14 +31,15 @@ data/com.endlessm.Metrics.service: data/com.endlessm.Metrics.service.in
 	$(substitute_libexecdir) $< >$@.tmp && \
 	mv $@.tmp $@
 
-substitute_persistent_cache_dir = sed \
+substitute_metrics_files = sed \
 	-e 's|@PERSISTENT_CACHE_DIR[@]|$(PERSISTENT_CACHE_DIR)|g' \
+	-e 's|@PERMISSIONS_FILE[@]|$(PERMISSIONS_FILE)|g' \
 	$(NULL)
 
-data/eos-metrics-persistent-cache.conf: data/eos-metrics-persistent-cache.conf.in
+data/eos-metrics.conf: data/eos-metrics.conf.in
 	$(AM_V_GEN)$(MKDIR_P) data && \
 	rm -f $@ $@.tmp && \
-	$(substitute_persistent_cache_dir) $< >$@.tmp && \
+	$(substitute_metrics_files) $< >$@.tmp && \
 	mv $@.tmp $@
 
 policydir = ${datadir}/polkit-1/actions
@@ -50,18 +51,18 @@ dist_systembussecuritypolicy_DATA = data/com.endlessm.Metrics.conf
 dist_sysconf_DATA = data/eos-metrics-permissions.conf
 
 tmpfilesddir = $(libdir)/tmpfiles.d/
-tmpfilesd_DATA = data/eos-metrics-persistent-cache.conf
+tmpfilesd_DATA = data/eos-metrics.conf
 
 EXTRA_DIST += \
 	data/com.endlessm.Metrics.xml \
 	data/com.endlessm.Metrics.service.in \
 	data/eos-metrics-event-recorder.service.in \
-	data/eos-metrics-persistent-cache.conf.in \
+	data/eos-metrics.conf.in \
 	$(NULL)
 
 CLEANFILES += \
 	$(daemon_dbus_sources) \
 	data/com.endlessm.Metrics.service \
 	data/eos-metrics-event-recorder.service \
-	data/eos-metrics-persistent-cache.conf \
+	data/eos-metrics.conf \
 	$(NULL)

--- a/data/eos-metrics.conf.in
+++ b/data/eos-metrics.conf.in
@@ -1,2 +1,3 @@
 d @PERSISTENT_CACHE_DIR@ 2774 metrics metrics -
 Z @PERSISTENT_CACHE_DIR@ 2774 metrics metrics -
+Z @PERMISSIONS_FILE@ 0664 metrics metrics -


### PR DESCRIPTION
/etc is not world-writable by default. We need to make sure that the
metrics user and group retain control of it. Adding the chown to the
make install hook wasn't enough because OSTree clobbers it after
installation.

[endlessm/eos-sdk#1573]
