### PR TITLE
Include eos-set-metrics-env in event recorder package

### DIFF
--- a/debian/eos-metrics-event-recorder.install
+++ b/debian/eos-metrics-event-recorder.install
@@ -5,3 +5,4 @@ usr/lib/eos-metrics/eos-metrics-event-recorder
 usr/lib/tmpfiles.d/eos-metrics.conf
 usr/share/dbus-1/system-services/com.endlessm.Metrics.service
 usr/share/polkit-1/actions/com.endlessm.Metrics.policy
+usr/bin/eos-set-metrics-env


### PR DESCRIPTION
[endlessm/eos-sdk#1576]
