### PR TITLE
Set environment for dconf

### DIFF
--- a/data/eos-metrics-event-recorder.service.in
+++ b/data/eos-metrics-event-recorder.service.in
@@ -5,6 +5,7 @@ Wants=systemd-logind.service
 After=dbus.service systemd-logind.service
 
 [Service]
+Environment=DCONF_PROFILE=/dev/null
 User=metrics
 Type=dbus
 BusName=com.endlessm.Metrics


### PR DESCRIPTION
According to https://bugzilla.gnome.org/show_bug.cgi?id=732654,
dconf does not properly deal with system users who have no home
directory. The workaround is to set the daemon environment to
DCONF_PROFILE=/dev/null.

[endlessm/eos-sdk#1586]
