### PR TITLE
Dev machines send metrics every 15 mins

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -45,7 +45,7 @@ prevent testing code from sending metrics to the production server. */
  *
  * For QA, the "dev" environment delay is much shorter.
  */
-#define DEV_NETWORK_SEND_INTERVAL (60u * 10u) // Ten minutes
+#define DEV_NETWORK_SEND_INTERVAL (60u * 15u) // Fifteen minutes
 #define DEFAULT_NETWORK_SEND_INTERVAL (60u * 60u) // One hour
 
 /*


### PR DESCRIPTION
This is up from 10 mins which was too short to ensure the retries
wouldn't bleed through into the next upload.
[endlessm/eos-sdk#1589]
