### PR TITLE
Dont write to disk on store() always.

### DIFF
--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -1254,7 +1254,7 @@ emer_persistent_cache_store_metrics (EmerPersistentCache  *self,
   *num_sequences_stored = 0;
 
   G_LOCK (update_boot_offset);
-  if (!update_boot_offset (self, TRUE)) // Always update timestamps.
+  if (!update_boot_offset (self, FALSE)) // Typically don't update timestamps.
     {
       g_critical ("Couldn't update the boot offset, dropping metrics.");
       G_UNLOCK (update_boot_offset);


### PR DESCRIPTION
Previously, we were writing to our metafile more often than we needed
to. We were writing periodically to update our timestamps, and we were
writing every time store() was called.  This was not necessary and was
a performance/durability liability.

Instead, we only write to disk via metafile on store() when some form
of corruption is detected.  This required rewiring several unit tests
to use the public API getter of the boot offset instead of relying
on an implementation detail of store() that used to exist.
[endlessm/eos-sdk#1564]
