### PR TITLE
Fixed testing segault from singleton.

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -952,7 +952,7 @@ set_machine_id_provider (EmerDaemon            *self,
   EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
 
   if (machine_id_prov == NULL)
-    machine_id_prov = emer_machine_id_provider_get_default ();
+    machine_id_prov = emer_machine_id_provider_new ();
 
   priv->machine_id_provider = g_object_ref (machine_id_prov);
 }
@@ -1243,7 +1243,7 @@ emer_daemon_class_init (EmerDaemonClass *klass)
    *
    * An #EmerMachineIdProvider for retrieving the UUID of this machine.
    * If this property is not specified, the default machine ID provider (from
-   * emer_machine_id_provider_get_default()) will be used.
+   * emer_machine_id_provider_new()) will be used.
    * You should only set this property to something else for testing purposes.
    */
   emer_daemon_props[PROP_MACHINE_ID_PROVIDER] =

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -152,46 +152,39 @@ emer_machine_id_provider_init (EmerMachineIdProvider *self)
 }
 
 /*
- * emer_machine_id_provider_new:
+ * emer_machine_id_provider_new_full:
  * @machine_id_file_path: path to a file; see #EmerMachineIdProvider:path
  *
  * Testing function for creating a new #EmerMachineIdProvider in the C API.
  * You only need to use this if you are creating a mock ID provider for unit
  * testing.
  *
- * For all normal uses, you should use emer_machine_id_provider_get_default()
+ * For all normal uses, you should use emer_machine_id_provider_new()
  * instead.
  *
  * Returns: (transfer full): A new #EmerMachineIdProvider.
  * Free with g_object_unref() when done if using C.
  */
 EmerMachineIdProvider *
-emer_machine_id_provider_new (const gchar *machine_id_file_path)
-{ 
-  return g_object_new (EMER_TYPE_MACHINE_ID_PROVIDER, 
+emer_machine_id_provider_new_full (const gchar *machine_id_file_path)
+{
+  return g_object_new (EMER_TYPE_MACHINE_ID_PROVIDER,
                        "path", machine_id_file_path,
                        NULL);
 }
 
 /*
- * emer_machine_id_provider_get_default:
+ * emer_machine_id_provider_new:
  *
- * Gets the ID provider that you should use for obtaining a unique machine ID.
+ * Gets the ID provider that you should use for obtaining a unique machine ID in
+ * production code. Uses a default filepath.
  *
- * Returns: (transfer none): the default #EmerMachineIdProvider.
- * This object is owned by the metrics library; do not free it.
+ * Returns: (transfer full): a production #EmerMachineIdProvider.
  */
 EmerMachineIdProvider *
-emer_machine_id_provider_get_default (void)
+emer_machine_id_provider_new (void)
 {
-  static EmerMachineIdProvider *singleton;
-  G_LOCK_DEFINE_STATIC (singleton);
-
-  G_LOCK (singleton);
-  if (singleton == NULL)
-    singleton = g_object_new (EMER_TYPE_MACHINE_ID_PROVIDER, NULL);
-  G_UNLOCK (singleton);
-  return singleton;
+  return g_object_new (EMER_TYPE_MACHINE_ID_PROVIDER, NULL);
 }
 
 /*

--- a/daemon/emer-machine-id-provider.h
+++ b/daemon/emer-machine-id-provider.h
@@ -58,14 +58,14 @@ struct _EmerMachineIdProviderClass
   GObjectClass parent_class;
 };
 
-GType                  emer_machine_id_provider_get_type    (void) G_GNUC_CONST;
+GType                  emer_machine_id_provider_get_type (void) G_GNUC_CONST;
 
-EmerMachineIdProvider *emer_machine_id_provider_new         (const gchar           *machine_id_file_path);
+EmerMachineIdProvider *emer_machine_id_provider_new      (void);
 
-EmerMachineIdProvider *emer_machine_id_provider_get_default (void);
+EmerMachineIdProvider *emer_machine_id_provider_new_full (const gchar           *machine_id_file_path);
 
-gboolean               emer_machine_id_provider_get_id      (EmerMachineIdProvider *self,
-                                                             guchar                 uuid[16]);
+gboolean               emer_machine_id_provider_get_id   (EmerMachineIdProvider *self,
+                                                          guchar                 uuid[16]);
 
 G_END_DECLS
 

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -73,7 +73,7 @@ setup (Fixture      *fixture,
        gconstpointer unused)
 {
   EmerMachineIdProvider *id_prov =
-    emer_machine_id_provider_new (MACHINE_ID_PATH);
+    emer_machine_id_provider_new_full (MACHINE_ID_PATH);
   fixture->mock_permissions_prov = emer_permissions_provider_new ();
   fixture->mock_persistent_cache = emer_persistent_cache_new (NULL, NULL);
   fixture->test_object =

--- a/tests/daemon/test-machine-id-provider.c
+++ b/tests/daemon/test-machine-id-provider.c
@@ -34,8 +34,8 @@ write_testing_machine_id ()
                                               NULL,
                                               FALSE,
                                               G_FILE_CREATE_REPLACE_DESTINATION | G_FILE_CREATE_PRIVATE,
-                                              NULL, 
-                                              NULL, 
+                                              NULL,
+                                              NULL,
                                               NULL);
   if (!success)
     g_critical ("Testing code failed to write testing machine id.");
@@ -58,19 +58,9 @@ test_machine_id_provider_new_succeeds (void)
 {
   write_testing_machine_id ();
   EmerMachineIdProvider *id_provider =
-    emer_machine_id_provider_new (TESTING_FILE_PATH);
+    emer_machine_id_provider_new ();
   g_assert (id_provider != NULL);
   g_object_unref (id_provider);
-}
-
-static void
-test_machine_id_provider_get_default_is_singleton (void)
-{
-  write_testing_machine_id ();
-  EmerMachineIdProvider *m1 = emer_machine_id_provider_get_default ();
-  EmerMachineIdProvider *m2 = emer_machine_id_provider_get_default ();
-  g_assert (m1 == m2);
-  // A singleton shouldn't be unref'd.
 }
 
 static void
@@ -78,7 +68,7 @@ test_machine_id_provider_can_get_id (void)
 {
   write_testing_machine_id ();
   EmerMachineIdProvider *id_provider =
-    emer_machine_id_provider_new (TESTING_FILE_PATH);
+    emer_machine_id_provider_new_full (TESTING_FILE_PATH);
   uuid_t id;
   g_assert (emer_machine_id_provider_get_id (id_provider, id));
   gchar unparsed_id[HYPHENS_IN_ID + FILE_LENGTH];
@@ -97,8 +87,6 @@ main (int                argc,
 
   g_test_add_func ("/machine-id-provider/new-succeeds",
                    test_machine_id_provider_new_succeeds);
-  g_test_add_func ("/machine-id-provider/get-default-is-singleton",
-                   test_machine_id_provider_get_default_is_singleton);
   g_test_add_func ("/machine-id-provider/can-get-id",
                    test_machine_id_provider_can_get_id);
 


### PR DESCRIPTION
Within the boot id provider, the singleton pattern was being used
unnecessarily which was harmless but for the unref() call in the
testing code. This would cause segfaults when the tests were run
on a machine actually using the daemon at the time.

This pattern causes complexity, and has been replaced by a normal
new() function for production and a new_full() for testing. There
is no get_default() anymore. I changed the name because by convention
the get_default() functions return singletons.
[endlessm/eos-sdk#1596]
