### PR TITLE
Correct byte swap check

### DIFF
--- a/src/metric_request_parser.c
+++ b/src/metric_request_parser.c
@@ -156,14 +156,14 @@ deserialize_metrics (gconstpointer serialized_metrics,
                              serialized_metrics, length, FALSE, NULL, NULL);
 
   GVariant *native_endian_metrics_variant = metrics_variant;
-  if (G_BYTE_ORDER == G_LITTLE_ENDIAN)
+  if (G_BYTE_ORDER == G_BIG_ENDIAN)
     {
       native_endian_metrics_variant = g_variant_byteswap (metrics_variant);
       g_variant_unref (metrics_variant);
     }
   else
     {
-      g_assert (G_BYTE_ORDER == G_BIG_ENDIAN);
+      g_assert (G_BYTE_ORDER == G_LITTLE_ENDIAN);
     }
   return native_endian_metrics_variant;
 }


### PR DESCRIPTION
Change the byte swap check for the incoming metrics
GVariant. The check for big endian and little endian
was switched and is now corrected.

[endlessm/eos-sdk#1603]
