### PR TITLE
Correct typos.

### DIFF
--- a/tools/eos-select-metrics-env.in
+++ b/tools/eos-select-metrics-env.in
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 if [ ! -f @permissions_file@ ]; then
-    echo "Configuration file at @permissions_file@ not found." >&2
+    echo "Configuration file at @permissions_file@ not found or permission denied." >&2
     exit 1
 fi
 
@@ -9,6 +9,6 @@ ENVIRONMENT=$1
 if [ "$ENVIRONMENT" == "dev" ] || [ "$ENVIRONMENT" == "test" ] || [ "$ENVIRONMENT" == "production" ]; then
     sed -i "s/\(environment *= *\).*/\1$ENVIRONMENT/" @permissions_file@
 else
-    echo "Invalid enviroment $ENVIRONMENT passed in as parameter." >$2
+    echo "Invalid environment $ENVIRONMENT passed in as parameter." >&2
     exit 2
 fi


### PR DESCRIPTION
The output is a bit misleading in one of the error cases because the
error can be hit if the file isn't found or if permission is denied,
but the error only mentions the first case. Also, there is a $2
(second input) where there should be a &2 (stderr file), which causes
a crash when the script is passed an unexepected environment string.

[endlessm/eos-sdk#1576]
