### PR TITLE
Add permissions check for request

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -737,6 +737,12 @@ upload_events (GNetworkMonitor *source_object,
 {
   EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
 
+  if (!priv->recording_enabled)
+    {
+      g_object_unref (self);
+      return;
+    }
+
   GError *error = NULL;
   if (!g_network_monitor_can_reach_finish (priv->network_monitor, res, &error))
     {


### PR DESCRIPTION
Added a check for permissions before sending a
network request. If metrics are disabled, we
should not send a network request.

[endlessm/eos-sdk#1325]
