### PR TITLE
Remove refs and unrefs of self.

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -851,9 +851,9 @@ handle_login_manager_signal (GDBusProxy *dbus_proxy,
 {
   if (strcmp ("PrepareForShutdown", signal_name) == 0)
     {
-      gboolean before_shutdown;
-      g_variant_get_child (parameters, 0, "b", &before_shutdown);
-      if (before_shutdown)
+      gboolean shutting_down;
+      g_variant_get_child (parameters, 0, "b", &shutting_down);
+      if (shutting_down)
         {
           flush_to_persistent_cache (self);
           release_shutdown_inhibitor (self);


### PR DESCRIPTION
The refs and unrefs of self were originally introduced to avoid a race
condition between the finalize method and upload_events. This was
overzealous because the finalize method and upload_events are expected
to run in the same thread.

At present the only other place the daemon is ref'd or unref'd is in
daemon/emer-main.c. In practice, the only effect of the refs/unrefs
removed in this change is to introduce the possibility that the event
recorder daemon isn't released when daemon/emer-main.c receives
SIGTERM. This is undesirable because the finalize method of the daemon
flushes its RAM buffer to the persistent cache. Thus, if the daemon is
holding a reference to itself when daemon/emer-main.c receives SIGTERM,
we will lose any events that are currently in the RAM buffer.

We also flush the RAM buffer to the persistent cache when the
PrepareForShutdown signal is sent because this is the last point in
time at which we can comfortably perform disk I/O before the daemon
gets killed. Unfortunately, logout, a high-value event, happens after
the PrepareForShutdown is sent, so we rely on the flush performed by
the finalize method to record it. Without the removal of the
refs and unrefs of self, we will fail to record logout events in cases
where the system is shut down safely without an explicit logout by the
user while we are trying to upload events.

[endlessm/eos-shell#2216]
