### PR TITLE
CACHE_DIRECTORY now a property.

### DIFF
--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -132,7 +132,7 @@ gboolean             emer_persistent_cache_store_metrics       (EmerPersistentCa
  */
 EmerPersistentCache *emer_persistent_cache_new_full            (GCancellable             *cancellable,
                                                                 GError                  **error,
-                                                                gchar                    *custom_directory,
+                                                                const gchar              *custom_directory,
                                                                 guint64                   custom_cache_size,
                                                                 EmerBootIdProvider       *boot_id_provider,
                                                                 EmerCacheVersionProvider *version_provider,

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -33,7 +33,7 @@ emer_persistent_cache_new (GCancellable *cancellable,
 EmerPersistentCache *
 emer_persistent_cache_new_full (GCancellable             *cancellable,
                                 GError                  **error,
-                                gchar                    *custom_directory,
+                                const gchar              *custom_directory,
                                 guint64                   custom_cache_size,
                                 EmerBootIdProvider       *boot_id_provider,
                                 EmerCacheVersionProvider *version_provider,


### PR DESCRIPTION
The CACHE_DIRECTORY was a gchar \* that was hoped would not
be modified but there was no enforcing of that hope. Now it is a
GObject property with the default set to the previous default. The
code is much cleaner as a consequence.
[endlessm/eos-sdk#1163]
