### PR TITLE
Two tests clean up tmp files.

### DIFF
--- a/tests/daemon/test-boot-id-provider.c
+++ b/tests/daemon/test-boot-id-provider.c
@@ -59,6 +59,10 @@ static void
 teardown (struct Fixture *fixture,
           gconstpointer   unused)
 {
+  gchar *path = g_file_get_path (fixture->tmp_file);
+  g_unlink (path);
+  g_free (path);
+
   g_object_unref (fixture->tmp_file);
   g_object_unref (fixture->id_provider);
 }


### PR DESCRIPTION
The boot id provider and machine id provider were leaving testing
files in the /tmp/ folder after finishing. The machine id provider
doesn't use a testing harness so the fix is a little uglier but
should be cleaned up in a later issue.
[endlessm/eos-sdk#1514]
