### PR TITLE
Don't persist metrics on shutdown if disabled.

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -702,6 +702,9 @@ flush_to_persistent_cache (EmerDaemon *self)
 {
   EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
 
+  if (!priv->recording_enabled)
+    return;
+
   g_mutex_lock (&priv->singular_buffer_lock);
   g_mutex_lock (&priv->aggregate_buffer_lock);
   g_mutex_lock (&priv->sequence_buffer_lock);


### PR DESCRIPTION
When the user has disabled the metrics system we shouldn't persist
metrics on their device. Currently we persist metrics on shutdown
even if the metrics system is disabled. This change stops
persisting metrics on shutdown if the metrics system is disabled.

[endlessm/eos-sdk#1778]
