### PR TITLE
Sealed memleak in permissions provider.

### DIFF
--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -302,6 +302,7 @@ emer_permissions_provider_get_daemon_enabled (EmerPermissionsProvider *self)
                   "Returning default value. Message: %s.",
                   DAEMON_ENABLED_GROUP_NAME, DAEMON_ENABLED_KEY_NAME,
                   error->message);
+      g_error_free (error);
       /* retval is FALSE in case of error */
     }
 


### PR DESCRIPTION
The permissions provider had an error path that would not free its
associated error when it was reached. The magnitude of this memory
leak was probably pretty small.
[endlessm/eos-sdk#1660]
