### PR TITLE
Wait for mock DBus to come up

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -152,4 +152,5 @@ EXTRA_DIST += \
 	tests/test-opt-out-integration.py \
 	tests/smoke-tests/smoke.js \
 	tests/smoke-tests/event-types.js \
+	tests/wait-for-service-helper.py \
 	$(NULL)

--- a/tests/launch-mock-dbus-tests.sh
+++ b/tests/launch-mock-dbus-tests.sh
@@ -20,8 +20,8 @@ python -m dbusmock --system \
     /com/endlessm/Metrics \
     com.endlessm.Metrics.EventRecorderServer &
 
-# FIXME need a better way to wait for the service to come up
-sleep 1s
+# Wait for the service to come up
+python `dirname $0`/wait-for-service-helper.py
 
 gdbus call --system \
     -d com.endlessm.Metrics \

--- a/tests/test-opt-out-integration.py
+++ b/tests/test-opt-out-integration.py
@@ -1,6 +1,5 @@
 import dbus
 import subprocess
-import time
 import unittest
 
 import dbusmock
@@ -26,8 +25,9 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
         """Start the event recorder on the mock system bus."""
         self.daemon = subprocess.Popen('./eos-metrics-event-recorder')
 
-        # FIXME find a better way to wait for the service to come up
-        time.sleep(1)
+        # Wait for the service to come up
+        self.wait_for_bus_object('com.endlessm.Metrics',
+            '/com/endlessm/Metrics', system_bus=True)
 
         # Spawn an external process for polkit authorization
         (self.polkit_popen, self.polkit_obj) = self.spawn_server_template('polkitd',

--- a/tests/wait-for-service-helper.py
+++ b/tests/wait-for-service-helper.py
@@ -1,0 +1,25 @@
+import sys
+from gi.repository import GLib, Gio
+
+
+DBUS_NAME = 'com.endlessm.Metrics'
+
+
+def on_name_appeared(connection, name, owner):
+    print DBUS_NAME, 'appeared'
+    Gio.bus_unwatch_name(watcher_id)
+    loop.quit()
+
+
+def on_timeout():
+    print 'Timed out'
+    Gio.bus_unwatch_name(watcher_id)
+    sys.exit(1)
+
+print 'Watching for name', DBUS_NAME
+watcher_id = Gio.bus_watch_name(Gio.BusType.SYSTEM, DBUS_NAME,
+    Gio.BusNameWatcherFlags.NONE, on_name_appeared, None)
+GLib.timeout_add_seconds(5, on_timeout)
+
+loop = GLib.MainLoop()
+loop.run()


### PR DESCRIPTION
This introduces a small helper script that waits for the mock metrics
object to appear on the mock DBus. Previously we relied on "sleep 1s"
to be long enough for the service to come up, which could easily break
if the system load was high. This solution with the helper script also
avoids a sleep loop, preferring the GLib main loop instead.

(Philip & Devin)

[endlessm/eos-sdk#1168]
