### PR TITLE
Deprecation of login event.

### DIFF
--- a/docs/reference/eosmetrics/Makefile.am
+++ b/docs/reference/eosmetrics/Makefile.am
@@ -20,7 +20,7 @@ SCANGOBJ_OPTIONS=
 
 # Extra options to supply to gtkdoc-scan.
 # e.g. SCAN_OPTIONS=--deprecated-guards="GTK_DISABLE_DEPRECATED"
-SCAN_OPTIONS=--rebuild-types
+SCAN_OPTIONS=--rebuild-types --deprecated-guards="EMTR_DISABLE_DEPRECATED"
 
 # Extra options to supply to gtkdoc-mkdb.
 # e.g. MKDB_OPTIONS=--xml-mode --output-format=xml

--- a/eosmetrics/emtr-event-types.h
+++ b/eosmetrics/emtr-event-types.h
@@ -33,12 +33,17 @@ EMTR_ALL_API_VERSIONS
 gboolean emtr_event_id_to_name (const gchar  *event_id,
                                 const gchar **event_name);
 
+#ifndef EMTR_DISABLE_DEPRECATED
 /**
  * EMTR_EVENT_USER_IS_LOGGED_IN:
  *
  * Started when a user logs in and stopped when that user logs out.
+ *
+ * Deprecated: 0.2: A newer version of this metric is defined in
+ * eos-metrics-instrumentation.c in the eos-metrics-instrumentation repo.
  */
 #define EMTR_EVENT_USER_IS_LOGGED_IN "ab839fd2-a927-456c-8c18-f1136722666b"
+#endif
 
 /**
  * EMTR_EVENT_NETWORK_STATUS_CHANGED:


### PR DESCRIPTION
Updated documentation in this repo to indicate that the older
version of this metric, located here, is deprecated.
[endlessm/eos-sdk#1686]
