### PR TITLE
Use g_once_init_enter() for singleton

### DIFF
--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -365,13 +365,13 @@ emtr_event_recorder_new (void)
 EmtrEventRecorder *
 emtr_event_recorder_get_default (void)
 {
-  static EmtrEventRecorder *singleton;
-  G_LOCK_DEFINE_STATIC (singleton);
+  static EmtrEventRecorder *singleton = NULL;
 
-  G_LOCK (singleton);
-  if (singleton == NULL)
-    singleton = g_object_new (EMTR_TYPE_EVENT_RECORDER, NULL);
-  G_UNLOCK (singleton);
+  if (g_once_init_enter (&singleton))
+    {
+      EmtrEventRecorder *retval = g_object_new (EMTR_TYPE_EVENT_RECORDER, NULL);
+      g_once_init_leave (&singleton, retval);
+    }
 
   return singleton;
 }


### PR DESCRIPTION
Instead of manually defining a lock, use the built-in functionality of
g_once_init_enter() to ensure that returning a singleton event recorder
is thread-safe and only executed once.

[endlessm/eos-sdk#1145]
