### PR TITLE
Fix memory leak in *_drain_metrics.

### DIFF
--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -896,6 +896,10 @@ emer_persistent_cache_drain_metrics (EmerPersistentCache  *self,
     {
       // The error has served its purpose in the previous call.
       g_error_free (error);
+
+      free_variant_list (*list_of_individual_metrics);
+      free_variant_list (*list_of_aggregate_metrics);
+      free_variant_list (*list_of_sequence_metrics);
       return FALSE;
     }
 


### PR DESCRIPTION
When we drain metrics we fail to free the newly created variant lists
if we fail to purge the cache files. This change patches that memory
leak.

[endlessm/eos-sdk#1627]
