### PR TITLE
Fix memory leak of fds.

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -838,10 +838,12 @@ inhibit_shutdown (EmerDaemon *self)
       g_warning ("Error inhibiting shutdown. Login manager returned %d file "
                  "descriptors, but we expected 1 file descriptor.",
                  fd_list_length);
-      return;
+      goto finally;
     }
 
   priv->shutdown_inhibitor = fds[0];
+
+finally:
   g_free (fds);
 }
 


### PR DESCRIPTION
We leak fds in inhibit_shutdown when fd_list_length is not the expected
value, 1. This change patches said leak.

[endlessm/eos-sdk#1639]
