### PR TITLE
Bump client version number.

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -26,7 +26,7 @@
 /*
  * The version of this client's network protocol.
  */
-#define CLIENT_VERSION_NUMBER "0"
+#define CLIENT_VERSION_NUMBER "1"
 
 /* The URI of the metrics production proxy server. Is kept in a #define to
 prevent testing code from sending metrics to the production server. It ends


### PR DESCRIPTION
We believe we have fixed an issue with machine IDs that previously
caused all machine IDs for a given release to be identical. Now that
machines have unique IDs, we are incrementing the client version number
to help us distinguish bogus from legitimate data.

[endlessm/eos-sdk#1876]
