### PR TITLE
Expand permissions to world-executable.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,8 +55,8 @@ permissions_file=$(permissionsdir)eos-metrics-permissions.conf
 # chown and chgrp are not allowed unless you are root or under some specific
 # other conditions that may not be met every time you run 'make'.
 install-data-hook:
-	$(MKDIR_P) --mode=g+s,ug+rwx,a+r $(DESTDIR)$(persistentcachedir) $(DESTDIR)$(permissionsdir)
-	chmod --recursive g+s,ug+rwx,a+r $(DESTDIR)$(persistentcachedir) $(DESTDIR)$(permissionsdir)
+	$(MKDIR_P) --mode=g+s,ug+rwx,a+rx $(DESTDIR)$(persistentcachedir) $(DESTDIR)$(permissionsdir)
+	chmod --recursive g+s,ug+rwx,a+rx $(DESTDIR)$(persistentcachedir) $(DESTDIR)$(permissionsdir)
 	@if id -u metrics 2> /dev/null; then \
 		if ! chown --recursive metrics:metrics $(DESTDIR)$(persistentcachedir) $(DESTDIR)$(permissionsdir); then \
 			echo "*************************************"; \

--- a/data/eos-metrics.conf.in
+++ b/data/eos-metrics.conf.in
@@ -1,4 +1,4 @@
-d @persistentcachedir@ 2774 metrics metrics -
-Z @persistentcachedir@ 2774 metrics metrics -
-d @permissionsdir@ 2774 metrics metrics -
-Z @permissionsdir@ 2774 metrics metrics -
+d @persistentcachedir@ 2776 metrics metrics -
+Z @persistentcachedir@ 2776 metrics metrics -
+d @permissionsdir@ 2776 metrics metrics -
+Z @permissionsdir@ 2776 metrics metrics -


### PR DESCRIPTION
There is no point in making files within /etc/metrics/ and
/var/cache/metrics/ world-readable when the directories themselves
aren't world-executable. This change makes /etc/metrics/ and
/var/cache/metrics/ world-executable so that their contents can be
listed (and thus read).

[endlessm/eos-sdk#1959]
