### PR TITLE
Make directories world-executable.

### DIFF
--- a/data/eos-metrics.conf.in
+++ b/data/eos-metrics.conf.in
@@ -1,4 +1,4 @@
-d @persistentcachedir@ 2776 metrics metrics -
-Z @persistentcachedir@ 2776 metrics metrics -
-d @permissionsdir@ 2776 metrics metrics -
-Z @permissionsdir@ 2776 metrics metrics -
+d @persistentcachedir@ 2775 metrics metrics -
+Z @persistentcachedir@ 2775 metrics metrics -
+d @permissionsdir@ 2775 metrics metrics -
+Z @permissionsdir@ 2775 metrics metrics -


### PR DESCRIPTION
2776 is world-writable, which is not desirable for /etc/metrics/ or
/var/cache/metrics/ because only the metrics system should be editing
files in those directories. They should instead be 2775, which is
world-executable. This is desirable because directories must be
executable in order for their contents to be listed.

[endlessm/eos-sdk#1959]
