### PR TITLE
Update EXTRA_DIST with new smoke tests.

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -170,7 +170,11 @@ TESTS_ENVIRONMENT = \
 EXTRA_DIST += \
 	tests/test-daemon-integration.py \
 	tests/test-opt-out-integration.py \
-	tests/smoke-tests/smoke.js \
 	tests/smoke-tests/event-types.js \
+	tests/smoke-tests/smokeEventRecorderHeavyPayload.js \
+	tests/smoke-tests/smokeEventRecorder.js \
+	tests/smoke-tests/smokeLibrary.js \
+	tests/smoke-tests/smokeOpenProgram.js \
+	tests/smoke-tests/smokeProgram.js \
 	tests/wait-for-service-helper.py \
 	$(NULL)


### PR DESCRIPTION
We recently added several new smoke tests and deleted an old one. We
forgot to update tests/Makefile.am.inc to refer to the new files
though. This change updates EXTRA_DIST to use the latest smoke tests
instead of the old ones.

[endlessm/eos-sdk#1513]
