### PR TITLE
Remove eos-send-metrics from .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ eos-metrics-0.0.0
 /EosMetrics-0.gir
 /EosMetrics-0.typelib
 /docs/reference/eosmetrics/version.xml
-/tools/eos-send-metrics
 /emer-event-recorder-server.[ch]
 /eos-metrics-event-recorder
 /data/eos-metrics.conf


### PR DESCRIPTION
We are about to split the eos-metrics repository in two, but before we
do that let's remove unused code.

The eos-send-metrics tool no longer exists, so we no longer need to
.gitignore the binary associated with it.

[endlessm/eos-sdk#2043]
