### PR TITLE
Remove event recorder API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-eos-metrics
+eos-event-recorder-daemon
 ===========
 
-This repository hosts the code for the metrics API
+This repository hosts the code for the event recorder daemon, a DBus server.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-eos-metrics (0.0.0) unstable; urgency=low
+eos-event-recorder-daemon (0.0.0) unstable; urgency=low
 
   * Initial release
 
- -- Philip Chimento <philip@endlessm.com>  Sat, 11 Jan 2014 20:03:11 -0500
+ -- Kurt von Laven <kurt@endlessm.com>  Thu, 25 Sep 2014 09:18:00 -0700

--- a/debian/control
+++ b/debian/control
@@ -1,69 +1,29 @@
-Source: eos-metrics
+Source: eos-event-recorder-daemon
 Priority: standard
-Maintainer: Philip Chimento <philip@endlessm.com>
+Maintainer: Kurt von Laven <kurt@endlessm.com>
 Build-Depends: autotools-dev,
                debhelper (>= 8.0.0),
                dh-systemd,
-               gobject-introspection,
-               gtk-doc-tools (>= 1.18),
-               libgirepository1.0-dev,
+               eos-metrics-0-dev,
                libglib2.0-dev (>= 2.38),
                libpolkit-gobject-1-dev,
                libsoup2.4-dev (>= 2.42),
                pkg-config,
                python-dbusmock,
                systemd,
-               uuid-dev,
-               yelp-tools,
-               yelp-xsl
+               uuid-dev
 Standards-Version: 3.9.4
 Section: non-free/libs
 Homepage: http://www.endlessm.com
 
-Package: eos-metrics-event-recorder
+Package: eos-event-recorder-daemon
 Section: non-free/net
 Architecture: any
-Depends: ${misc:Depends}
-Description: EndlessOS Metrics Kit
- Daemon for aggregating and recording metrics data in EndlessOS.
-
-Package: eos-metrics-0-dev
-Section: non-free/libdevel
-Architecture: any
+Breaks: eos-metrics-event-recorder
+Replaces: eos-metrics-event-recorder
+Provides: eos-metrics-event-recorder
 Depends: libeosmetrics-0-0 (= ${binary:Version}),
-         libsoup2.4-dev (>= 2.42),
-         uuid-dev,
-         ${misc:Depends}
-Description: Files needed for developing using the EndlessOS Metrics Kit
- Install this package if you are compiling C programs that use the EndlessOS
- Metrics Kit.
-
-Package: libeosmetrics-0-0
-Section: non-free/libs
-Architecture: any
-Depends: eos-metrics-event-recorder,
          ${shlibs:Depends},
          ${misc:Depends}
-Description: EndlessOS Metrics Kit
- Library for recording and sending metrics data in EndlessOS.
-
-Package: eos-metrics-0-doc
-Section: non-free/doc
-Architecture: all
-Depends: ${misc:Depends}
-Suggests: devhelp
-Description: EndlessOS Metrics Kit API documentation
- API documentation for the EndlessOS Metrics Kit. Install this if you want to
- access the API documentation locally, either in your browser or in the Devhelp
- program.
-
-Package: gir1.2-eosmetrics-0
-Section: non-free/introspection
-Architecture: any
-Depends: ${gir:Depends},
-         ${misc:Depends}
-Description: EndlessOS Metrics Kit introspection files
- Introspection data for the EndlessOS Metrics Kit. Install this if you want to
- use the GObject introspection bindings for the EndlessOS Metrics Kit from a
- language such as Javascript.
-
+Description: EndlessOS Event Recorder Daemon
+ Daemon for aggregating and recording metrics data in EndlessOS.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: eos-metrics
-Upstream-Contact: Philip Chimento <philip@endlessm.com>
+Upstream-Name: eos-event-recorder-daemon
+Upstream-Contact: Kurt von Laven <kurt@endlessm.com>
 Disclaimer: This package is not part of Debian. It is proprietary software.
-Copyright: Copyright 2014 Endless Mobile, Inc.
+Copyright: Copyright 2013-2014 Endless Mobile, Inc.
 License: Proprietary

--- a/debian/eos-metrics-0-dev.install
+++ b/debian/eos-metrics-0-dev.install
@@ -1,4 +1,0 @@
-usr/include/eosmetrics*/*
-usr/lib/libeosmetrics*.so
-usr/lib/pkgconfig/eosmetrics*.pc
-usr/share/gir-1.0/EosMetrics*.gir

--- a/debian/eos-metrics-0-doc.install
+++ b/debian/eos-metrics-0-doc.install
@@ -1,1 +1,0 @@
-usr/share/gtk-doc/html/eosmetrics*/*

--- a/debian/eos-metrics-event-recorder.install
+++ b/debian/eos-metrics-event-recorder.install
@@ -1,8 +1,0 @@
-etc/dbus-1/system.d/com.endlessm.Metrics.conf
-etc/metrics/eos-metrics-permissions.conf
-lib/systemd/system/eos-metrics-event-recorder.service
-usr/lib/eos-metrics/eos-metrics-event-recorder
-usr/lib/tmpfiles.d/eos-metrics.conf
-usr/share/dbus-1/system-services/com.endlessm.Metrics.service
-usr/share/polkit-1/actions/com.endlessm.Metrics.policy
-usr/bin/eos-select-metrics-env

--- a/debian/eos-metrics.doc-base
+++ b/debian/eos-metrics.doc-base
@@ -1,9 +1,0 @@
-Document: eos-metrics0
-Title: EndlessOS Metrics Kit reference (C API)
-Author: Endless Mobile, Inc.
-Abstract: API documentation for the EndlessOS Metrics Kit, API version 0
-Section: Programming/C
-
-Format: HTML
-Index: /usr/share/gtk-doc/html/eosmetrics-0/index.html
-Files: /usr/share/gtk-doc/html/eosmetrics-0/*.html

--- a/debian/gir1.2-eosmetrics-0.install
+++ b/debian/gir1.2-eosmetrics-0.install
@@ -1,1 +1,0 @@
-usr/lib/girepository-1.0/EosMetrics*.typelib

--- a/debian/libeosmetrics-0-0.install
+++ b/debian/libeosmetrics-0-0.install
@@ -1,1 +1,0 @@
-usr/lib/libeosmetrics*.so.*

--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -1,4 +1,10 @@
-# The metrics permissions config file has a non-standard owner (root:metrics)
-# and a non-standard permissions (664).
-eos-metrics-event-recorder binary: wrong-file-owner-uid-or-gid
-eos-metrics-event-recorder binary: non-standard-file-perm
+# The metrics permissions config file has a non-standard owner (metrics:metrics)
+# and non-standard permissions (2775).
+eos-event-recorder-daemon binary: wrong-file-owner-uid-or-gid
+eos-event-recorder-daemon binary: setgid-binary
+
+# TODO: Override bad-distribution-in-changes-file once that's possible. See
+# https://groups.google.com/forum/#!msg/linux.debian.bugs.dist/6bDgg9-o8W4/Z1QRsHMGBLcJ.
+# FIXME: Remove TODO once unstable is added to
+# /usr/share/lintian/vendors/ubuntu/main/data/changes-file/known-dists. See
+# https://bugs.launchpad.net/ubuntu/+source/lintian/+bug/1303603.

--- a/debian/rules
+++ b/debian/rules
@@ -10,11 +10,11 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@  --with autotools-dev,gir,systemd
+	dh $@  --with autotools-dev,systemd
 
 # Build our documentation as well
 override_dh_auto_configure:
-	dh_auto_configure -- --enable-strict-flags --enable-gtk-doc --enable-gir-doc
+	dh_auto_configure -- --enable-strict-flags
 
 override_dh_auto_test:
 	dh_auto_test || ( find . -name '*.log' | xargs cat; false )


### PR DESCRIPTION
We are open-sourcing the event recorder API since it is used in mutter,
and we want to comply with mutter's GPL license. We are keeping the
event recorder server closed source, so the eos-metrics repository is
being renamed to eos-event-recorder-daemon. The event recorder API will
then be added to a new public repository named eos-metrics.

[endlessm/eos-sdk#2043]
