### PR TITLE
Use configure.ac as file that must exist.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,7 @@
 # Bootstrap script for EosMetrics
 # Run this script on a clean source checkout to get ready for building.
 
-FILE_MUST_EXIST=eosmetrics/eosmetrics.h
+FILE_MUST_EXIST=configure.ac
 
 test -n "$srcdir" || srcdir=`dirname "$0"`
 test -n "$srcdir" || srcdir=.


### PR DESCRIPTION
This change needs to be made to both the public and private repos, so I
factored it out.

configure.ac is our new standard file that must exist.

[endlessm/eos-sdk#2043]
