### PR TITLE
Remove unused configure flag.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,7 @@
 
 # Build our documentation as well
 override_dh_auto_configure:
-	dh_auto_configure -- --enable-strict-flags --enable-gtk-doc --enable-gir-doc --disable-login-tests
+	dh_auto_configure -- --enable-strict-flags --enable-gtk-doc --enable-gir-doc
 
 override_dh_auto_test:
 	dh_auto_test || ( find . -name '*.log' | xargs cat; false )


### PR DESCRIPTION
We had login tests disabled at one point because they were failing on
Jenkins. Login tests have been already re-enabled and are succeeding on
Jenkins. This change merely removes a no longer used flag that used to
disable login tests.

[endlessm/eos-sdk#2043]
