### PR TITLE
Bump event recorder API dependency version.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Maintainer: Kurt von Laven <kurt@endlessm.com>
 Build-Depends: autotools-dev,
                debhelper (>= 8.0.0),
                dh-systemd,
-               eos-metrics-0-dev,
+               eos-metrics-0-dev (>= 0.2),
                libglib2.0-dev (>= 2.38),
                libpolkit-gobject-1-dev,
                libsoup2.4-dev (>= 2.42),
@@ -22,8 +22,7 @@ Architecture: any
 Breaks: eos-metrics-event-recorder
 Replaces: eos-metrics-event-recorder
 Provides: eos-metrics-event-recorder
-Depends: libeosmetrics-0-0 (= ${binary:Version}),
-         ${shlibs:Depends},
+Depends: ${shlibs:Depends},
          ${misc:Depends}
 Description: EndlessOS Event Recorder Daemon
  Daemon for aggregating and recording metrics data in EndlessOS.


### PR DESCRIPTION
Without this change, we don't assure ourselves that
com.endlessm.Metrics.xml and emtr-util.h are available in the package we
are depending on. The former is needed at build-time, and the latter is
needed at run-time.

Also, the run-time dependency on the metrics library is implicit in
${shlibs:Depends}, so we removed it.

[endlessm/eos-sdk#2043]
