### PR TITLE
No longer leak FileIOStream in test.

### DIFF
--- a/tests/daemon/test-network-send-provider.c
+++ b/tests/daemon/test-network-send-provider.c
@@ -54,6 +54,7 @@ setup (Fixture      *fixture,
 {
   GFileIOStream *stream;
   fixture->tmp_file = g_file_new_tmp (TESTING_FILE_PATH, &stream, NULL);
+  g_object_unref (stream);
   fixture->tmp_path = g_file_get_path (fixture->tmp_file);
 
   fixture->key_file = g_key_file_new ();


### PR DESCRIPTION
The NetworkSendProvider tests no longer leak GFileIOStreams.

[endlessm/eos-sdk#2548]
