### PR TITLE
Update copyright file to GPLv2+

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,5 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: eos-event-recorder-daemon
 Upstream-Contact: Kurt von Laven <kurt@endlessm.com>
-Disclaimer: This package is not part of Debian. It is proprietary software.
-Copyright: Copyright 2013-2014 Endless Mobile, Inc.
-License: Proprietary
+Copyright: Copyright 2013, 2014, 2015 Endless Mobile, Inc. All rights reserved.
+License: GPL-2+


### PR DESCRIPTION
This updates the copyright year and specifies that the package is
licensed under GPLv2 or later.

[endlessm/eos-sdk#2876]