### PR TITLE
Update timestamps on shutdown.

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -930,6 +930,21 @@ finally:
 }
 
 static void
+update_timestamps (EmerDaemon *self)
+{
+  EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
+
+  GError *error = NULL;
+  if (!emer_persistent_cache_get_boot_time_offset (priv->persistent_cache,
+                                                   NULL, &error, TRUE))
+    {
+      g_warning ("Persistent cache could not update timestamps: %s.",
+                 error->message);
+      g_error_free (error);
+    }
+}
+
+static void
 handle_login_manager_signal (GDBusProxy *dbus_proxy,
                              gchar      *sender_name,
                              gchar      *signal_name,
@@ -942,6 +957,7 @@ handle_login_manager_signal (GDBusProxy *dbus_proxy,
       g_variant_get_child (parameters, 0, "b", &shutting_down);
       if (shutting_down)
         {
+          update_timestamps (self);
           flush_to_persistent_cache (self);
           release_shutdown_inhibitor (self);
         }

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -169,16 +169,6 @@ get_saved_boot_id (EmerPersistentCache *self,
       return TRUE;
     }
 
-  if (!g_key_file_load_from_file (priv->boot_offset_key_file,
-                                  priv->boot_metadata_file_path,
-                                  G_KEY_FILE_NONE,
-                                  error))
-    {
-      g_prefix_error (error, "Failed to open KeyFile at: %s.",
-                      priv->boot_metadata_file_path);
-      return FALSE;
-    }
-
   gchar *id_as_string = g_key_file_get_string (priv->boot_offset_key_file,
                                                CACHE_TIMING_GROUP_NAME,
                                                CACHE_LAST_BOOT_ID_KEY,

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -698,13 +698,14 @@ update_boot_offset_source_func (EmerPersistentCache *self)
 
 /*
  * Gets the boot time offset and stores it in the out parameter offset.
- * If the always_update_timestamps parameter is FALSE, this will not perform
- * writes to disk to update the timestamps during this operation unless the boot
- * id is out of date, or some corruption is detected which forces a rewrite of
- * the boot timing metadata file.
+ * If the always_update_timestamps parameter is FALSE, does not write to disk
+ * solely to update the timestamps during this operation unless the boot id is
+ * out of date or some corruption is detected that prompts a total rewrite of
+ * the boot timing metadata file. Pass an offset of NULL if you don't care about
+ * its value.
  *
- * Will return TRUE on success. Will return FALSE on failure, will not set the
- * offset in the out parameter and will set the GError if error is not NULL.
+ * Returns TRUE on success. Returns FALSE on failure and sets the error unless
+ * it's NULL. Does not alter the offset out parameter on failure.
  */
 gboolean
 emer_persistent_cache_get_boot_time_offset (EmerPersistentCache *self,
@@ -732,7 +733,10 @@ emer_persistent_cache_get_boot_time_offset (EmerPersistentCache *self,
 
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
-  *offset = priv->boot_offset;
+
+  if (offset != NULL)
+    *offset = priv->boot_offset;
+
   return TRUE;
 }
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -180,9 +180,11 @@ get_saved_boot_id (EmerPersistentCache *self,
       return FALSE;
     }
 
-  /* Strangely, with both the keyfile and the system file, a newline is appended
-     and retrieved when a uuid is changed to a string and stored on disk.
-     We chomp it off here because uuid_parse will fail otherwise. */
+  /*
+   * With both the keyfile and the system file, a newline is appended
+   * when a uuid is changed to a string and stored on disk.
+   * We chomp it off here because uuid_parse will fail otherwise.
+   */
   g_strchomp (id_as_string);
   if (uuid_parse (id_as_string, priv->saved_boot_id) != 0)
     {
@@ -598,10 +600,9 @@ update_boot_offset (EmerPersistentCache *self,
       if (!g_error_matches (error, G_KEY_FILE_ERROR,
                             G_KEY_FILE_ERROR_NOT_FOUND) &&
           !g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
-        {
-          g_warning ("Got an unexpected error trying to load %s. Error: %s.",
-                     priv->boot_metadata_file_path, error->message);
-        }
+        g_warning ("Got an unexpected error trying to load %s. Error: %s.",
+                   priv->boot_metadata_file_path, error->message);
+
       g_error_free (error);
       return reset_boot_offset_metadata_file (self, &relative_time,
                                               &absolute_time);

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -25,6 +25,7 @@
 
 typedef struct _EmerPersistentCachePrivate
 {
+  gint num_timestamp_updates;
   gint store_metrics_called;
 } EmerPersistentCachePrivate;
 
@@ -66,6 +67,13 @@ emer_persistent_cache_get_boot_time_offset (EmerPersistentCache *self,
                                             GError             **error,
                                             gboolean             always_update_timestamps)
 {
+  if (always_update_timestamps)
+    {
+      EmerPersistentCachePrivate *priv =
+        emer_persistent_cache_get_instance_private (self);
+      priv->num_timestamp_updates++;
+    }
+
   return TRUE;
 }
 
@@ -106,6 +114,15 @@ emer_persistent_cache_store_metrics (EmerPersistentCache *self,
 }
 
 /* API OF MOCK OBJECT */
+
+gint
+mock_persistent_cache_get_num_timestamp_updates (EmerPersistentCache *self)
+{
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
+  return priv->num_timestamp_updates;
+}
 
 /* Return number of calls to emer_persistent_cache_store_metrics() */
 gint

--- a/tests/daemon/mock-persistent-cache.h
+++ b/tests/daemon/mock-persistent-cache.h
@@ -29,7 +29,8 @@
 
 G_BEGIN_DECLS
 
-gint mock_persistent_cache_get_store_metrics_called (EmerPersistentCache *self);
+gint mock_persistent_cache_get_num_timestamp_updates (EmerPersistentCache *self);
+gint mock_persistent_cache_get_store_metrics_called  (EmerPersistentCache *self);
 
 G_END_DECLS
 

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -465,6 +465,29 @@ test_daemon_inhibits_shutdown (Fixture      *fixture,
 }
 
 static void
+test_daemon_updates_timestamps_on_shutdown (Fixture      *fixture,
+                                            gconstpointer unused)
+{
+  start_mock_logind_service (fixture);
+
+  gint num_timestamp_updates_before =
+    mock_persistent_cache_get_num_timestamp_updates (fixture->mock_persistent_cache);
+
+  await_shutdown_inhibit (fixture);
+  emit_shutdown_signal (TRUE);
+
+  // Wait for EmerDaemon to handle the signal.
+  while (g_main_context_pending (NULL))
+    g_main_context_iteration (NULL, TRUE);
+
+  gint num_timestamp_updates_after =
+    mock_persistent_cache_get_num_timestamp_updates (fixture->mock_persistent_cache);
+  g_assert_cmpint (num_timestamp_updates_after, ==, num_timestamp_updates_before + 1);
+
+  terminate_mock_logind_service_and_wait (fixture);
+}
+
+static void
 test_daemon_flushes_to_persistent_cache_once_on_shutdown (Fixture      *fixture,
                                                           gconstpointer unused)
 {
@@ -531,6 +554,8 @@ main (int                argc,
   ADD_DAEMON_TEST ("/daemon/does-not-record-event-sequence-if-not-allowed",
                    test_daemon_does_not_record_event_sequence_if_not_allowed);
   ADD_DAEMON_TEST ("/daemon/inhibits-shutdown", test_daemon_inhibits_shutdown);
+  ADD_DAEMON_TEST ("/daemon/updates-timestamps-on-shutdown",
+                   test_daemon_updates_timestamps_on_shutdown);
   ADD_DAEMON_TEST ("/daemon/flushes-to-persistent-cache-once-on-shutdown",
                    test_daemon_flushes_to_persistent_cache_once_on_shutdown);
   ADD_DAEMON_TEST ("/daemon/reinhibits-shutdown-on-shutdown-cancel",

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -488,8 +488,8 @@ test_daemon_updates_timestamps_on_shutdown (Fixture      *fixture,
 }
 
 static void
-test_daemon_flushes_to_persistent_cache_once_on_shutdown (Fixture      *fixture,
-                                                          gconstpointer unused)
+test_daemon_flushes_to_persistent_cache_on_shutdown (Fixture      *fixture,
+                                                     gconstpointer unused)
 {
   start_mock_logind_service (fixture);
 
@@ -539,8 +539,7 @@ main (int                argc,
   g_test_add ((path), Fixture, NULL, setup, (test_func), teardown)
 
   ADD_DAEMON_TEST ("/daemon/new-succeeds", test_daemon_new_succeeds);
-  ADD_DAEMON_TEST ("/daemon/new-full-succeeds",
-                   test_daemon_new_full_succeeds);
+  ADD_DAEMON_TEST ("/daemon/new-full-succeeds", test_daemon_new_full_succeeds);
   ADD_DAEMON_TEST ("/daemon/can-record-singular-event",
                    test_daemon_can_record_singular_event);
   ADD_DAEMON_TEST ("/daemon/can-record-aggregate-events",
@@ -556,8 +555,8 @@ main (int                argc,
   ADD_DAEMON_TEST ("/daemon/inhibits-shutdown", test_daemon_inhibits_shutdown);
   ADD_DAEMON_TEST ("/daemon/updates-timestamps-on-shutdown",
                    test_daemon_updates_timestamps_on_shutdown);
-  ADD_DAEMON_TEST ("/daemon/flushes-to-persistent-cache-once-on-shutdown",
-                   test_daemon_flushes_to_persistent_cache_once_on_shutdown);
+  ADD_DAEMON_TEST ("/daemon/flushes-to-persistent-cache-on-shutdown",
+                   test_daemon_flushes_to_persistent_cache_on_shutdown);
   ADD_DAEMON_TEST ("/daemon/reinhibits-shutdown-on-shutdown-cancel",
                    test_daemon_reinhibits_shutdown_on_shutdown_cancel);
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -104,8 +104,8 @@ write_empty_metrics_file (gchar *suffix)
 
   GError *error = NULL;
   g_file_replace_contents (file, "", 0, NULL, FALSE,
-  	                       G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL,
-  	                       &error);
+                           G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL,
+                           &error);
   g_assert_no_error (error);
   g_object_unref (file);
 }
@@ -993,9 +993,8 @@ test_persistent_cache_store_one_singular_event_succeeds (gboolean     *unused,
 {
   EmerPersistentCache *cache = make_testing_cache ();
   capacity_t capacity;
-  gboolean success = store_single_singular_event (cache, &capacity);
+  g_assert (store_single_singular_event (cache, &capacity));
   g_object_unref (cache);
-  g_assert (success);
   g_assert_cmpint (capacity, ==, CAPACITY_LOW);
 }
 
@@ -1005,9 +1004,8 @@ test_persistent_cache_store_one_aggregate_event_succeeds (gboolean     *unused,
 {
   EmerPersistentCache *cache = make_testing_cache ();
   capacity_t capacity;
-  gboolean success = store_single_aggregate_event (cache, &capacity);
+  g_assert (store_single_aggregate_event (cache, &capacity));
   g_object_unref (cache);
-  g_assert (success);
   g_assert_cmpint (capacity, ==, CAPACITY_LOW);
 }
 
@@ -1017,9 +1015,8 @@ test_persistent_cache_store_one_sequence_event_succeeds (gboolean     *unused,
 {
   EmerPersistentCache *cache = make_testing_cache ();
   capacity_t capacity;
-  gboolean success = store_single_sequence_event (cache, &capacity);
+  g_assert (store_single_sequence_event (cache, &capacity));
   g_object_unref (cache);
-  g_assert (success);
   g_assert_cmpint (capacity, ==, CAPACITY_LOW);
 }
 
@@ -1729,10 +1726,10 @@ test_persistent_cache_get_offset_wont_update_timestamps_if_it_isnt_supposed_to (
                                                         FALSE));
   g_assert_no_error (error);
 
-   // These timestamps should not have changed.
-   g_assert_cmpint (relative_time, ==, read_relative_time ());
-   g_assert_cmpint (absolute_time, ==, read_absolute_time ());
-   g_object_unref (cache);
+  // These timestamps should not have changed.
+  g_assert_cmpint (relative_time, ==, read_relative_time ());
+  g_assert_cmpint (absolute_time, ==, read_absolute_time ());
+  g_object_unref (cache);
 }
 
 /*

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -263,7 +263,7 @@ read_offset (void)
                                                CACHE_BOOT_OFFSET_KEY,
                                                &error);
   g_key_file_unref (key_file);
-  g_assert (error == NULL);
+  g_assert_no_error (error);
   return stored_offset;
 }
 
@@ -727,9 +727,9 @@ store_single_singular_event (EmerPersistentCache *cache,
                                          &num_sequences_stored,
                                          capacity);
 
-  g_assert (num_singulars_stored == 1);
-  g_assert (num_aggregates_stored == 0);
-  g_assert (num_sequences_stored == 0);
+  g_assert_cmpint (num_singulars_stored, ==, 1);
+  g_assert_cmpint (num_aggregates_stored, ==, 0);
+  g_assert_cmpint (num_sequences_stored, ==, 0);
 
   return success;
 }
@@ -762,9 +762,9 @@ store_single_aggregate_event (EmerPersistentCache *cache,
                                          &num_sequences_stored,
                                          capacity);
 
-  g_assert (num_singulars_stored == 0);
-  g_assert (num_aggregates_stored == 1);
-  g_assert (num_sequences_stored == 0);
+  g_assert_cmpint (num_singulars_stored, ==, 0);
+  g_assert_cmpint (num_aggregates_stored, ==, 1);
+  g_assert_cmpint (num_sequences_stored, ==, 0);
 
   return success;
 }
@@ -796,9 +796,9 @@ store_single_sequence_event (EmerPersistentCache *cache,
                                          &num_sequences_stored,
                                          capacity);
 
-  g_assert (num_singulars_stored == 0);
-  g_assert (num_aggregates_stored == 0);
-  g_assert (num_sequences_stored == 1);
+  g_assert_cmpint (num_singulars_stored, ==, 0);
+  g_assert_cmpint (num_aggregates_stored, ==, 0);
+  g_assert_cmpint (num_sequences_stored, ==, 1);
 
   return success;
 }
@@ -941,11 +941,11 @@ test_persistent_cache_new_succeeds (gboolean     *unused,
 {
   GError *error = NULL;
   EmerPersistentCache *cache = make_testing_cache ();
-  g_assert (cache != NULL);
+  g_assert_nonnull (cache);
   g_object_unref (cache);
   if (error != NULL)
     g_error_free (error);
-  g_assert (error == NULL);
+  g_assert_no_error (error);
 }
 
 /*
@@ -979,10 +979,10 @@ test_persistent_cache_store_sets_out_parameters (gboolean     *unused,
                                                  &capacity));
 
   // An empty cache should be in the LOW capacity state.
-  g_assert (capacity == CAPACITY_LOW);
-  g_assert (num_singulars_stored == 0);
-  g_assert (num_aggregates_stored == 0);
-  g_assert (num_sequences_stored == 0);
+  g_assert_cmpint (capacity, ==, CAPACITY_LOW);
+  g_assert_cmpint (num_singulars_stored, ==, 0);
+  g_assert_cmpint (num_aggregates_stored, ==, 0);
+  g_assert_cmpint (num_sequences_stored, ==, 0);
 
   g_object_unref (cache);
 }
@@ -996,7 +996,7 @@ test_persistent_cache_store_one_singular_event_succeeds (gboolean     *unused,
   gboolean success = store_single_singular_event (cache, &capacity);
   g_object_unref (cache);
   g_assert (success);
-  g_assert (capacity == CAPACITY_LOW);
+  g_assert_cmpint (capacity, ==, CAPACITY_LOW);
 }
 
 static void
@@ -1008,7 +1008,7 @@ test_persistent_cache_store_one_aggregate_event_succeeds (gboolean     *unused,
   gboolean success = store_single_aggregate_event (cache, &capacity);
   g_object_unref (cache);
   g_assert (success);
-  g_assert (capacity == CAPACITY_LOW);
+  g_assert_cmpint (capacity, ==, CAPACITY_LOW);
 }
 
 static void
@@ -1020,7 +1020,7 @@ test_persistent_cache_store_one_sequence_event_succeeds (gboolean     *unused,
   gboolean success = store_single_sequence_event (cache, &capacity);
   g_object_unref (cache);
   g_assert (success);
-  g_assert (capacity == CAPACITY_LOW);
+  g_assert_cmpint (capacity, ==, CAPACITY_LOW);
 }
 
 static void
@@ -1057,11 +1057,11 @@ test_persistent_cache_store_one_of_each_succeeds (gboolean     *unused,
 
   g_assert (success);
 
-  g_assert (num_singulars_stored == 1);
-  g_assert (num_aggregates_stored == 1);
-  g_assert (num_sequences_stored == 1);
+  g_assert_cmpint (num_singulars_stored, ==, 1);
+  g_assert_cmpint (num_aggregates_stored, ==, 1);
+  g_assert_cmpint (num_sequences_stored, ==, 1);
 
-  g_assert (capacity == CAPACITY_LOW);
+  g_assert_cmpint (capacity, ==, CAPACITY_LOW);
 }
 
 static void
@@ -1080,9 +1080,9 @@ test_persistent_cache_store_many_succeeds (gboolean     *unused,
   g_object_unref (cache);
   g_assert (success);
 
-  g_assert (num_singulars_stored == num_singulars_made);
-  g_assert (num_aggregates_stored == num_aggregates_made);
-  g_assert (num_sequences_stored == num_sequences_made);
+  g_assert_cmpint (num_singulars_stored, ==, num_singulars_made);
+  g_assert_cmpint (num_aggregates_stored, ==, num_aggregates_made);
+  g_assert_cmpint (num_sequences_stored, ==, num_sequences_made);
 }
 
 static void
@@ -1119,19 +1119,19 @@ test_persistent_cache_store_when_full_succeeds (gboolean     *unused,
 
       if (capacity == CAPACITY_MAX)
         {
-          g_assert (num_singulars_stored <= num_singulars_made);
-          g_assert (num_aggregates_stored <= num_aggregates_made);
-          g_assert (num_sequences_stored <= num_sequences_made);
+          g_assert_cmpint (num_singulars_stored, <=, num_singulars_made);
+          g_assert_cmpint (num_aggregates_stored, <=, num_aggregates_made);
+          g_assert_cmpint (num_sequences_stored, <=, num_sequences_made);
           break;
         }
 
-      g_assert (num_singulars_stored == num_singulars_made);
-      g_assert (num_aggregates_stored == num_aggregates_made);
-      g_assert (num_sequences_stored == num_sequences_made);
+      g_assert_cmpint (num_singulars_stored, ==, num_singulars_made);
+      g_assert_cmpint (num_aggregates_stored, ==, num_aggregates_made);
+      g_assert_cmpint (num_sequences_stored, ==, num_sequences_made);
     }
 
   g_object_unref (cache);
-  g_assert (capacity == CAPACITY_MAX);
+  g_assert_cmpint (capacity, ==, CAPACITY_MAX);
 }
 
 static void
@@ -1171,8 +1171,8 @@ test_persistent_cache_drain_one_singular_event_succeeds (gboolean     *unused,
   g_assert (success);
 
   assert_singulars_equal_variants (singulars_stored, 1, singulars_drained);
-  g_assert (c_array_len (aggregates_drained) == 0);
-  g_assert (c_array_len (sequences_drained) == 0);
+  g_assert_cmpint (c_array_len (aggregates_drained), ==, 0);
+  g_assert_cmpint (c_array_len (sequences_drained), ==, 0);
 
   trash_singular_event (singulars_stored);
 
@@ -1218,9 +1218,9 @@ test_persistent_cache_drain_one_aggregate_event_succeeds (gboolean     *unused,
 
   g_assert (success);
 
-  g_assert (c_array_len (singulars_drained) == 0);
+  g_assert_cmpint (c_array_len (singulars_drained), ==, 0);
   assert_aggregates_equal_variants (aggregates_stored, 1, aggregates_drained);
-  g_assert (c_array_len (sequences_drained) == 0);
+  g_assert_cmpint (c_array_len (sequences_drained), ==, 0);
 
   trash_aggregate_event (aggregates_stored);
 
@@ -1255,7 +1255,7 @@ test_persistent_cache_drain_one_sequence_event_succeeds (gboolean     *unused,
                                        &num_sequences_stored,
                                        &capacity);
 
-  g_assert (num_sequences_stored == 1);
+  g_assert_cmpint (num_sequences_stored, ==, 1);
 
   GVariant **singulars_drained, **aggregates_drained, **sequences_drained;
 
@@ -1268,8 +1268,8 @@ test_persistent_cache_drain_one_sequence_event_succeeds (gboolean     *unused,
 
   g_assert (success);
 
-  g_assert (c_array_len (singulars_drained) == 0);
-  g_assert (c_array_len (aggregates_drained) == 0);
+  g_assert_cmpint (c_array_len (singulars_drained), ==, 0);
+  g_assert_cmpint (c_array_len (aggregates_drained), ==, 0);
   assert_sequences_equal_variants (sequences_stored, 1, sequences_drained);
 
   trash_sequence_event (sequences_stored);
@@ -1360,9 +1360,9 @@ test_persistent_cache_drain_empty_succeeds (gboolean     *unused,
 
   g_assert (success);
 
-  g_assert (c_array_len (singulars_drained) == 0);
-  g_assert (c_array_len (aggregates_drained) == 0);
-  g_assert (c_array_len (sequences_drained) == 0);
+  g_assert_cmpint (c_array_len (singulars_drained), ==, 0);
+  g_assert_cmpint (c_array_len (aggregates_drained), ==, 0);
+  g_assert_cmpint (c_array_len (sequences_drained), ==, 0);
 
   free_variant_c_array (singulars_drained);
   free_variant_c_array (aggregates_drained);
@@ -1414,9 +1414,9 @@ test_persistent_cache_purges_when_out_of_date_succeeds (gboolean     *unused,
                                        MAX_BYTES_TO_READ);
   g_object_unref (cache2);
 
-  g_assert (c_array_len (singulars_drained) == 0);
-  g_assert (c_array_len (aggregates_drained) == 0);
-  g_assert (c_array_len (sequences_drained) == 0);
+  g_assert_cmpint (c_array_len (singulars_drained), ==, 0);
+  g_assert_cmpint (c_array_len (aggregates_drained), ==, 0);
+  g_assert_cmpint (c_array_len (sequences_drained), ==, 0);
 
   free_variant_c_array (singulars_drained);
   free_variant_c_array (aggregates_drained);
@@ -1467,9 +1467,9 @@ test_persistent_cache_wipes_metrics_when_boot_offset_corrupted (gboolean     *un
                                        MAX_BYTES_TO_READ);
 
   // Only an aggregate event should remain.
-  g_assert (c_array_len (singulars_drained) == 0);
-  g_assert (c_array_len (aggregates_drained) == 1);
-  g_assert (c_array_len (sequences_drained) == 0);
+  g_assert_cmpint (c_array_len (singulars_drained), ==, 0);
+  g_assert_cmpint (c_array_len (aggregates_drained), ==, 1);
+  g_assert_cmpint (c_array_len (sequences_drained), ==, 0);
 
   free_variant_c_array (singulars_drained);
   free_variant_c_array (aggregates_drained);
@@ -1564,7 +1564,7 @@ test_persistent_cache_does_not_compute_offset_when_boot_id_is_same (gboolean    
   g_assert_no_error (error);
 
   gint64 third_offset = read_offset ();
-  g_assert (third_offset == second_offset);
+  g_assert_cmpint (third_offset, ==, second_offset);
 
   g_object_unref (cache3);
 }
@@ -1602,8 +1602,10 @@ test_persistent_cache_computes_reasonable_offset (gboolean     *unused,
 
   g_assert (boot_timestamp_is_valid (relative_time, absolute_time));
   gint64 second_offset = read_offset ();
-  g_assert (second_offset <= first_offset + ACCEPTABLE_OFFSET_VARIANCE);
-  g_assert (second_offset >= first_offset - ACCEPTABLE_OFFSET_VARIANCE);
+  gint64 max_second_offset = first_offset + ACCEPTABLE_OFFSET_VARIANCE;
+  gint64 min_second_offset = first_offset - ACCEPTABLE_OFFSET_VARIANCE;
+  g_assert_cmpint (second_offset, <=, max_second_offset);
+  g_assert_cmpint (second_offset, >=, min_second_offset);
 
   // This should not have simply reset the metadata file again.
   g_assert (!boot_offset_was_reset ());
@@ -1644,7 +1646,7 @@ test_persistent_cache_builds_boot_metadata_file (gboolean     *unused,
   gint64 second_offset = read_offset();
 
   // The offset should not have changed.
-  g_assert (first_offset == second_offset);
+  g_assert_cmpint (first_offset, ==, second_offset);
   g_assert (boot_offset_was_reset ());
 
   g_object_unref (cache);
@@ -1689,7 +1691,7 @@ test_persistent_cache_reads_cached_boot_offset (gboolean     *unused,
 
   g_assert (boot_timestamp_is_valid (relative_time, absolute_time));
 
-  g_assert (first_offset == second_offset);
+  g_assert_cmpint (first_offset, ==, second_offset);
 
   g_object_unref (cache);
 }
@@ -1728,8 +1730,8 @@ test_persistent_cache_get_offset_wont_update_timestamps_if_it_isnt_supposed_to (
   g_assert_no_error (error);
 
    // These timestamps should not have changed.
-   g_assert (relative_time == read_relative_time ());
-   g_assert (absolute_time == read_absolute_time ());
+   g_assert_cmpint (relative_time, ==, read_relative_time ());
+   g_assert_cmpint (absolute_time, ==, read_absolute_time ());
    g_object_unref (cache);
 }
 
@@ -1789,7 +1791,7 @@ test_g_file_measure_disk_usage_returns_zero_on_empty_file (gboolean     *unused,
                                        NULL, NULL, NULL, &disk_usage, NULL,
                                        NULL, &error));
   g_assert_no_error (error);
-  g_assert (disk_usage == 0);
+  g_assert_cmpint (disk_usage, ==, 0);
 
   g_object_unref (file);
   g_unlink (path);

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -1494,14 +1494,13 @@ test_persistent_cache_resets_boot_metadata_file_when_boot_offset_corrupted (gboo
   // Corrupt metadata file.
   remove_offset ();
 
-  gint64 unused_offset;
   GError *error = NULL;
   g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, "Could not find a "
                          "valid boot offset in the metadata file. Error: *.");
 
   // This call should detect corruption and reset the metadata file.
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, &unused_offset,
-                                                        &error, TRUE));
+  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
+                                                        TRUE));
 
   g_test_assert_expected_messages ();
   g_assert_no_error (error);
@@ -1531,10 +1530,9 @@ test_persistent_cache_does_not_compute_offset_when_boot_id_is_same (gboolean    
 {
   EmerPersistentCache *cache = make_testing_cache ();
 
-  gint64 unused_offset;
   GError *error = NULL;
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, &unused_offset,
-                                                        &error, TRUE));
+  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
+                                                        TRUE));
   g_assert_no_error (error);
   g_assert (boot_offset_was_reset ());
 
@@ -1548,8 +1546,8 @@ test_persistent_cache_does_not_compute_offset_when_boot_id_is_same (gboolean    
   EmerPersistentCache *cache2 = make_testing_cache ();
 
   // This call should have to compute the boot offset itself.
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache2, &unused_offset,
-                                                        &error, TRUE));
+  g_assert (emer_persistent_cache_get_boot_time_offset (cache2, NULL, &error,
+                                                        TRUE));
   g_assert_no_error (error);
 
   g_assert (boot_timestamp_is_valid (relative_time, absolute_time));
@@ -1561,8 +1559,8 @@ test_persistent_cache_does_not_compute_offset_when_boot_id_is_same (gboolean    
   g_object_unref (cache2);
   EmerPersistentCache *cache3 = make_testing_cache ();
 
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache3, &unused_offset,
-                                                        &error, TRUE));
+  g_assert (emer_persistent_cache_get_boot_time_offset (cache3, NULL, &error,
+                                                        TRUE));
   g_assert_no_error (error);
 
   gint64 third_offset = read_offset ();
@@ -1628,9 +1626,8 @@ test_persistent_cache_builds_boot_metadata_file (gboolean     *unused,
   EmerPersistentCache *cache = make_testing_cache ();
 
   GError *error = NULL;
-  gint64 unused_offset;
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, &unused_offset,
-                                                        &error, TRUE));
+  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
+                                                        TRUE));
   g_assert_no_error (error);
 
   gint64 first_offset = read_offset ();
@@ -1639,8 +1636,8 @@ test_persistent_cache_builds_boot_metadata_file (gboolean     *unused,
   g_assert (emtr_util_get_current_time (CLOCK_BOOTTIME, &relative_time) &&
             emtr_util_get_current_time (CLOCK_REALTIME, &absolute_time));
 
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, &unused_offset,
-                                                        &error, TRUE));
+  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
+                                                        TRUE));
   g_assert_no_error (error);
 
   g_assert (boot_timestamp_is_valid (relative_time, absolute_time));
@@ -1713,12 +1710,11 @@ test_persistent_cache_get_offset_wont_update_timestamps_if_it_isnt_supposed_to (
   EmerPersistentCache *cache = make_testing_cache ();
   write_default_boot_offset_key_file_to_disk ();
 
-  gint64 unused_offset;
   GError *error = NULL;
 
   // Update metadata file to reasonable values.
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, &unused_offset,
-                                                        &error, TRUE));
+  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
+                                                        TRUE));
   g_assert_no_error (error);
   gint64 relative_time = read_relative_time ();
   gint64 absolute_time = read_absolute_time ();
@@ -1727,8 +1723,8 @@ test_persistent_cache_get_offset_wont_update_timestamps_if_it_isnt_supposed_to (
   g_usleep (75000); // 0.075 seconds
 
   // This call shouldn't update the metadata file.
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, &unused_offset,
-                                                        &error, FALSE));
+  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
+                                                        FALSE));
   g_assert_no_error (error);
 
    // These timestamps should not have changed.
@@ -1752,15 +1748,14 @@ test_persistent_cache_get_offset_can_build_boot_metadata_file (gboolean     *unu
    * production code.
    */
 
-  gint64 offset;
   GError *error = NULL;
 
   /*
    * This call should create the metadata file even though the
    * always_update_timestamps parameter is FALSE.
    */
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, &offset,
-                                                        &error, FALSE));
+  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
+                                                        FALSE));
   g_assert_no_error (error);
 
   // The previous request should have reset the metadata file.


### PR DESCRIPTION
When the PrepareForShutdown signal is sent with parameter TRUE,
indicating that we are about to shutdown, update the relative and
absolute timestamps in the persistent cache's boot offset metadata
file. This makes the metrics' systems time-keeping algorithm more robust
in the event that the timestamp update that is triggered when the
persistent cache is finalized doesn't make it to disk before the system
shuts down.

[endlessm/eos-sdk#1558]