### PR TITLE
Send metrics on first try.

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -613,10 +613,8 @@ create_request_body (EmerDaemon *self)
   GVariantBuilder machine_id_builder;
   get_uuid_builder (machine_id, &machine_id_builder);
 
-  gint send_number;
-  if (!emer_network_send_provider_get_send_number (priv->network_send_provider,
-                                                   &send_number))
-    return NULL;
+  gint send_number =
+    emer_network_send_provider_get_send_number (priv->network_send_provider);
   emer_network_send_provider_increment_send_number (priv->network_send_provider);
 
   GVariantBuilder singulars_builder;

--- a/daemon/emer-network-send-provider.c
+++ b/daemon/emer-network-send-provider.c
@@ -191,16 +191,19 @@ reset_network_send_data (EmerNetworkSendProvider *self)
                   error->message);
       g_error_free (error);
     }
+
+  priv->send_number = 0;
+  priv->data_cached = TRUE;
 }
 
-static gboolean
+static void
 read_network_send_data (EmerNetworkSendProvider *self)
 {
   EmerNetworkSendProviderPrivate *priv =
     emer_network_send_provider_get_instance_private (self);
 
   if (priv->data_cached)
-    return TRUE;
+    return;
 
   GError *error = NULL;
   if (!g_key_file_load_from_file (priv->key_file, priv->path, G_KEY_FILE_NONE,
@@ -215,38 +218,29 @@ read_network_send_data (EmerNetworkSendProvider *self)
     goto handle_failed_read;
 
   priv->data_cached = TRUE;
-  return TRUE;
+  return;
 
 handle_failed_read:
   g_warning ("Failed to read from network send file. Resetting data. "
              "Error: %s.", error->message);
   g_error_free (error);
   reset_network_send_data (self);
-  return FALSE;
 }
 
 /*
  * emer_network_send_provider_get_send_number:
  * @self: the network send provider.
- * @send_number: the address of the gint to store the send number in.
  *
- * Retrieves the network send number.
- *
- * Returns: a boolean indicating success or failure of retrieval.
- * If this returns %FALSE, 'send_number' will be unaltered.
+ * Returns the network send number.
  */
-gboolean
-emer_network_send_provider_get_send_number (EmerNetworkSendProvider *self,
-                                            gint                    *send_number)
+gint
+emer_network_send_provider_get_send_number (EmerNetworkSendProvider *self)
 {
   EmerNetworkSendProviderPrivate *priv =
     emer_network_send_provider_get_instance_private (self);
 
-  if (!read_network_send_data (self))
-    return FALSE;
-
-  *send_number = priv->send_number;
-  return TRUE;
+  read_network_send_data (self);
+  return priv->send_number;
 }
 
 /*
@@ -255,17 +249,14 @@ emer_network_send_provider_get_send_number (EmerNetworkSendProvider *self,
  *
  * Increments the network send number and creates a new metadata file if one
  * doesn't already exist.
- *
- * Returns: %TRUE on success, and %FALSE on failure.
  */
-gboolean
+void
 emer_network_send_provider_increment_send_number (EmerNetworkSendProvider *self)
 {
   EmerNetworkSendProviderPrivate *priv =
     emer_network_send_provider_get_instance_private (self);
 
-  if (!read_network_send_data (self))
-    return FALSE;
+  read_network_send_data (self);
 
   g_key_file_set_integer (priv->key_file, NETWORK_SEND_GROUP,
                           NETWORK_SEND_KEY, priv->send_number + 1);
@@ -275,9 +266,7 @@ emer_network_send_provider_increment_send_number (EmerNetworkSendProvider *self)
       g_critical ("Failed to write to network send file. Error: %s.",
                   error->message);
       g_error_free (error);
-      return FALSE;
     }
 
   priv->send_number++;
-  return TRUE;
 }

--- a/daemon/emer-network-send-provider.c
+++ b/daemon/emer-network-send-provider.c
@@ -198,6 +198,7 @@ read_network_send_data (EmerNetworkSendProvider *self)
 {
   EmerNetworkSendProviderPrivate *priv =
     emer_network_send_provider_get_instance_private (self);
+
   if (priv->data_cached)
     return TRUE;
 

--- a/daemon/emer-network-send-provider.h
+++ b/daemon/emer-network-send-provider.h
@@ -81,10 +81,9 @@ EmerNetworkSendProvider *emer_network_send_provider_new                   (void)
 
 EmerNetworkSendProvider *emer_network_send_provider_new_full              (const gchar             *path);
 
-gboolean                 emer_network_send_provider_get_send_number       (EmerNetworkSendProvider *self,
-                                                                           gint                    *send_number);
+gint                     emer_network_send_provider_get_send_number       (EmerNetworkSendProvider *self);
 
-gboolean                 emer_network_send_provider_increment_send_number (EmerNetworkSendProvider *self);
+void                     emer_network_send_provider_increment_send_number (EmerNetworkSendProvider *self);
 
 G_END_DECLS
 

--- a/tests/daemon/mock-network-send-provider.c
+++ b/tests/daemon/mock-network-send-provider.c
@@ -63,6 +63,7 @@ emer_network_send_provider_get_send_number (EmerNetworkSendProvider *self,
 {
   EmerNetworkSendProviderPrivate *priv =
     emer_network_send_provider_get_instance_private (self);
+
   *send_number = priv->send_number;
   return TRUE;
 }
@@ -72,6 +73,7 @@ emer_network_send_provider_increment_send_number (EmerNetworkSendProvider *self)
 {
   EmerNetworkSendProviderPrivate *priv =
     emer_network_send_provider_get_instance_private (self);
+
   priv->send_number++;
   return TRUE;
 }

--- a/tests/daemon/mock-network-send-provider.c
+++ b/tests/daemon/mock-network-send-provider.c
@@ -57,23 +57,20 @@ emer_network_send_provider_new_full (const char *path)
   return emer_network_send_provider_new ();
 }
 
-gboolean
-emer_network_send_provider_get_send_number (EmerNetworkSendProvider *self,
-                                            gint                    *send_number)
+gint
+emer_network_send_provider_get_send_number (EmerNetworkSendProvider *self)
 {
   EmerNetworkSendProviderPrivate *priv =
     emer_network_send_provider_get_instance_private (self);
 
-  *send_number = priv->send_number;
-  return TRUE;
+  return priv->send_number;
 }
 
-gboolean
+void
 emer_network_send_provider_increment_send_number (EmerNetworkSendProvider *self)
 {
   EmerNetworkSendProviderPrivate *priv =
     emer_network_send_provider_get_instance_private (self);
 
   priv->send_number++;
-  return TRUE;
 }

--- a/tests/daemon/test-network-send-provider.c
+++ b/tests/daemon/test-network-send-provider.c
@@ -104,9 +104,8 @@ static void
 test_network_send_provider_can_get_send_number (Fixture      *fixture,
                                                 gconstpointer unused)
 {
-  gint send_number;
-  g_assert (emer_network_send_provider_get_send_number (fixture->network_send_provider,
-                                                        &send_number));
+  gint send_number =
+    emer_network_send_provider_get_send_number (fixture->network_send_provider);
   g_assert_cmpint (send_number, ==, STARTING_SEND_NUMBER);
 }
 
@@ -115,18 +114,16 @@ test_network_send_provider_caches_send_number (Fixture      *fixture,
                                                gconstpointer unused)
 {
   // First read should cache the value.
-  gint first_send_number;
-  g_assert (emer_network_send_provider_get_send_number (fixture->network_send_provider,
-                                                        &first_send_number));
+  gint first_send_number =
+    emer_network_send_provider_get_send_number (fixture->network_send_provider);
 
   g_assert_cmpint (first_send_number, ==, STARTING_SEND_NUMBER);
 
   // This key_file should now be ignored by the provider.
   write_testing_keyfile (fixture, OTHER_KEY_FILE);
 
-  gint second_send_number;
-  g_assert (emer_network_send_provider_get_send_number (fixture->network_send_provider,
-                                                        &second_send_number));
+  gint second_send_number =
+    emer_network_send_provider_get_send_number (fixture->network_send_provider);
 
   // Should not have changed.
   g_assert_cmpint (second_send_number, ==, STARTING_SEND_NUMBER);
@@ -136,11 +133,10 @@ static void
 test_network_send_provider_can_increment_send_number (Fixture      *fixture,
                                                       gconstpointer unused)
 {
-  g_assert (emer_network_send_provider_increment_send_number (fixture->network_send_provider));
+  emer_network_send_provider_increment_send_number (fixture->network_send_provider);
 
-  gint incremented_send_number;
-  g_assert (emer_network_send_provider_get_send_number (fixture->network_send_provider,
-                                                        &incremented_send_number));
+  gint incremented_send_number =
+    emer_network_send_provider_get_send_number (fixture->network_send_provider);
   g_assert_cmpint (incremented_send_number, ==, STARTING_SEND_NUMBER + 1);
 }
 
@@ -154,24 +150,20 @@ test_network_send_provider_resets_when_corrupted (Fixture      *fixture,
                          "*Failed to read from network send file. "
                          "Resetting data.*");
 
-  // Value will never be mutated by the failing function.
-  gint starting_invalid_send_number = -1;
-  gint invalid_send_number = starting_invalid_send_number;
-
-  // Reading from an invalid file should reset the key file and throw a warning.
-  g_assert_false (emer_network_send_provider_get_send_number (fixture->network_send_provider,
-                                                              &invalid_send_number));
+  // Reading from an invalid file should reset the key file and log a warning.
+  gint first_send_number =
+    emer_network_send_provider_get_send_number (fixture->network_send_provider);
 
   g_test_assert_expected_messages ();
-  g_assert_cmpint (invalid_send_number, ==, starting_invalid_send_number);
+  g_assert_cmpint (first_send_number, ==, RESET_SEND_NUMBER);
 
-  /* Setting this to a non-0 value to prevent a false positive. The reset values
-     are 0, so this will avoid that. */
-  gint reset_send_number = -1;
-
-  g_assert (emer_network_send_provider_get_send_number (fixture->network_send_provider,
-                                                        &reset_send_number));
-  g_assert_cmpint (reset_send_number, ==, RESET_SEND_NUMBER);
+  /*
+   * This time the key file should already exist and no warning should be
+   * logged.
+   */
+  gint second_send_number =
+    emer_network_send_provider_get_send_number (fixture->network_send_provider);
+  g_assert_cmpint (second_send_number, ==, RESET_SEND_NUMBER);
 }
 
 int

--- a/tests/daemon/test-network-send-provider.c
+++ b/tests/daemon/test-network-send-provider.c
@@ -118,6 +118,7 @@ test_network_send_provider_caches_send_number (Fixture      *fixture,
   gint first_send_number;
   g_assert (emer_network_send_provider_get_send_number (fixture->network_send_provider,
                                                         &first_send_number));
+
   g_assert_cmpint (first_send_number, ==, STARTING_SEND_NUMBER);
 
   // This key_file should now be ignored by the provider.


### PR DESCRIPTION
Currently we don't send any metrics on the first try on a new image
because we notice that there is no network send file, write a default
send file and bail. Instead of bailing out, we now plow ahead and send
metrics regardless of whether we were able to find a network send file.

[endlessm/eos-sdk#3003]