### PR TITLE
Update timestamps before releasing inhibitor.

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1242,7 +1242,9 @@ emer_daemon_finalize (GObject *object)
   g_source_remove (priv->upload_events_timeout_source_id);
 
   flush_to_persistent_cache (self);
+  g_clear_object (&priv->persistent_cache);
   release_shutdown_inhibitor (self);
+
   g_clear_object (&priv->login_manager_proxy);
   g_clear_object (&priv->ping_socket);
   g_free (priv->proxy_server_uri);
@@ -1252,7 +1254,6 @@ emer_daemon_finalize (GObject *object)
   g_clear_object (&priv->machine_id_provider);
   g_clear_object (&priv->network_send_provider);
   g_clear_object (&priv->permissions_provider);
-  g_clear_object (&priv->persistent_cache);
   // Do not free the GNetworkMonitor.  It is transfer none.
 
   free_singular_buffer (priv->singular_buffer, priv->num_singulars_buffered);

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -955,8 +955,8 @@ handle_login_manager_signal (GDBusProxy *dbus_proxy,
       g_variant_get_child (parameters, 0, "b", &shutting_down);
       if (shutting_down)
         {
-          update_timestamps (self);
           flush_to_persistent_cache (self);
+          update_timestamps (self);
           release_shutdown_inhibitor (self);
         }
       else


### PR DESCRIPTION
Currently, in emer_daemon_finalize, we release the shutdown inhibitor
after flushing the persistent cache but before updating the timestamps
in the persistent cache's boot offset metadata file. The point of
inhibiting shutdown is to give us enough time to perform any necessary
disk writes before the system shuts down, so we now perform all
necessary disk writes before releasing the shutdown inhibitor. This is
is unlikely to be a problem in practice because we only expect
emer_daemon_finalize to be called after the PrepareForShutdown signal
would be sent.

[endlessm/eos-sdk#3018]