### PR TITLE
Support specifying max cache size via file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build products
 /eos-event-recorder-daemon-0.0.0
 /tests/daemon/test-boot-id-provider
+/tests/daemon/test-cache-size-provider
 /tests/daemon/test-cache-version-provider
 /tests/daemon/test-daemon.dbusdaemon
 /tests/daemon/test-machine-id-provider

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /data/eos-metrics-event-recorder.service
 /data/com.endlessm.Metrics.service
 /data/eos-metrics-persistent-cache.conf
+/tools/eos-enable-metrics-uploading
 /tools/eos-select-metrics-env
 /tools/print-persistent-cache
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,20 +50,19 @@ BUILT_SOURCES =
 noinst_PROGRAMS =
 
 persistentcachedir=$(localstatedir)/cache/metrics/
-permissionsdir=$(sysconfdir)/metrics/
-permissions_file=$(permissionsdir)eos-metrics-permissions.conf
+configdir=$(sysconfdir)/metrics/
 
 # chown and chgrp are not allowed unless you are root or under some specific
 # other conditions that may not be met every time you run 'make'.
 install-data-hook:
-	$(MKDIR_P) --mode=g+s,ug+rwx,a+rx $(DESTDIR)$(persistentcachedir) $(DESTDIR)$(permissionsdir)
-	chmod --recursive g+s,ug+rwx,a+rx $(DESTDIR)$(persistentcachedir) $(DESTDIR)$(permissionsdir)
+	$(MKDIR_P) --mode=g+s,ug+rwx,a+rx $(DESTDIR)$(persistentcachedir) $(DESTDIR)$(configdir)
+	chmod --recursive g+s,ug+rwx,a+rx $(DESTDIR)$(persistentcachedir) $(DESTDIR)$(configdir)
 	@if id -u metrics 2> /dev/null; then \
-		if ! chown --recursive metrics:metrics $(DESTDIR)$(persistentcachedir) $(DESTDIR)$(permissionsdir); then \
+		if ! chown --recursive metrics:metrics $(DESTDIR)$(persistentcachedir) $(DESTDIR)$(configdir); then \
 			echo "*************************************"; \
 			echo "Make sure to recursively change the owner and"; \
 			echo "group of the $(persistentcachedir) and the" ; \
-			echo "$(permissionsdir) directories to 'metrics'."; \
+			echo "$(configdir) directories to 'metrics'."; \
 			echo "*************************************"; \
 		fi; \
 	else \
@@ -76,7 +75,7 @@ install-data-hook:
 	fi
 
 uninstall-hook:
-	rm -rf $(DESTDIR)$(persistentcachedir) $(DESTDIR)$(permissionsdir)
+	rm -rf $(DESTDIR)$(persistentcachedir) $(DESTDIR)$(configdir)
 
 # # # DATA # # #
 

--- a/daemon/Makefile.am.inc
+++ b/daemon/Makefile.am.inc
@@ -50,8 +50,8 @@ eos_metrics_event_recorder_SOURCES = \
 eos_metrics_event_recorder_CPPFLAGS = \
 	$(EOS_EVENT_RECORDER_DAEMON_CFLAGS) \
 	-D_POSIX_C_SOURCE=200112L \
+	-DCONFIG_DIR="\"$(configdir)\"" \
 	-DPERSISTENT_CACHE_DIR="\"$(persistentcachedir)\"" \
-	-DPERMISSIONS_FILE="\"$(permissions_file)\"" \
 	$(NULL)
 
 eos_metrics_event_recorder_LDADD = $(EOS_EVENT_RECORDER_DAEMON_LIBS)

--- a/daemon/Makefile.am.inc
+++ b/daemon/Makefile.am.inc
@@ -37,6 +37,7 @@ CLEANFILES += $(daemon_dbus_sources)
 eos_metrics_event_recorder_SOURCES = \
 	daemon/emer-main.c \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
+	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
 	daemon/emer-cache-version-provider.c daemon/emer-cache-version-provider.h \
 	daemon/emer-daemon.c daemon/emer-daemon.h \
 	daemon/emer-machine-id-provider.c daemon/emer-machine-id-provider.h \

--- a/daemon/emer-cache-size-provider.c
+++ b/daemon/emer-cache-size-provider.c
@@ -1,0 +1,210 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2015 Endless Mobile, Inc. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "emer-cache-size-provider.h"
+
+typedef struct EmerCacheSizeProviderPrivate
+{
+  gchar *path;
+  guint64 max_cache_size;
+  gboolean data_cached;
+  GKeyFile *key_file;
+} EmerCacheSizeProviderPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (EmerCacheSizeProvider, emer_cache_size_provider, G_TYPE_OBJECT)
+
+/*
+ * The filepath to the metadata file containing the maximum persistent cache
+ * size.
+ */
+#define DEFAULT_CACHE_SIZE_FILE_PATH CONFIG_DIR "cache-size.conf"
+
+#define CACHE_SIZE_GROUP "persistent_cache_size"
+#define MAX_CACHE_SIZE_KEY "maximum"
+
+enum
+{
+  PROP_0,
+  PROP_PATH,
+  NPROPS
+};
+
+static GParamSpec *emer_cache_size_provider_props[NPROPS] = { NULL, };
+
+/*
+ * SECTION:emer-cache-size-provider
+ * @title: Cache Size Provider
+ * @short_description: Specifies the maximum permissable size of the persistent
+ * cache.
+ *
+ * Abstracts away how the maximum cache size is specified via the
+ * emer_cache_size_provider_get_max_cache_size method.
+ */
+
+static void
+set_cache_size_path (EmerCacheSizeProvider *self,
+                     const gchar           *given_path)
+{
+  EmerCacheSizeProviderPrivate *priv =
+    emer_cache_size_provider_get_instance_private (self);
+  priv->path = g_strdup (given_path);
+}
+
+static void
+emer_cache_size_provider_set_property (GObject      *object,
+                                       guint         property_id,
+                                       const GValue *value,
+                                       GParamSpec   *pspec)
+{
+  EmerCacheSizeProvider *self = EMER_CACHE_SIZE_PROVIDER (object);
+
+  switch (property_id)
+    {
+    case PROP_PATH:
+      set_cache_size_path (self, g_value_get_string (value));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+    }
+}
+
+static void
+emer_cache_size_provider_finalize (GObject *object)
+{
+  EmerCacheSizeProvider *self = EMER_CACHE_SIZE_PROVIDER (object);
+  EmerCacheSizeProviderPrivate *priv =
+    emer_cache_size_provider_get_instance_private (self);
+
+  g_free (priv->path);
+  g_key_file_unref (priv->key_file);
+  G_OBJECT_CLASS (emer_cache_size_provider_parent_class)->finalize (object);
+}
+
+static void
+emer_cache_size_provider_class_init (EmerCacheSizeProviderClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  /* Blurb string is good enough default documentation for this. */
+  emer_cache_size_provider_props[PROP_PATH] =
+    g_param_spec_string ("path", "Path",
+                         "The path to the file where the maximum persistent "
+                         "cache size is stored.",
+                         DEFAULT_CACHE_SIZE_FILE_PATH,
+                         G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+  object_class->set_property = emer_cache_size_provider_set_property;
+  object_class->finalize = emer_cache_size_provider_finalize;
+
+  g_object_class_install_properties (object_class, NPROPS,
+                                     emer_cache_size_provider_props);
+}
+
+static void
+emer_cache_size_provider_init (EmerCacheSizeProvider *self)
+{
+  EmerCacheSizeProviderPrivate *priv =
+    emer_cache_size_provider_get_instance_private (self);
+  priv->key_file = g_key_file_new ();
+}
+
+/*
+ * emer_cache_size_provider_new:
+ *
+ * Constructs a provider that obtains the maximum persistent cache size from the
+ * default filepath.
+ *
+ * Returns: (transfer full): A new #EmerCacheSizeProvider.
+ * Free with g_object_unref().
+ */
+EmerCacheSizeProvider *
+emer_cache_size_provider_new (void)
+{
+  return g_object_new (EMER_TYPE_CACHE_SIZE_PROVIDER, NULL);
+}
+
+/*
+ * emer_cache_size_provider_new_full:
+ * @path: path to a file specifying a maximum persistent cache size; see
+ * #EmerCacheSizeProvider:path.
+ *
+ * Constructs a provider that obtains the maximum persistent cache size from the
+ * given filepath.
+ *
+ * Returns: (transfer full): A new #EmerCacheSizeProvider.
+ * Free with g_object_unref().
+ */
+EmerCacheSizeProvider *
+emer_cache_size_provider_new_full (const gchar *path)
+{
+  return g_object_new (EMER_TYPE_CACHE_SIZE_PROVIDER,
+                       "path", path,
+                       NULL);
+}
+
+static void
+read_cache_size_data (EmerCacheSizeProvider *self)
+{
+  EmerCacheSizeProviderPrivate *priv =
+    emer_cache_size_provider_get_instance_private (self);
+
+  if (priv->data_cached)
+    return;
+
+  GError *error = NULL;
+  if (!g_key_file_load_from_file (priv->key_file, priv->path, G_KEY_FILE_NONE,
+                                  &error))
+    goto handle_failed_read;
+
+  priv->max_cache_size = g_key_file_get_uint64 (priv->key_file,
+                                                CACHE_SIZE_GROUP,
+                                                MAX_CACHE_SIZE_KEY,
+                                                &error);
+  if (error != NULL)
+    goto handle_failed_read;
+
+  priv->data_cached = TRUE;
+  return;
+
+handle_failed_read:
+  g_warning ("Failed to read from cache size file. Error: %s.", error->message);
+  g_error_free (error);
+}
+
+/*
+ * emer_cache_size_provider_get_max_cache_size:
+ * @self: the max cache size provider
+ *
+ * Returns the maximum persistent cache size in bytes, which defaults to 0 if
+ * the underlying configuration file can't be read.
+ */
+guint64
+emer_cache_size_provider_get_max_cache_size (EmerCacheSizeProvider *self)
+{
+  EmerCacheSizeProviderPrivate *priv =
+    emer_cache_size_provider_get_instance_private (self);
+
+  read_cache_size_data (self);
+  return priv->max_cache_size;
+}

--- a/daemon/emer-cache-size-provider.h
+++ b/daemon/emer-cache-size-provider.h
@@ -1,0 +1,88 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2015 Endless Mobile, Inc. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EMER_CACHE_SIZE_PROVIDER_H
+#define EMER_CACHE_SIZE_PROVIDER_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define EMER_TYPE_CACHE_SIZE_PROVIDER emer_cache_size_provider_get_type()
+
+#define EMER_CACHE_SIZE_PROVIDER(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST ((obj), \
+  EMER_TYPE_CACHE_SIZE_PROVIDER, EmerCacheSizeProvider))
+
+#define EMER_CACHE_SIZE_PROVIDER_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST ((klass), \
+  EMER_TYPE_CACHE_SIZE_PROVIDER, EmerCacheSizeProviderClass))
+
+#define EMER_IS_CACHE_SIZE_PROVIDER(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), \
+  EMER_TYPE_CACHE_SIZE_PROVIDER))
+
+#define EMER_IS_CACHE_SIZE_PROVIDER_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE ((klass), \
+  EMER_TYPE_CACHE_SIZE_PROVIDER))
+
+#define EMER_CACHE_SIZE_PROVIDER_GET_CLASS(obj) \
+  (G_TYPE_INSTANCE_GET_CLASS ((obj), \
+  EMER_TYPE_CACHE_SIZE_PROVIDER, EmerCacheSizeProviderClass))
+
+/*
+ * EmerCacheSizeProvider:
+ *
+ * This instance structure contains no public members.
+ */
+typedef struct _EmerCacheSizeProvider EmerCacheSizeProvider;
+
+/*
+ * EmerCacheSizeProvider:
+ *
+ * This class structure contains no public members.
+ */
+typedef struct _EmerCacheSizeProviderClass EmerCacheSizeProviderClass;
+
+struct _EmerCacheSizeProvider
+{
+  /*< private >*/
+  GObject parent;
+};
+
+struct _EmerCacheSizeProviderClass
+{
+  /*< private >*/
+  GObjectClass parent_class;
+};
+
+GType                  emer_cache_size_provider_get_type              (void) G_GNUC_CONST;
+
+EmerCacheSizeProvider *emer_cache_size_provider_new                   (void);
+
+EmerCacheSizeProvider *emer_cache_size_provider_new_full              (const gchar           *path);
+
+guint64                emer_cache_size_provider_get_max_cache_size    (EmerCacheSizeProvider *self);
+
+G_END_DECLS
+
+#endif /* EMER_CACHE_SIZE_PROVIDER_H */

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -770,6 +770,11 @@ upload_events (GNetworkMonitor *source_object,
   if (!priv->recording_enabled)
     return;
 
+  gboolean uploading_enabled =
+    emer_permissions_provider_get_uploading_enabled (priv->permissions_provider);
+  if (!uploading_enabled)
+    return;
+
   GError *error = NULL;
   if (!g_network_monitor_can_reach_finish (priv->network_monitor, res, &error))
     {

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -53,6 +53,8 @@ G_DEFINE_TYPE_WITH_PRIVATE (EmerPermissionsProvider, emer_permissions_provider, 
   DAEMON_ENABLED_KEY_NAME "=false\n" \
   DAEMON_ENVIRONMENT_KEY_NAME "=production\n"
 
+#define PERMISSIONS_FILE CONFIG_DIR "eos-metrics-permissions.conf"
+
 enum
 {
   PROP_0,

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -117,9 +117,9 @@ read_config_file_sync (EmerPermissionsProvider *self)
   GError *error = NULL;
 
   gchar *path = g_file_get_path (priv->permissions_config_file);
-  gboolean success = g_key_file_load_from_file (priv->permissions, path,
-                                                G_KEY_FILE_NONE, &error);
-  if (!success)
+  gboolean load_succeeded =
+    g_key_file_load_from_file (priv->permissions, path, G_KEY_FILE_NONE, &error);
+  if (!load_succeeded)
     {
       load_fallback_data (self);
 
@@ -498,9 +498,9 @@ emer_permissions_provider_get_daemon_enabled (EmerPermissionsProvider *self)
     emer_permissions_provider_get_instance_private (self);
 
   GError *error = NULL;
-  gboolean retval = g_key_file_get_boolean (priv->permissions,
-                                            DAEMON_GLOBAL_GROUP_NAME,
-                                            DAEMON_ENABLED_KEY_NAME, &error);
+  gboolean daemon_enabled =
+    g_key_file_get_boolean (priv->permissions, DAEMON_GLOBAL_GROUP_NAME,
+                            DAEMON_ENABLED_KEY_NAME, &error);
   if (error != NULL)
     {
       g_critical ("Couldn't find key '%s:%s' in permissions config file. "
@@ -508,10 +508,9 @@ emer_permissions_provider_get_daemon_enabled (EmerPermissionsProvider *self)
                   DAEMON_GLOBAL_GROUP_NAME, DAEMON_ENABLED_KEY_NAME,
                   error->message);
       g_error_free (error);
-      /* retval is FALSE in case of error */
     }
 
-  return retval;
+  return daemon_enabled;
 }
 
 /*

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -278,8 +278,8 @@ read_environment (EmerPermissionsProvider *self)
       g_strcmp0 (environment, "test") != 0 &&
       g_strcmp0 (environment, "production") != 0)
     {
-      g_warning ("Error: Metrics environment is set to: %s in %s. "
-                 "Valid metrics environments are: dev, test, production.",
+      g_warning ("Error: Metrics environment is set to: %s in %s. Valid "
+                 "metrics environments are: dev, test, production.",
                  environment, PERMISSIONS_FILE);
       g_clear_pointer (&environment, g_free);
     }

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -128,8 +128,8 @@ read_config_file_sync (EmerPermissionsProvider *self)
         g_critical ("Permissions config file '%s' was invalid or could not be "
                     "read. Loading fallback data. Error: %s.", path,
                     error->message);
-      /* but if the config file was simply not there, fail silently and stick
-      with the defaults */
+      /* If the config file was simply not there, fail silently and stick
+       * with the defaults. */
 
       g_clear_error (&error);
     }

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -98,7 +98,7 @@ write_config_file_sync (EmerPermissionsProvider *self)
   if (!g_key_file_save_to_file (priv->permissions, permissions_config_file_path,
       &error))
     {
-      g_critical ("Could not write to permissions config file '%s': %s.",
+      g_critical ("Could not write to permissions config file '%s'. Error: %s.",
                   permissions_config_file_path, error->message);
       g_clear_error (&error);
     }
@@ -126,7 +126,7 @@ read_config_file_sync (EmerPermissionsProvider *self)
       if (!g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT) &&
           !g_error_matches (error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_NOT_FOUND))
         g_critical ("Permissions config file '%s' was invalid or could not be "
-                    "read. Loading fallback data. Message: %s.", path,
+                    "read. Loading fallback data. Error: %s.", path,
                     error->message);
       /* but if the config file was simply not there, fail silently and stick
       with the defaults */
@@ -268,7 +268,7 @@ read_environment (EmerPermissionsProvider *self)
   if (error != NULL)
     {
       g_critical ("Couldn't find key '%s:%s' in permissions config file. "
-                  "Returning default value. Message: %s.",
+                  "Returning default value. Error: %s.",
                   DAEMON_GLOBAL_GROUP_NAME, DAEMON_ENVIRONMENT_KEY_NAME,
                   error->message);
       g_error_free (error);
@@ -504,7 +504,7 @@ emer_permissions_provider_get_daemon_enabled (EmerPermissionsProvider *self)
   if (error != NULL)
     {
       g_critical ("Couldn't find key '%s:%s' in permissions config file. "
-                  "Returning default value. Message: %s.",
+                  "Returning default value. Error: %s.",
                   DAEMON_GLOBAL_GROUP_NAME, DAEMON_ENABLED_KEY_NAME,
                   error->message);
       g_error_free (error);

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -134,10 +134,10 @@ read_config_file_sync (EmerPermissionsProvider *self)
       g_clear_error (&error);
     }
 
+  g_free (path);
+
   g_object_notify_by_pspec (G_OBJECT (self),
                             emer_permissions_provider_props[PROP_DAEMON_ENABLED]);
-
-  g_free (path);
 }
 
 /* Helper function to run write_config_file_sync() in another thread. */

--- a/daemon/emer-permissions-provider.h
+++ b/daemon/emer-permissions-provider.h
@@ -62,19 +62,21 @@ struct _EmerPermissionsProviderClass
   GObjectClass parent_class;
 };
 
-GType                    emer_permissions_provider_get_type           (void) G_GNUC_CONST;
+GType                    emer_permissions_provider_get_type              (void) G_GNUC_CONST;
 
-EmerPermissionsProvider *emer_permissions_provider_new                (void);
+EmerPermissionsProvider *emer_permissions_provider_new                   (void);
 
-EmerPermissionsProvider *emer_permissions_provider_new_full           (const gchar             *config_file_path,
-                                                                       const gchar             *ostree_config_file_path);
+EmerPermissionsProvider *emer_permissions_provider_new_full              (const gchar             *config_file_path,
+                                                                          const gchar             *ostree_config_file_path);
 
-gboolean                 emer_permissions_provider_get_daemon_enabled (EmerPermissionsProvider *self);
+gboolean                 emer_permissions_provider_get_daemon_enabled    (EmerPermissionsProvider *self);
 
-void                     emer_permissions_provider_set_daemon_enabled (EmerPermissionsProvider *self,
-                                                                       gboolean                 enabled);
+void                     emer_permissions_provider_set_daemon_enabled    (EmerPermissionsProvider *self,
+                                                                          gboolean                 enabled);
 
-gchar                   *emer_permissions_provider_get_environment    (EmerPermissionsProvider *self);
+gboolean                 emer_permissions_provider_get_uploading_enabled (EmerPermissionsProvider *self);
+
+gchar                   *emer_permissions_provider_get_environment       (EmerPermissionsProvider *self);
 
 G_END_DECLS
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -1421,7 +1421,7 @@ set_boot_id_provider (EmerPersistentCache *self,
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  if (priv->boot_id_provider == NULL)
+  if (boot_id_provider == NULL)
     priv->boot_id_provider = emer_boot_id_provider_new ();
   else
     priv->boot_id_provider = g_object_ref_sink (boot_id_provider);

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -62,7 +62,7 @@ typedef struct GVariantWritable
 
 typedef struct _EmerPersistentCachePrivate
 {
-  guint64 max_cache_size;
+  EmerCacheSizeProvider *cache_size_provider;
   guint64 cache_size;
   capacity_t capacity;
 
@@ -114,12 +114,6 @@ G_DEFINE_TYPE_WITH_CODE (EmerPersistentCache, emer_persistent_cache, G_TYPE_OBJE
 #define BOOT_ID_FILE_LENGTH 37
 
 /*
- * The largest amount of memory (in bytes) that the metrics cache may
- * occupy before incoming metrics are ignored.
- */
-#define DEFAULT_MAX_CACHE_SIZE 92160u // 90 kB
-
-/*
  * The amount of time (in seconds) between every periodic update to the boot
  * offset file is made. This will primarily keep our relative timestamps more
  * accurate.
@@ -138,7 +132,7 @@ enum
 {
   PROP_0,
   PROP_CACHE_DIRECTORY,
-  PROP_MAX_CACHE_SIZE,
+  PROP_CACHE_SIZE_PROVIDER,
   PROP_BOOT_ID_PROVIDER,
   PROP_CACHE_VERSION_PROVIDER,
   PROP_BOOT_OFFSET_UPDATE_INTERVAL,
@@ -940,7 +934,10 @@ cache_has_room (EmerPersistentCache *self,
     emer_persistent_cache_get_instance_private (self);
   if (priv->capacity == CAPACITY_MAX)
     return FALSE;
-  return priv->cache_size + size <= priv->max_cache_size;
+
+  guint64 max_cache_size =
+    emer_cache_size_provider_get_max_cache_size (priv->cache_size_provider);
+  return priv->cache_size + size <= max_cache_size;
 }
 
 /*
@@ -954,15 +951,25 @@ update_capacity (EmerPersistentCache *self,
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
+
   if (set_to_max)
-    priv->capacity = CAPACITY_MAX;
-  else if (priv->cache_size >= HIGH_CAPACITY_THRESHOLD * priv->max_cache_size)
-    priv->capacity = CAPACITY_HIGH;
+    {
+      priv->capacity = CAPACITY_MAX;
+    }
   else
-    priv->capacity = CAPACITY_LOW;
+    {
+      guint64 max_cache_size =
+        emer_cache_size_provider_get_max_cache_size (priv->cache_size_provider);
+
+      if (priv->cache_size >= HIGH_CAPACITY_THRESHOLD * max_cache_size)
+        priv->capacity = CAPACITY_HIGH;
+      else
+        priv->capacity = CAPACITY_LOW;
+    }
 
   return priv->capacity;
 }
+
 
 /*
  * Converts the given GVariant to a string via serialization and byte swapping
@@ -1395,12 +1402,16 @@ set_cache_directory (EmerPersistentCache *self,
 }
 
 static void
-set_max_cache_size (EmerPersistentCache *self,
-                    guint64              size_in_bytes)
+set_cache_size_provider (EmerPersistentCache   *self,
+                         EmerCacheSizeProvider *cache_size_provider)
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
-  priv->max_cache_size = size_in_bytes;
+
+  if (cache_size_provider == NULL)
+    priv->cache_size_provider = emer_cache_size_provider_new ();
+  else
+    priv->cache_size_provider = g_object_ref_sink (cache_size_provider);
 }
 
 static void
@@ -1468,8 +1479,8 @@ emer_persistent_cache_set_property (GObject      *object,
       set_cache_directory (self, g_value_get_string (value));
       break;
 
-    case PROP_MAX_CACHE_SIZE:
-      set_max_cache_size (self, g_value_get_uint64 (value));
+    case PROP_CACHE_SIZE_PROVIDER:
+      set_cache_size_provider (self, g_value_get_object (value));
       break;
 
     case PROP_BOOT_ID_PROVIDER:
@@ -1500,6 +1511,7 @@ emer_persistent_cache_finalize (GObject *object)
 
   g_source_remove (priv->boot_offset_update_timeout_source_id);
 
+  g_object_unref (priv->cache_size_provider);
   g_object_unref (priv->boot_id_provider);
   g_object_unref (priv->cache_version_provider);
   g_free (priv->boot_metadata_file_path);
@@ -1526,11 +1538,11 @@ emer_persistent_cache_class_init (EmerPersistentCacheClass *klass)
                          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   /* Blurb string is good enough default documentation for this. */
-  emer_persistent_cache_props[PROP_MAX_CACHE_SIZE] =
-    g_param_spec_uint64 ("max-cache-size", "Maximum cache size",
-                         "The maximum number of bytes allowed to be stored in"
-                         " the persistent cache.",
-                         0, G_MAXUINT64, DEFAULT_MAX_CACHE_SIZE,
+  emer_persistent_cache_props[PROP_CACHE_SIZE_PROVIDER] =
+    g_param_spec_object ("cache-size-provider", "Cache size provider",
+                         "The provider for the maximum number of bytes that "
+                         "may be stored in the persistent cache.",
+                         EMER_TYPE_CACHE_SIZE_PROVIDER,
                          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   /* Blurb string is good enough default documentation for this. */
@@ -1613,7 +1625,7 @@ EmerPersistentCache *
 emer_persistent_cache_new_full (GCancellable             *cancellable,
                                 GError                  **error,
                                 const gchar              *custom_directory,
-                                guint64                   custom_cache_size,
+                                EmerCacheSizeProvider    *cache_size_provider,
                                 EmerBootIdProvider       *boot_id_provider,
                                 EmerCacheVersionProvider *cache_version_provider,
                                 guint                     boot_offset_update_interval)
@@ -1622,7 +1634,7 @@ emer_persistent_cache_new_full (GCancellable             *cancellable,
                          cancellable,
                          error,
                          "cache-directory", custom_directory,
-                         "max-cache-size", custom_cache_size,
+                         "cache-size-provider", cache_size_provider,
                          "boot-id-provider", boot_id_provider,
                          "cache-version-provider", cache_version_provider,
                          "boot-offset-update-interval", boot_offset_update_interval,

--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -27,6 +27,7 @@
 #include <gio/gio.h>
 
 #include "daemon/emer-boot-id-provider.h"
+#include "daemon/emer-cache-size-provider.h"
 #include "daemon/emer-cache-version-provider.h"
 #include "shared/metrics-util.h"
 
@@ -148,7 +149,7 @@ gboolean             emer_persistent_cache_store_metrics       (EmerPersistentCa
 EmerPersistentCache *emer_persistent_cache_new_full            (GCancellable             *cancellable,
                                                                 GError                  **error,
                                                                 const gchar              *custom_directory,
-                                                                guint64                   custom_cache_size,
+                                                                EmerCacheSizeProvider    *cache_size_provider,
                                                                 EmerBootIdProvider       *boot_id_provider,
                                                                 EmerCacheVersionProvider *version_provider,
                                                                 guint                     boot_offset_update_interval);

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -56,6 +56,7 @@ systembussecuritypolicydir = ${sysconfdir}/dbus-1/system.d
 dist_systembussecuritypolicy_DATA = data/com.endlessm.Metrics.conf
 
 dist_config_DATA = \
+	data/cache-size.conf \
 	data/eos-metrics-permissions.conf \
 	$(NULL)
 

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -40,7 +40,7 @@ data/com.endlessm.Metrics.service: data/com.endlessm.Metrics.service.in
 
 substitute_metrics_files = sed \
 	-e 's|@persistentcachedir[@]|$(persistentcachedir)|g' \
-	-e 's|@permissionsdir[@]|$(permissionsdir)|g' \
+	-e 's|@configdir[@]|$(configdir)|g' \
 	$(NULL)
 
 data/eos-metrics.conf: data/eos-metrics.conf.in
@@ -55,7 +55,9 @@ dist_policy_DATA = data/com.endlessm.Metrics.policy
 systembussecuritypolicydir = ${sysconfdir}/dbus-1/system.d
 dist_systembussecuritypolicy_DATA = data/com.endlessm.Metrics.conf
 
-dist_permissions_DATA = data/eos-metrics-permissions.conf
+dist_config_DATA = \
+	data/eos-metrics-permissions.conf \
+	$(NULL)
 
 tmpfilesddir = $(libdir)/tmpfiles.d/
 tmpfilesd_DATA = data/eos-metrics.conf

--- a/data/cache-size.conf
+++ b/data/cache-size.conf
@@ -1,0 +1,2 @@
+[persistent_cache_size]
+maximum=92160

--- a/data/eos-metrics-permissions.conf
+++ b/data/eos-metrics-permissions.conf
@@ -1,3 +1,4 @@
 [global]
 enabled=false
+uploading_enabled=true
 environment=production

--- a/data/eos-metrics.conf.in
+++ b/data/eos-metrics.conf.in
@@ -1,4 +1,4 @@
 d @persistentcachedir@ 2775 metrics metrics -
 Z @persistentcachedir@ 2775 metrics metrics -
-d @permissionsdir@ 2775 metrics metrics -
-Z @permissionsdir@ 2775 metrics metrics -
+d @configdir@ 2775 metrics metrics -
+Z @configdir@ 2775 metrics metrics -

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -30,8 +30,8 @@ DAEMON_TEST_FLAGS = \
 	@EOS_EVENT_RECORDER_DAEMON_CFLAGS@ \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/daemon \
+	-DCONFIG_DIR="\"$(configdir)\"" \
 	-DPERSISTENT_CACHE_DIR="\"$(persistentcachedir)\"" \
-	-DPERMISSIONS_FILE="\"$(permissions_file)\"" \
 	$(NULL)
 DAEMON_TEST_LIBS = @EOS_EVENT_RECORDER_DAEMON_LIBS@
 

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -18,6 +18,7 @@
 
 noinst_PROGRAMS += \
 	tests/daemon/test-boot-id-provider \
+	tests/daemon/test-cache-size-provider \
 	tests/daemon/test-cache-version-provider \
 	tests/daemon/test-daemon.dbusdaemon \
 	tests/daemon/test-machine-id-provider \
@@ -34,6 +35,13 @@ DAEMON_TEST_FLAGS = \
 	-DPERSISTENT_CACHE_DIR="\"$(persistentcachedir)\"" \
 	$(NULL)
 DAEMON_TEST_LIBS = @EOS_EVENT_RECORDER_DAEMON_LIBS@
+
+tests_daemon_test_cache_size_provider_SOURCES = \
+	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
+	tests/daemon/test-cache-size-provider.c \
+	$(NULL)
+tests_daemon_test_cache_size_provider_CPPFLAGS = $(DAEMON_TEST_FLAGS)
+tests_daemon_test_cache_size_provider_LDADD = $(DAEMON_TEST_LIBS)
 
 tests_daemon_test_cache_version_provider_SOURCES = \
 	daemon/emer-cache-version-provider.c daemon/emer-cache-version-provider.h \
@@ -53,6 +61,7 @@ tests_daemon_test_daemon_dbusdaemon_SOURCES = \
 	daemon/emer-daemon.c daemon/emer-daemon.h \
 	tests/daemon/test-daemon.c \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
+	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
 	daemon/emer-cache-version-provider.c daemon/emer-cache-version-provider.h \
 	daemon/emer-machine-id-provider.c daemon/emer-machine-id-provider.h \
 	tests/daemon/mock-network-send-provider.c \
@@ -94,6 +103,7 @@ tests_daemon_test_persistent_cache_SOURCES = \
 	tests/daemon/test-persistent-cache.c \
 	daemon/emer-persistent-cache.c daemon/emer-persistent-cache.h \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
+	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
 	daemon/emer-cache-version-provider.c daemon/emer-cache-version-provider.h \
 	shared/metrics-util.c shared/metrics-util.h \
 	$(NULL)
@@ -111,6 +121,7 @@ dist_noinst_SCRIPTS = \
 TESTS = \
 	tests/test-opt-out-integration.py \
 	tests/daemon/test-boot-id-provider \
+	tests/daemon/test-cache-size-provider \
 	tests/daemon/test-cache-version-provider \
 	tests/daemon/test-daemon.dbusdaemon \
 	tests/daemon/test-machine-id-provider \

--- a/tests/daemon/mock-permissions-provider.c
+++ b/tests/daemon/mock-permissions-provider.c
@@ -88,6 +88,12 @@ emer_permissions_provider_set_daemon_enabled (EmerPermissionsProvider *self,
   g_signal_emit_by_name (self, "notify::daemon-enabled", NULL);
 }
 
+gboolean
+emer_permissions_provider_get_uploading_enabled (EmerPermissionsProvider *self)
+{
+  return TRUE;
+}
+
 gchar *
 emer_permissions_provider_get_environment (EmerPermissionsProvider *self)
 {

--- a/tests/daemon/mock-permissions-provider.c
+++ b/tests/daemon/mock-permissions-provider.c
@@ -102,7 +102,7 @@ emer_permissions_provider_get_environment (EmerPermissionsProvider *self)
 
 /* API OF MOCK OBJECT */
 
-/* Return number of calls to emer_permissions_provider_get_daemon_enabled() */
+/* Return number of calls to emer_permissions_provider_get_daemon_enabled(). */
 gint
 mock_permissions_provider_get_daemon_enabled_called (EmerPermissionsProvider *self)
 {

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -53,7 +53,7 @@ EmerPersistentCache *
 emer_persistent_cache_new_full (GCancellable             *cancellable,
                                 GError                  **error,
                                 const gchar              *custom_directory,
-                                guint64                   custom_cache_size,
+                                EmerCacheSizeProvider    *cache_size_provider,
                                 EmerBootIdProvider       *boot_id_provider,
                                 EmerCacheVersionProvider *version_provider,
                                 guint                     boot_offset_update_interval)

--- a/tests/daemon/test-boot-id-provider.c
+++ b/tests/daemon/test-boot-id-provider.c
@@ -67,7 +67,7 @@ setup (struct Fixture *fixture,
   GFileIOStream *stream;
   fixture->tmp_file = g_file_new_tmp (TESTING_FILE_PATH, &stream, NULL);
   g_object_unref (stream);
-  g_assert (fixture->tmp_file != NULL);
+  g_assert_nonnull (fixture->tmp_file);
   write_testing_boot_id (fixture, FIRST_TESTING_ID);
   gchar *path = g_file_get_path (fixture->tmp_file);
   fixture->id_provider = emer_boot_id_provider_new_full (path);
@@ -92,7 +92,7 @@ static void
 test_boot_id_provider_new_succeeds (struct Fixture *fixture,
                                     gconstpointer   unused)
 {
-  g_assert (fixture->id_provider != NULL);
+  g_assert_nonnull (fixture->id_provider);
 }
 
 static void

--- a/tests/daemon/test-boot-id-provider.c
+++ b/tests/daemon/test-boot-id-provider.c
@@ -66,6 +66,7 @@ setup (struct Fixture *fixture,
 {
   GFileIOStream *stream;
   fixture->tmp_file = g_file_new_tmp (TESTING_FILE_PATH, &stream, NULL);
+  g_object_unref (stream);
   g_assert (fixture->tmp_file != NULL);
   write_testing_boot_id (fixture, FIRST_TESTING_ID);
   gchar *path = g_file_get_path (fixture->tmp_file);

--- a/tests/daemon/test-cache-size-provider.c
+++ b/tests/daemon/test-cache-size-provider.c
@@ -1,0 +1,141 @@
+/* Copyright 2015 Endless Mobile, Inc. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "emer-cache-size-provider.h"
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#define CACHE_SIZE_FILE_PATH "cache_size_file_XXXXXX"
+
+#define FIRST_MAX_CACHE_SIZE 40
+
+#define FIRST_CACHE_SIZE_FILE_CONTENTS \
+ "[persistent_cache_size]\n" \
+ "maximum=40\n"
+
+#define SECOND_CACHE_SIZE_FILE_CONTENTS \
+ "[persistent_cache_size]\n" \
+ "maximum=3\n"
+
+// Helper Functions
+
+typedef struct Fixture
+{
+  EmerCacheSizeProvider *cache_size_provider;
+  GFile *tmp_file;
+  gchar *tmp_path;
+  GKeyFile *key_file;
+} Fixture;
+
+static void
+write_cache_size_file (Fixture *fixture,
+                       gchar   *key_file_data)
+{
+  GError *error = NULL;
+  g_key_file_load_from_data (fixture->key_file, key_file_data, -1,
+                             G_KEY_FILE_NONE, &error);
+  g_assert_no_error (error);
+
+  g_key_file_save_to_file (fixture->key_file, fixture->tmp_path, &error);
+  g_assert_no_error (error);
+}
+
+static void
+setup (Fixture      *fixture,
+       gconstpointer unused)
+{
+  GFileIOStream *stream;
+  fixture->tmp_file = g_file_new_tmp (CACHE_SIZE_FILE_PATH, &stream, NULL);
+  g_object_unref (stream);
+  fixture->tmp_path = g_file_get_path (fixture->tmp_file);
+
+  fixture->key_file = g_key_file_new ();
+  write_cache_size_file (fixture, FIRST_CACHE_SIZE_FILE_CONTENTS);
+
+  fixture->cache_size_provider =
+    emer_cache_size_provider_new_full (fixture->tmp_path);
+}
+
+static void
+teardown (Fixture      *fixture,
+          gconstpointer unused)
+{
+  g_key_file_unref (fixture->key_file);
+  g_object_unref (fixture->tmp_file);
+  g_unlink (fixture->tmp_path);
+  g_free (fixture->tmp_path);
+  g_object_unref (fixture->cache_size_provider);
+}
+
+static void
+test_cache_size_provider_new_succeeds (Fixture      *fixture,
+                                       gconstpointer unused)
+{
+  g_assert_nonnull (fixture->cache_size_provider);
+}
+
+static void
+test_cache_size_provider_can_get_max_cache_size (Fixture      *fixture,
+                                                 gconstpointer unused)
+{
+  guint64 max_cache_size =
+    emer_cache_size_provider_get_max_cache_size (fixture->cache_size_provider);
+  g_assert_cmpint (max_cache_size, ==, FIRST_MAX_CACHE_SIZE);
+}
+
+static void
+test_cache_size_provider_caches_max_cache_size (Fixture      *fixture,
+                                                gconstpointer unused)
+{
+  // The first read should cache the max cache size.
+  guint64 first_max_cache_size =
+    emer_cache_size_provider_get_max_cache_size (fixture->cache_size_provider);
+  g_assert_cmpint (first_max_cache_size, ==, FIRST_MAX_CACHE_SIZE);
+
+  // This file should be ignored by the cache size provider.
+  write_cache_size_file (fixture, SECOND_CACHE_SIZE_FILE_CONTENTS);
+
+  // The second read should read from memory, not disk.
+  guint64 second_max_cache_size =
+    emer_cache_size_provider_get_max_cache_size (fixture->cache_size_provider);
+  g_assert_cmpint (second_max_cache_size, ==, FIRST_MAX_CACHE_SIZE);
+}
+
+int
+main (int                argc,
+      const char * const argv[])
+{
+  g_test_init (&argc, (char ***) &argv, NULL);
+#define ADD_CACHE_SIZE_TEST_FUNC(path, func) \
+  g_test_add ((path), Fixture, NULL, setup, (func), teardown)
+
+  ADD_CACHE_SIZE_TEST_FUNC ("/cache-size-provider/new-succeeds",
+                            test_cache_size_provider_new_succeeds);
+  ADD_CACHE_SIZE_TEST_FUNC ("/cache-size-provider/can-get-max-cache-size",
+                            test_cache_size_provider_can_get_max_cache_size);
+  ADD_CACHE_SIZE_TEST_FUNC ("/cache-size-provider/caches-max-cache-size",
+                            test_cache_size_provider_caches_max_cache_size);
+
+#undef ADD_CACHE_SIZE_TEST_FUNC
+
+  return g_test_run ();
+}

--- a/tests/daemon/test-cache-version-provider.c
+++ b/tests/daemon/test-cache-version-provider.c
@@ -65,6 +65,7 @@ setup (Fixture      *fixture,
 {
   GFileIOStream *stream;
   fixture->tmp_file = g_file_new_tmp (TESTING_FILE_PATH, &stream, NULL);
+  g_object_unref (stream);
   fixture->tmp_path = g_file_get_path (fixture->tmp_file);
 
   fixture->key_file = g_key_file_new ();

--- a/tests/daemon/test-cache-version-provider.c
+++ b/tests/daemon/test-cache-version-provider.c
@@ -89,7 +89,7 @@ static void
 test_cache_version_provider_new_succeeds (Fixture      *fixture,
                                           gconstpointer unused)
 {
-  g_assert (fixture->version_provider != NULL);
+  g_assert_nonnull (fixture->version_provider);
 }
 
 static void

--- a/tests/daemon/test-cache-version-provider.c
+++ b/tests/daemon/test-cache-version-provider.c
@@ -31,7 +31,6 @@
  "[cache_version_info]\n" \
  "version=40\n"
 
-#define SECOND_VERSION 42
 #define SECOND_KEY_FILE \
  "[cache_version_info]\n" \
  "version=42\n"

--- a/tests/daemon/test-network-send-provider.c
+++ b/tests/daemon/test-network-send-provider.c
@@ -97,7 +97,7 @@ static void
 test_network_send_provider_new_succeeds (Fixture      *fixture,
                                          gconstpointer unused)
 {
-  g_assert (fixture->network_send_provider != NULL);
+  g_assert_nonnull (fixture->network_send_provider);
 }
 
 static void

--- a/tests/daemon/test-permissions-provider.c
+++ b/tests/daemon/test-permissions-provider.c
@@ -38,24 +38,34 @@
 #define PERMISSIONS_CONFIG_FILE_ENABLED_TEST \
   "[global]\n" \
   "enabled=true\n" \
+  "uploading_enabled=true\n" \
   "environment=test"
 #define PERMISSIONS_CONFIG_FILE_DISABLED_TEST \
   "[global]\n" \
   "enabled=false\n" \
+  "uploading_enabled=true\n" \
+  "environment=test"
+#define PERMISSIONS_CONFIG_FILE_UPLOADING_DISABLED_TEST \
+  "[global]\n" \
+  "enabled=true\n" \
+  "uploading_enabled=false\n" \
   "environment=test"
 #define PERMISSIONS_CONFIG_FILE_INVALID \
   "lavubeu;f'w943ty[jdn;fbl\n"
 #define PERMISSIONS_CONFIG_FILE_ENABLED_DEV \
   "[global]\n" \
   "enabled=true\n" \
+  "uploading_enabled=true\n" \
   "environment=dev"
 #define PERMISSIONS_CONFIG_FILE_ENABLED_PRODUCTION \
   "[global]\n" \
   "enabled=true\n" \
+  "uploading_enabled=true\n" \
   "environment=production"
 #define PERMISSIONS_CONFIG_FILE_ENABLED_INVALID_ENVIRONMENT \
   "[global]\n" \
   "enabled=true\n" \
+  "uploading_enabled=true\n" \
   "environment=invalid"
 #define OSTREE_CONFIG_FILE_STAGING_URL \
   "[core]\n" \
@@ -296,6 +306,34 @@ test_permissions_provider_get_daemon_enabled_fallback (Fixture      *fixture,
 }
 
 static void
+test_permissions_provider_get_uploading_enabled (Fixture      *fixture,
+                                                 gconstpointer unused)
+{
+  gboolean uploading_enabled =
+    emer_permissions_provider_get_uploading_enabled (fixture->test_object);
+  g_assert_true (uploading_enabled);
+}
+
+static void
+test_permissions_provider_get_uploading_enabled_false (Fixture      *fixture,
+                                                       gconstpointer unused)
+{
+  gboolean uploading_enabled =
+    emer_permissions_provider_get_uploading_enabled (fixture->test_object);
+  g_assert_false (uploading_enabled);
+}
+
+static void
+test_permissions_provider_get_uploading_enabled_fallback (Fixture      *fixture,
+                                                          gconstpointer unused)
+{
+  gboolean uploading_enabled =
+    emer_permissions_provider_get_uploading_enabled (fixture->test_object);
+  g_assert_true (uploading_enabled);
+  g_test_assert_expected_messages ();
+}
+
+static void
 test_permissions_provider_get_environment_test (Fixture      *fixture,
                                                 gconstpointer unused)
 {
@@ -433,6 +471,18 @@ main (int                argc,
                                  PERMISSIONS_CONFIG_FILE_INVALID,
                                  setup_invalid_file,
                                  test_permissions_provider_get_daemon_enabled_fallback);
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/get-uploading-enabled/enabled",
+                                 PERMISSIONS_CONFIG_FILE_ENABLED_TEST,
+                                 setup_with_config_file,
+                                 test_permissions_provider_get_uploading_enabled);
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/get-uploading-enabled/disabled",
+                                 PERMISSIONS_CONFIG_FILE_UPLOADING_DISABLED_TEST,
+                                 setup_with_config_file,
+                                 test_permissions_provider_get_uploading_enabled_false);
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/get-uploading-enabled/invalid-file",
+                                 PERMISSIONS_CONFIG_FILE_INVALID,
+                                 setup_invalid_file,
+                                 test_permissions_provider_get_uploading_enabled_fallback);
   ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/get-environment/test",
                                  PERMISSIONS_CONFIG_FILE_ENABLED_TEST,
                                  setup_with_config_file,

--- a/tests/daemon/test-permissions-provider.c
+++ b/tests/daemon/test-permissions-provider.c
@@ -43,7 +43,7 @@
   "[global]\n" \
   "enabled=false\n" \
   "environment=test"
-#define PERMISSIONS_CONFIG_FILE_INVALID_ENVIRONMENT \
+#define PERMISSIONS_CONFIG_FILE_INVALID \
   "lavubeu;f'w943ty[jdn;fbl\n"
 #define PERMISSIONS_CONFIG_FILE_ENABLED_DEV \
   "[global]\n" \
@@ -418,7 +418,7 @@ main (int                argc,
                                  NULL, setup_with_config_file,
                                  test_permissions_provider_new);
   ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/new/invalid-permissions-config-file",
-                                 PERMISSIONS_CONFIG_FILE_INVALID_ENVIRONMENT,
+                                 PERMISSIONS_CONFIG_FILE_INVALID,
                                  setup_invalid_file,
                                  test_permissions_provider_new_invalid_file);
   ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/get-daemon-enabled/enabled",
@@ -430,7 +430,7 @@ main (int                argc,
                                  setup_with_config_file,
                                  test_permissions_provider_get_daemon_enabled_false);
   ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/get-daemon-enabled/invalid-permissions-config-file",
-                                 PERMISSIONS_CONFIG_FILE_INVALID_ENVIRONMENT,
+                                 PERMISSIONS_CONFIG_FILE_INVALID,
                                  setup_invalid_file,
                                  test_permissions_provider_get_daemon_enabled_fallback);
   ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/get-environment/test",

--- a/tests/daemon/test-permissions-provider.c
+++ b/tests/daemon/test-permissions-provider.c
@@ -128,16 +128,16 @@ write_config_file (GFileIOStream *stream,
 
   if (contents != NULL)
     {
-      g_assert (g_output_stream_write_all (ostream, contents,
-                                           strlen (contents),
-                                           NULL /* bytes written */,
-                                           NULL, NULL));
+      gboolean write_succeeded =
+        g_output_stream_write_all (ostream, contents, strlen (contents),
+                                   NULL /* bytes written */, NULL, NULL);
+      g_assert_true (write_succeeded);
       g_object_unref (stream);
     }
   else
     {
       g_object_unref (stream);
-      g_assert (g_file_delete (config_file, NULL, NULL));
+      g_assert_true (g_file_delete (config_file, NULL, NULL));
     }
 
   return g_file_get_path (config_file);
@@ -287,21 +287,27 @@ static void
 test_permissions_provider_get_daemon_enabled (Fixture      *fixture,
                                               gconstpointer unused)
 {
-  g_assert (emer_permissions_provider_get_daemon_enabled (fixture->test_object));
+  gboolean daemon_enabled =
+    emer_permissions_provider_get_daemon_enabled (fixture->test_object);
+  g_assert_true (daemon_enabled);
 }
 
 static void
 test_permissions_provider_get_daemon_enabled_false (Fixture      *fixture,
                                                     gconstpointer unused)
 {
-  g_assert_false (emer_permissions_provider_get_daemon_enabled (fixture->test_object));
+  gboolean daemon_enabled =
+    emer_permissions_provider_get_daemon_enabled (fixture->test_object);
+  g_assert_false (daemon_enabled);
 }
 
 static void
 test_permissions_provider_get_daemon_enabled_fallback (Fixture      *fixture,
                                                        gconstpointer unused)
 {
-  g_assert_false (emer_permissions_provider_get_daemon_enabled (fixture->test_object));
+  gboolean daemon_enabled =
+    emer_permissions_provider_get_daemon_enabled (fixture->test_object);
+  g_assert_false (daemon_enabled);
   g_test_assert_expected_messages ();
 }
 
@@ -389,7 +395,7 @@ test_permissions_provider_set_daemon_enabled (Fixture      *fixture,
 {
   g_idle_add ((GSourceFunc) set_daemon_enabled_false_idle, fixture);
   g_main_loop_run (fixture->main_loop);
-  g_assert (fixture->notify_daemon_called);
+  g_assert_true (fixture->notify_daemon_called);
   g_assert_false (fixture->notify_daemon_called_with);
 }
 
@@ -411,9 +417,11 @@ test_permissions_provider_set_daemon_enabled_updates_config_file (Fixture      *
                                                                   gconstpointer unused)
 {
   gchar *contents;
-  g_assert (g_file_load_contents (fixture->permissions_config_file, NULL,
-                                  &contents, NULL, NULL, NULL));
-  g_assert (strstr (contents, "enabled=true"));
+  gboolean loaded_file =
+    g_file_load_contents (fixture->permissions_config_file, NULL, &contents,
+                          NULL, NULL, NULL);
+  g_assert_true (loaded_file);
+  g_assert_nonnull (strstr (contents, "enabled=true"));
   g_free (contents);
 
   g_idle_add ((GSourceFunc) set_daemon_enabled_false_idle, fixture);
@@ -433,8 +441,10 @@ test_permissions_provider_set_daemon_enabled_updates_config_file (Fixture      *
 
   g_object_unref (monitor);
 
-  g_assert (g_file_load_contents (fixture->permissions_config_file, NULL,
-                                  &contents, NULL, NULL, NULL));
+  loaded_file =
+    g_file_load_contents (fixture->permissions_config_file, NULL, &contents,
+                          NULL, NULL, NULL);
+  g_assert_true (loaded_file);
   g_assert_nonnull (strstr (contents, "enabled=false"));
   g_free (contents);
 }

--- a/tests/daemon/test-permissions-provider.c
+++ b/tests/daemon/test-permissions-provider.c
@@ -458,14 +458,14 @@ main (int                argc,
 #define ADD_PERMISSIONS_PROVIDER_TEST(path, file_contents, setup, test_func) \
   g_test_add ((path), Fixture, (file_contents), (setup), (test_func), teardown);
 
-  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/new/existing-permissions-config-file",
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/new/valid-file",
                                  PERMISSIONS_CONFIG_FILE_ENABLED_TEST,
                                  setup_with_config_file,
                                  test_permissions_provider_new);
-  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/new/absent-permissions-config-file",
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/new/absent-file",
                                  NULL, setup_with_config_file,
                                  test_permissions_provider_new);
-  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/new/invalid-permissions-config-file",
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/new/invalid-file",
                                  PERMISSIONS_CONFIG_FILE_INVALID,
                                  setup_invalid_file,
                                  test_permissions_provider_new_invalid_file);
@@ -477,7 +477,7 @@ main (int                argc,
                                  PERMISSIONS_CONFIG_FILE_DISABLED_TEST,
                                  setup_with_config_file,
                                  test_permissions_provider_get_daemon_enabled_false);
-  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/get-daemon-enabled/invalid-permissions-config-file",
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/get-daemon-enabled/invalid-file",
                                  PERMISSIONS_CONFIG_FILE_INVALID,
                                  setup_invalid_file,
                                  test_permissions_provider_get_daemon_enabled_fallback);

--- a/tests/daemon/test-permissions-provider.c
+++ b/tests/daemon/test-permissions-provider.c
@@ -98,13 +98,13 @@ typedef struct {
 /* Callback for notify::daemon-enabled that records what it was called with and
 quits the main loop so the test can continue. */
 static void
-on_notify_daemon_enabled (GObject    *test_object,
-                          GParamSpec *pspec,
-                          Fixture    *fixture)
+on_notify_daemon_enabled (EmerPermissionsProvider *permissions_provider,
+                          GParamSpec              *pspec,
+                          Fixture                 *fixture)
 {
   if (!fixture->notify_daemon_called)
     fixture->notify_daemon_called_with =
-      emer_permissions_provider_get_daemon_enabled (EMER_PERMISSIONS_PROVIDER (test_object));
+      emer_permissions_provider_get_daemon_enabled (permissions_provider);
   fixture->notify_daemon_called = TRUE;
   g_main_loop_quit (fixture->main_loop);
 }

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -104,7 +104,7 @@ write_mock_system_boot_id_file (void)
 }
 
 static void
-write_default_cache_version_key_file_to_disk (void)
+write_default_cache_version_key_file (void)
 {
   GKeyFile *key_file = g_key_file_new ();
   g_assert (g_key_file_load_from_data (key_file,
@@ -161,7 +161,7 @@ setup (gboolean     *unused,
   g_mkdir (TEST_DIRECTORY, 0777); // All permissions are granted by 0777.
   write_cache_size_file ();
   write_mock_system_boot_id_file ();
-  write_default_cache_version_key_file_to_disk ();
+  write_default_cache_version_key_file ();
   write_empty_metrics_files ();
 }
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -185,6 +185,7 @@ make_testing_cache (void)
   g_object_unref (boot_id_provider);
   g_object_unref (cache_version_provider);
   g_assert_no_error (error);
+
   return cache;
 }
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -180,11 +180,11 @@ make_testing_cache (void)
                                     cache_size_provider, boot_id_provider,
                                     cache_version_provider,
                                     TEST_UPDATE_OFFSET_INTERVAL);
+  g_assert_no_error (error);
 
   g_object_unref (cache_size_provider);
   g_object_unref (boot_id_provider);
   g_object_unref (cache_version_provider);
-  g_assert_no_error (error);
 
   return cache;
 }

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -114,6 +114,7 @@ write_default_cache_version_key_file_to_disk (void)
   g_assert (g_key_file_save_to_file (key_file,
                                      TEST_DIRECTORY TEST_CACHE_VERSION_FILE,
                                      NULL));
+  g_key_file_unref (key_file);
 }
 
 static void

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -1114,6 +1114,7 @@ static void
 test_persistent_cache_store_when_full_succeeds (gboolean     *unused,
                                                 gconstpointer dontuseme)
 {
+  GError *error = NULL;
   EmerCacheSizeProvider *cache_size_provider =
     emer_cache_size_provider_new_full (TEST_DIRECTORY TEST_CACHE_SIZE_FILE);
   EmerBootIdProvider *boot_id_provider =
@@ -1121,10 +1122,11 @@ test_persistent_cache_store_when_full_succeeds (gboolean     *unused,
   EmerCacheVersionProvider *cache_version_provider =
     emer_cache_version_provider_new_full (TEST_DIRECTORY TEST_CACHE_VERSION_FILE);
   EmerPersistentCache *cache =
-    emer_persistent_cache_new_full (NULL, NULL, TEST_DIRECTORY,
+    emer_persistent_cache_new_full (NULL, &error, TEST_DIRECTORY,
                                     cache_size_provider, boot_id_provider,
                                     cache_version_provider,
                                     TEST_UPDATE_OFFSET_INTERVAL);
+  g_assert_no_error (error);
 
   g_object_unref (cache_version_provider);
   g_object_unref (boot_id_provider);
@@ -1403,6 +1405,7 @@ static void
 test_persistent_cache_purges_when_out_of_date_succeeds (gboolean     *unused,
                                                         gconstpointer dontuseme)
 {
+  GError *error = NULL;
   EmerCacheSizeProvider *cache_size_provider =
     emer_cache_size_provider_new_full (TEST_DIRECTORY TEST_CACHE_SIZE_FILE);
   EmerBootIdProvider *boot_id_provider =
@@ -1410,10 +1413,11 @@ test_persistent_cache_purges_when_out_of_date_succeeds (gboolean     *unused,
   EmerCacheVersionProvider *cache_version_provider =
     emer_cache_version_provider_new_full (TEST_DIRECTORY TEST_CACHE_VERSION_FILE);
   EmerPersistentCache *cache =
-    emer_persistent_cache_new_full (NULL, NULL, TEST_DIRECTORY,
+    emer_persistent_cache_new_full (NULL, &error, TEST_DIRECTORY,
                                     cache_size_provider, boot_id_provider,
                                     cache_version_provider,
                                     TEST_UPDATE_OFFSET_INTERVAL);
+  g_assert_no_error (error);
 
   g_object_unref (cache_size_provider);
   g_object_unref (boot_id_provider);
@@ -1429,7 +1433,6 @@ test_persistent_cache_purges_when_out_of_date_succeeds (gboolean     *unused,
   gint current_version;
   g_assert (emer_cache_version_provider_get_version (cache_version_provider,
                                                      &current_version));
-  GError *error = NULL;
   g_assert (emer_cache_version_provider_set_version (cache_version_provider,
                                                      current_version - 1,
                                                      &error));

--- a/tools/Makefile.am.inc
+++ b/tools/Makefile.am.inc
@@ -43,13 +43,30 @@ tools_print_persistent_cache_SOURCES = \
 tools_print_persistent_cache_CPPFLAGS = $(PERSISTENT_CACHE_TOOL_FLAGS)
 tools_print_persistent_cache_LDADD = $(PERSISTENT_CACHE_TOOL_LIBS)
 
-dist_bin_SCRIPTS = tools/eos-select-metrics-env
-EXTRA_DIST += tools/eos-select-metrics-env.in
-CLEANFILES += tools/eos-select-metrics-env
+dist_bin_SCRIPTS = \
+	tools/eos-enable-metrics-uploading \
+	tools/eos-select-metrics-env \
+	$(NULL)
+EXTRA_DIST += \
+	tools/eos-enable-metrics-uploading.in \
+	tools/eos-select-metrics-env.in \
+	$(NULL)
+CLEANFILES += \
+	tools/eos-enable-metrics-uploading \
+	tools/eos-select-metrics-env \
+	$(NULL)
 
 substitute_permissions_file = sed \
 	-e 's|@permissions_file[@]|$(permissions_file)|g' \
 	$(NULL)
+
+tools/eos-enable-metrics-uploading: tools/eos-enable-metrics-uploading.in Makefile
+	$(AM_V_GEN)$(MKDIR_P) tools && \
+	rm -f $@ $@.tmp && \
+	$(substitute_permissions_file) $< >$@.tmp && \
+	chmod +x,a-w $@.tmp && \
+	mv $@.tmp $@
+
 tools/eos-select-metrics-env: tools/eos-select-metrics-env.in Makefile
 	$(AM_V_GEN)$(MKDIR_P) tools && \
 	rm -f $@ $@.tmp && \

--- a/tools/Makefile.am.inc
+++ b/tools/Makefile.am.inc
@@ -28,6 +28,7 @@ PERSISTENT_CACHE_TOOL_FLAGS = \
 	-I$(top_srcdir)/tools \
 	-DPERSISTENT_CACHE_DIR="\"$(persistentcachedir)\"" \
 	-D_POSIX_C_SOURCE=200112L \
+	-DCONFIG_DIR="\"$(configdir)\"" \
 	$(NULL)
 PERSISTENT_CACHE_TOOL_LIBS = @EOS_EVENT_RECORDER_DAEMON_LIBS@
 

--- a/tools/Makefile.am.inc
+++ b/tools/Makefile.am.inc
@@ -26,9 +26,9 @@ PERSISTENT_CACHE_TOOL_FLAGS = \
 	-I$(top_srcdir)/daemon \
 	-I$(top_srcdir)/shared \
 	-I$(top_srcdir)/tools \
-	-DPERSISTENT_CACHE_DIR="\"$(persistentcachedir)\"" \
 	-D_POSIX_C_SOURCE=200112L \
 	-DCONFIG_DIR="\"$(configdir)\"" \
+	-DPERSISTENT_CACHE_DIR="\"$(persistentcachedir)\"" \
 	$(NULL)
 PERSISTENT_CACHE_TOOL_LIBS = @EOS_EVENT_RECORDER_DAEMON_LIBS@
 

--- a/tools/Makefile.am.inc
+++ b/tools/Makefile.am.inc
@@ -34,6 +34,7 @@ PERSISTENT_CACHE_TOOL_LIBS = @EOS_EVENT_RECORDER_DAEMON_LIBS@
 
 tools_print_persistent_cache_SOURCES = \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
+	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
 	daemon/emer-cache-version-provider.c daemon/emer-cache-version-provider.h \
 	daemon/emer-persistent-cache.c daemon/emer-persistent-cache.h \
 	shared/metrics-util.c shared/metrics-util.h \

--- a/tools/eos-enable-metrics-uploading.in
+++ b/tools/eos-enable-metrics-uploading.in
@@ -1,0 +1,38 @@
+#!/bin/bash -e
+
+# Copyright 2015 Endless Mobile, Inc.
+
+# This file is part of eos-event-recorder-daemon.
+#
+# eos-event-recorder-daemon is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or (at your
+# option) any later version.
+#
+# eos-event-recorder-daemon is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with eos-event-recorder-daemon.  If not, see
+# <http://www.gnu.org/licenses/>.
+
+if [ ! -f @permissions_file@ ]; then
+    echo "Configuration file at @permissions_file@ not found or permission denied." >&2
+    exit 1
+fi
+
+case "$1" in
+    -e|--enable)
+         UPLOADING_ENABLED=true
+         ;;
+    -d|--disable)
+         UPLOADING_ENABLED=false
+         ;;
+    *)
+        echo "Invalid flag "$1"; expected --enable or --disable." >&2
+        exit 2
+esac
+
+sed --in-place="s/\(uploading_enabled *= *\).*/\1"$UPLOADING_ENABLED"/" @permissions_file@

--- a/tools/eos-select-metrics-env.in
+++ b/tools/eos-select-metrics-env.in
@@ -25,7 +25,7 @@ fi
 
 ENVIRONMENT="$1"
 if [ "$ENVIRONMENT" == "dev" ] || [ "$ENVIRONMENT" == "test" ] || [ "$ENVIRONMENT" == "production" ]; then
-    sed -i "s/\(environment *= *\).*/\1"$ENVIRONMENT"/" @permissions_file@
+    sed --in-place="s/\(environment *= *\).*/\1"$ENVIRONMENT"/" @permissions_file@
 else
     echo "Invalid environment "$ENVIRONMENT" passed in as parameter." >&2
     exit 2

--- a/tools/eos-select-metrics-env.in
+++ b/tools/eos-select-metrics-env.in
@@ -23,10 +23,10 @@ if [ ! -f @permissions_file@ ]; then
     exit 1
 fi
 
-ENVIRONMENT=$1
+ENVIRONMENT="$1"
 if [ "$ENVIRONMENT" == "dev" ] || [ "$ENVIRONMENT" == "test" ] || [ "$ENVIRONMENT" == "production" ]; then
-    sed -i "s/\(environment *= *\).*/\1$ENVIRONMENT/" @permissions_file@
+    sed -i "s/\(environment *= *\).*/\1"$ENVIRONMENT"/" @permissions_file@
 else
-    echo "Invalid environment $ENVIRONMENT passed in as parameter." >&2
+    echo "Invalid environment "$ENVIRONMENT" passed in as parameter." >&2
     exit 2
 fi

--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -29,7 +29,10 @@
 #include "shared/metrics-util.h"
 
 #define TMP_DIR_TEMPLATE "persistent-cache-XXXXXX"
-#define MAX_CACHE_SIZE G_GUINT64_CONSTANT (92160) // 90 kB
+
+// TODO: Replace this with a reasonable value once it is used.
+#define MAX_BYTES_TO_READ G_GUINT64_CONSTANT (0)
+
 #define CACHE_VERSION_FILENAME "local_version_file"
 #define BOOT_OFFSET_UPDATE_INTERVAL (60u * 60u) // 1 hour
 
@@ -417,6 +420,7 @@ make_persistent_cache (GFile *directory)
   gchar *directory_path_with_slash = g_strconcat (directory_path, "/", NULL);
   g_free (directory_path);
 
+  EmerCacheSizeProvider *cache_size_provider = emer_cache_size_provider_new ();
   EmerBootIdProvider *boot_id_provider = emer_boot_id_provider_new ();
   gchar *cache_version_path =
     g_strconcat (directory_path_with_slash, CACHE_VERSION_FILENAME, NULL);
@@ -426,10 +430,12 @@ make_persistent_cache (GFile *directory)
 
   EmerPersistentCache *persistent_cache =
     emer_persistent_cache_new_full (NULL /* GCancellable */, &error,
-                                    directory_path_with_slash, MAX_CACHE_SIZE,
-                                    boot_id_provider, cache_version_provider,
+                                    directory_path_with_slash,
+                                    cache_size_provider, boot_id_provider,
+                                    cache_version_provider,
                                     BOOT_OFFSET_UPDATE_INTERVAL);
   g_free (directory_path_with_slash);
+  g_object_unref (cache_size_provider);
 
   if (persistent_cache == NULL)
     g_error_free (error);
@@ -500,7 +506,7 @@ main (int   argc,
   gboolean drain_succeeded =
     emer_persistent_cache_drain_metrics (persistent_cache, &singulars,
                                          &aggregates, &sequences,
-                                         MAX_CACHE_SIZE);
+                                         MAX_BYTES_TO_READ);
 
   g_object_unref (persistent_cache);
 

--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -436,6 +436,8 @@ make_persistent_cache (GFile *directory)
                                     BOOT_OFFSET_UPDATE_INTERVAL);
   g_free (directory_path_with_slash);
   g_object_unref (cache_size_provider);
+  g_object_unref (boot_id_provider);
+  g_object_unref (cache_version_provider);
 
   if (persistent_cache == NULL)
     g_error_free (error);

--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -422,6 +422,7 @@ make_persistent_cache (GFile *directory)
 
   EmerCacheSizeProvider *cache_size_provider = emer_cache_size_provider_new ();
   EmerBootIdProvider *boot_id_provider = emer_boot_id_provider_new ();
+
   gchar *cache_version_path =
     g_strconcat (directory_path_with_slash, CACHE_VERSION_FILENAME, NULL);
   EmerCacheVersionProvider *cache_version_provider =


### PR DESCRIPTION
Read the maximum persistent cache size out of the key file
/etc/metrics/cache-size.conf rather than hard-coding it. Introduce a
cache size provider to abstract away the details of reading from the key
file. This functionality will allow us to increase the maximum size of
the persistent cache for the clients we send on the imminent bus trip
without affecting any other clients.

[endlessm/eos-sdk#3151]