### PR TITLE
Fix eos-select-metrics-env script.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,7 @@ noinst_PROGRAMS =
 
 persistentcachedir=$(localstatedir)/cache/metrics/
 configdir=$(sysconfdir)/metrics/
+permissions_file=$(configdir)eos-metrics-permissions.conf
 
 # chown and chgrp are not allowed unless you are root or under some specific
 # other conditions that may not be met every time you run 'make'.

--- a/daemon/Makefile.am.inc
+++ b/daemon/Makefile.am.inc
@@ -52,6 +52,7 @@ eos_metrics_event_recorder_CPPFLAGS = \
 	$(EOS_EVENT_RECORDER_DAEMON_CFLAGS) \
 	-D_POSIX_C_SOURCE=200112L \
 	-DCONFIG_DIR="\"$(configdir)\"" \
+	-DPERMISSIONS_FILE="\"$(permissions_file)\"" \
 	-DPERSISTENT_CACHE_DIR="\"$(persistentcachedir)\"" \
 	$(NULL)
 

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -55,8 +55,6 @@ G_DEFINE_TYPE_WITH_PRIVATE (EmerPermissionsProvider, emer_permissions_provider, 
   DAEMON_UPLOADING_ENABLED_KEY_NAME "=true\n" \
   DAEMON_ENVIRONMENT_KEY_NAME "=production\n"
 
-#define PERMISSIONS_FILE CONFIG_DIR "eos-metrics-permissions.conf"
-
 enum
 {
   PROP_0,

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -32,6 +32,7 @@ DAEMON_TEST_FLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/daemon \
 	-DCONFIG_DIR="\"$(configdir)\"" \
+	-DPERMISSIONS_FILE="\"$(permissions_file)\"" \
 	-DPERSISTENT_CACHE_DIR="\"$(persistentcachedir)\"" \
 	$(NULL)
 DAEMON_TEST_LIBS = @EOS_EVENT_RECORDER_DAEMON_LIBS@

--- a/tools/Makefile.am.inc
+++ b/tools/Makefile.am.inc
@@ -28,6 +28,7 @@ PERSISTENT_CACHE_TOOL_FLAGS = \
 	-I$(top_srcdir)/tools \
 	-D_POSIX_C_SOURCE=200112L \
 	-DCONFIG_DIR="\"$(configdir)\"" \
+	-DPERMISSIONS_FILE="\"$(permissions_file)\"" \
 	-DPERSISTENT_CACHE_DIR="\"$(persistentcachedir)\"" \
 	$(NULL)
 PERSISTENT_CACHE_TOOL_LIBS = @EOS_EVENT_RECORDER_DAEMON_LIBS@

--- a/tools/eos-select-metrics-env.in
+++ b/tools/eos-select-metrics-env.in
@@ -25,7 +25,7 @@ fi
 
 ENVIRONMENT="$1"
 if [ "$ENVIRONMENT" == "dev" ] || [ "$ENVIRONMENT" == "test" ] || [ "$ENVIRONMENT" == "production" ]; then
-    sed --in-place="s/\(environment *= *\).*/\1"$ENVIRONMENT"/" @permissions_file@
+    sed --in-place "s/\(environment *= *\).*/\1"$ENVIRONMENT"/" @permissions_file@
 else
     echo "Invalid environment "$ENVIRONMENT" passed in as parameter." >&2
     exit 2


### PR DESCRIPTION
Add permissions_file back as a shared variable, and correct sed syntax.

[endlessm/eos-sdk#3124]