### PR TITLE
List python3-dbus as a build-time dependency.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Build-Depends: autotools-dev,
                libpolkit-gobject-1-dev,
                libsoup2.4-dev (>= 2.42),
                pkg-config,
+               python3-dbus,
                python3-dbusmock,
                systemd,
                uuid-dev


### PR DESCRIPTION
[endlessm/eos-sdk#3168]