### PR TITLE
Add emer_daemon_upload_events.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,6 +154,9 @@ PKG_CHECK_MODULES([EOS_EVENT_RECORDER_DAEMON], [$EMER_REQUIRED_MODULES])
 # This indicates a required dbus mocking interface for unit testing.
 AX_PYTHON_MODULE_VERSION([dbusmock], 0.10)
 
+# The Python dbus module is required for unit testing.
+AX_PYTHON_MODULE([dbus])
+
 # Code coverage
 # -------------
 EOS_COVERAGE_REPORT([c])

--- a/daemon/emer-boot-id-provider.c
+++ b/daemon/emer-boot-id-provider.c
@@ -22,7 +22,6 @@
 
 #include "emer-boot-id-provider.h"
 
-#include <stdio.h>
 #include <string.h>
 #include <uuid/uuid.h>
 

--- a/daemon/emer-cache-version-provider.c
+++ b/daemon/emer-cache-version-provider.c
@@ -22,8 +22,6 @@
 
 #include "emer-cache-version-provider.h"
 
-#include <stdio.h>
-
 typedef struct EmerCacheVersionProviderPrivate
 {
   gchar *path;

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -290,11 +290,11 @@ get_http_request_uri (EmerDaemon   *self,
 {
   EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
 
-  gchar *checksum_string = g_compute_checksum_for_data (G_CHECKSUM_SHA512, data,
-                                                        length);
+  gchar *checksum =
+    g_compute_checksum_for_data (G_CHECKSUM_SHA512, data, length);
   gchar *http_request_uri_string =
-    g_strconcat (priv->server_uri, checksum_string, NULL);
-  g_free (checksum_string);
+    g_strconcat (priv->server_uri, checksum, NULL);
+  g_free (checksum);
 
   SoupURI *http_request_uri = soup_uri_new (http_request_uri_string);
 
@@ -761,8 +761,8 @@ flush_to_persistent_cache (EmerDaemon *self)
 }
 
 static void
-handle_network_monitor_can_reach (GNetworkMonitor *source_object,
-                                  GAsyncResult    *res,
+handle_network_monitor_can_reach (GNetworkMonitor *network_monitor,
+                                  GAsyncResult    *result,
                                   EmerDaemon      *self)
 {
   EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
@@ -773,7 +773,8 @@ handle_network_monitor_can_reach (GNetworkMonitor *source_object,
   GTask *upload_task = g_queue_pop_head (priv->upload_queue);
 
   GError *error = NULL;
-  if (!g_network_monitor_can_reach_finish (priv->network_monitor, res, &error))
+  if (!g_network_monitor_can_reach_finish (priv->network_monitor, result,
+                                           &error))
     {
       flush_to_persistent_cache (self);
       g_task_return_error (upload_task, error);

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -832,7 +832,6 @@ get_ping_socket (EmerDaemon *self)
   {
     g_error ("Invalid server URI '%s' could not be parsed because: %s.",
              priv->server_uri, error->message);
-    g_error_free (error);
   }
 
   return ping_socket;

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -577,24 +577,15 @@ drain_persistent_cache (EmerDaemonPrivate *priv,
     return FALSE;
 
   for (gint i = 0; list_of_singulars[i] != NULL; i++)
-    {
-      g_variant_builder_add_value (singulars_builder, list_of_singulars[i]);
-      g_variant_unref (list_of_singulars[i]);
-    }
+    g_variant_builder_add_value (singulars_builder, list_of_singulars[i]);
   g_free (list_of_singulars);
 
   for (gint i = 0; list_of_aggregates[i] != NULL; i++)
-    {
-      g_variant_builder_add_value (aggregates_builder, list_of_aggregates[i]);
-      g_variant_unref (list_of_aggregates[i]);
-    }
+    g_variant_builder_add_value (aggregates_builder, list_of_aggregates[i]);
   g_free (list_of_aggregates);
 
   for (gint i = 0; list_of_sequences[i] != NULL; i++)
-    {
-      g_variant_builder_add_value (sequences_builder, list_of_sequences[i]);
-      g_variant_unref (list_of_sequences[i]);
-    }
+    g_variant_builder_add_value (sequences_builder, list_of_sequences[i]);
   g_free (list_of_sequences);
 
   return TRUE;

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -863,7 +863,7 @@ dequeue_and_do_upload (EmerDaemon  *self,
 
   if (priv->use_default_server_uri)
     {
-      g_clear_pointer (&priv->server_uri, g_free);
+      g_free (priv->server_uri);
       priv->server_uri =
         g_strconcat ("https://", environment, ".metrics.endlessm.com/"
                      CLIENT_VERSION_NUMBER "/", NULL);
@@ -1246,7 +1246,7 @@ emer_daemon_constructed (GObject *object)
     emer_permissions_provider_get_environment (priv->permissions_provider);
   schedule_upload (self, environment);
 
-  g_clear_pointer (&environment, g_free);
+  g_free (environment);
 
   G_OBJECT_CLASS (emer_daemon_parent_class)->constructed (object);
 }

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -219,8 +219,8 @@ release_shutdown_inhibitor (EmerDaemon *self)
 }
 
 static void
-uuid_from_gvariant (GVariant *event_id,
-                    uuid_t    uuid)
+uuid_from_variant (GVariant *event_id,
+                   uuid_t    uuid)
 {
   gsize event_id_length;
   g_variant_ref_sink (event_id);
@@ -1518,7 +1518,7 @@ emer_daemon_record_singular_event (EmerDaemon *self,
         priv->num_singulars_buffered;
       priv->num_singulars_buffered++;
       singular->user_id = user_id;
-      uuid_from_gvariant (event_id, singular->event_id);
+      uuid_from_variant (event_id, singular->event_id);
       GVariant *nullable_payload = get_nullable_payload (has_payload, payload);
       EventValue event_value = { relative_timestamp, nullable_payload };
       singular->event_value = event_value;
@@ -1560,7 +1560,7 @@ emer_daemon_record_aggregate_event (EmerDaemon *self,
       priv->num_aggregates_buffered++;
       SingularEvent singular;
       singular.user_id = user_id;
-      uuid_from_gvariant (event_id, singular.event_id);
+      uuid_from_variant (event_id, singular.event_id);
       aggregate->num_events = num_events;
       GVariant *nullable_payload = get_nullable_payload (has_payload, payload);
       EventValue event_value = { relative_timestamp, nullable_payload };
@@ -1600,7 +1600,7 @@ emer_daemon_record_event_sequence (EmerDaemon *self,
       priv->num_sequences_buffered++;
 
       event_sequence->user_id = user_id;
-      uuid_from_gvariant (event_id, event_sequence->event_id);
+      uuid_from_variant (event_id, event_sequence->event_id);
 
       g_variant_ref_sink (event_values);
       gsize num_events = g_variant_n_children (event_values);

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -795,7 +795,7 @@ upload_events (GNetworkMonitor *source_object,
   SoupURI *https_request_uri =
     get_https_request_uri (self, serialized_request_body, request_body_length);
   SoupMessage *https_message =
-    soup_message_new_from_uri ("PUT",  https_request_uri);
+    soup_message_new_from_uri ("PUT", https_request_uri);
   soup_uri_free (https_request_uri);
 
   soup_message_set_request (https_message, "application/octet-stream",

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -28,6 +28,7 @@
 #include <byteswap.h>
 #include <string.h>
 #include <time.h>
+#include <uuid/uuid.h>
 
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
@@ -35,7 +36,6 @@
 #include <glib-object.h>
 #include <glib/gstdio.h>
 #include <libsoup/soup.h>
-#include <uuid/uuid.h>
 
 #include <eosmetrics/eosmetrics.h>
 

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -339,7 +339,7 @@ get_updated_request_body (EmerDaemon *self,
                           GVariant   *request_body,
                           GError    **error)
 {
-  gint send_number;
+  gint32 send_number;
   GVariantIter *machine_id_iter;
   GVariantIter *singulars_iter, *aggregates_iter, *sequences_iter;
   g_variant_get (request_body, "(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))",

--- a/daemon/emer-daemon.h
+++ b/daemon/emer-daemon.h
@@ -28,6 +28,7 @@
 #include "emer-permissions-provider.h"
 #include "emer-persistent-cache.h"
 
+#include <gio/gio.h>
 #include <glib-object.h>
 
 G_BEGIN_DECLS
@@ -65,6 +66,8 @@ struct _EmerDaemon
 struct _EmerDaemonClass
 {
   GObjectClass parent_class;
+
+  void (*upload_finished_handler) (EmerDaemon *self);
 };
 
 GType                    emer_daemon_get_type                 (void) G_GNUC_CONST;
@@ -72,6 +75,7 @@ GType                    emer_daemon_get_type                 (void) G_GNUC_CONS
 EmerDaemon *             emer_daemon_new                      (void);
 
 EmerDaemon *             emer_daemon_new_full                 (GRand                   *rand,
+                                                               const gchar             *server_uri,
                                                                guint                    network_send_interval,
                                                                EmerMachineIdProvider   *machine_id_provider,
                                                                EmerNetworkSendProvider *network_send_provider,
@@ -98,6 +102,14 @@ void                     emer_daemon_record_event_sequence    (EmerDaemon       
                                                                guint32                  user_id,
                                                                GVariant                *event_id,
                                                                GVariant                *events);
+
+void                     emer_daemon_upload_events            (EmerDaemon              *self,
+                                                               GAsyncReadyCallback      callback,
+                                                               gpointer                 user_data);
+
+gboolean                 emer_daemon_upload_events_finish     (EmerDaemon              *self,
+                                                               GAsyncResult            *result,
+                                                               GError                 **error);
 
 EmerPermissionsProvider *emer_daemon_get_permissions_provider (EmerDaemon              *self);
 

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -300,6 +300,6 @@ emer_machine_id_provider_get_id (EmerMachineIdProvider *self,
     }
   G_UNLOCK (id_is_valid);
 
-  memcpy(machine_id, priv->id, UUID_LENGTH);
+  uuid_copy (machine_id, priv->id);
   return TRUE;
 }

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -24,7 +24,6 @@
 
 #include "shared/metrics-util.h"
 
-#include <stdio.h>
 #include <string.h>
 #include <uuid/uuid.h>
 #include <glib/gprintf.h>

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -280,7 +280,7 @@ read_machine_id (EmerMachineIdProvider *self)
  */
 gboolean
 emer_machine_id_provider_get_id (EmerMachineIdProvider *self,
-                                 uuid_t                 uuid)
+                                 uuid_t                 machine_id)
 {
   EmerMachineIdProviderPrivate *priv = emer_machine_id_provider_get_instance_private (self);
   static gboolean id_is_valid = FALSE;
@@ -301,6 +301,6 @@ emer_machine_id_provider_get_id (EmerMachineIdProvider *self,
     }
   G_UNLOCK (id_is_valid);
 
-  memcpy(uuid, priv->id, UUID_LENGTH);
+  memcpy(machine_id, priv->id, UUID_LENGTH);
   return TRUE;
 }

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -80,7 +80,9 @@ static GParamSpec *emer_machine_id_provider_props[NPROPS] = { NULL, };
 static const gchar *
 get_id_path (EmerMachineIdProvider *self)
 {
-  EmerMachineIdProviderPrivate *priv = emer_machine_id_provider_get_instance_private (self);
+  EmerMachineIdProviderPrivate *priv =
+    emer_machine_id_provider_get_instance_private (self);
+
   return priv->path;
 }
 
@@ -88,7 +90,9 @@ static void
 set_id_path (EmerMachineIdProvider *self,
              const gchar           *given_path)
 {
-  EmerMachineIdProviderPrivate *priv = emer_machine_id_provider_get_instance_private (self);
+  EmerMachineIdProviderPrivate *priv =
+    emer_machine_id_provider_get_instance_private (self);
+
   priv->path = g_strdup (given_path);
 }
 
@@ -132,7 +136,9 @@ static void
 emer_machine_id_provider_finalize (GObject *object)
 {
   EmerMachineIdProvider *self = EMER_MACHINE_ID_PROVIDER (object);
-  EmerMachineIdProviderPrivate *priv = emer_machine_id_provider_get_instance_private (self);
+  EmerMachineIdProviderPrivate *priv =
+    emer_machine_id_provider_get_instance_private (self);
+
   g_free (priv->path);
 
   G_OBJECT_CLASS (emer_machine_id_provider_parent_class)->finalize (object);
@@ -219,7 +225,8 @@ hyphenate_uuid (gchar *uuid_sans_hyphens)
 static gboolean
 read_machine_id (EmerMachineIdProvider *self)
 {
-  EmerMachineIdProviderPrivate *priv = emer_machine_id_provider_get_instance_private (self);
+  EmerMachineIdProviderPrivate *priv =
+    emer_machine_id_provider_get_instance_private (self);
 
   gchar *machine_id_sans_hyphens;
   gsize machine_id_sans_hyphens_length;
@@ -281,7 +288,9 @@ gboolean
 emer_machine_id_provider_get_id (EmerMachineIdProvider *self,
                                  uuid_t                 machine_id)
 {
-  EmerMachineIdProviderPrivate *priv = emer_machine_id_provider_get_instance_private (self);
+  EmerMachineIdProviderPrivate *priv =
+    emer_machine_id_provider_get_instance_private (self);
+
   static gboolean id_is_valid = FALSE;
   G_LOCK_DEFINE_STATIC (id_is_valid);
 

--- a/daemon/emer-machine-id-provider.h
+++ b/daemon/emer-machine-id-provider.h
@@ -83,7 +83,7 @@ EmerMachineIdProvider *emer_machine_id_provider_new      (void);
 EmerMachineIdProvider *emer_machine_id_provider_new_full (const gchar           *machine_id_file_path);
 
 gboolean               emer_machine_id_provider_get_id   (EmerMachineIdProvider *self,
-                                                          guchar                 uuid[16]);
+                                                          guchar                 machine_id[16]);
 
 G_END_DECLS
 

--- a/daemon/emer-machine-id-provider.h
+++ b/daemon/emer-machine-id-provider.h
@@ -24,6 +24,7 @@
 #define EMER_MACHINE_ID_PROVIDER_H
 
 #include <glib-object.h>
+#include <uuid/uuid.h>
 
 G_BEGIN_DECLS
 
@@ -83,7 +84,7 @@ EmerMachineIdProvider *emer_machine_id_provider_new      (void);
 EmerMachineIdProvider *emer_machine_id_provider_new_full (const gchar           *machine_id_file_path);
 
 gboolean               emer_machine_id_provider_get_id   (EmerMachineIdProvider *self,
-                                                          guchar                 machine_id[16]);
+                                                          uuid_t                 machine_id);
 
 G_END_DECLS
 

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -531,7 +531,9 @@ emer_permissions_provider_set_daemon_enabled (EmerPermissionsProvider *self,
 
   write_config_file_async (self);
 
-  g_object_notify (G_OBJECT (self), "daemon-enabled");
+  GParamSpec *daemon_enabled_pspec =
+    emer_permissions_provider_props[PROP_DAEMON_ENABLED];
+  g_object_notify_by_pspec (G_OBJECT (self), daemon_enabled_pspec);
 }
 
 /*

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -134,8 +134,9 @@ read_config_file_sync (EmerPermissionsProvider *self)
 
   g_free (path);
 
-  g_object_notify_by_pspec (G_OBJECT (self),
-                            emer_permissions_provider_props[PROP_DAEMON_ENABLED]);
+  GParamSpec *daemon_enabled_pspec =
+    emer_permissions_provider_props[PROP_DAEMON_ENABLED];
+  g_object_notify_by_pspec (G_OBJECT (self), daemon_enabled_pspec);
 }
 
 /* Helper function to run write_config_file_sync() in another thread. */

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -812,7 +812,7 @@ drain_metrics_file (EmerPersistentCache *self,
           g_error_free (error);
           g_object_unref (stream);
           g_object_unref (file);
-          g_array_free (dynamic_array, TRUE);
+          g_array_unref (dynamic_array);
           return FALSE;
         }
       if (length_bytes_read != sizeof (gsize))
@@ -821,7 +821,7 @@ drain_metrics_file (EmerPersistentCache *self,
                       length_bytes_read, sizeof (gsize));
           g_object_unref (stream);
           g_object_unref (file);
-          g_array_free (dynamic_array, TRUE);
+          g_array_unref (dynamic_array);
           return FALSE;
         }
 
@@ -846,7 +846,7 @@ drain_metrics_file (EmerPersistentCache *self,
           g_error_free (error);
           g_object_unref (stream);
           g_object_unref (file);
-          g_array_free (dynamic_array, TRUE);
+          g_array_unref (dynamic_array);
           return FALSE;
         }
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -813,22 +813,22 @@ drain_metrics_file (EmerPersistentCache *self,
         }
 
       // Deserialize
-      GVariant *current_metric =
+      GVariant *current_event =
         g_variant_new_from_data (G_VARIANT_TYPE (variant_type),
                                  writable.data,
                                  writable.length,
                                  FALSE,
                                  (GDestroyNotify) g_free,
                                  writable.data);
-      g_variant_ref_sink (current_metric);
+      g_variant_ref_sink (current_event);
 
       // Correct byte_ordering if necessary.
-      GVariant *native_endian_metric =
-        swap_bytes_if_big_endian (current_metric);
+      GVariant *native_endian_event =
+        swap_bytes_if_big_endian (current_event);
 
-      g_variant_unref (current_metric);
+      g_variant_unref (current_event);
 
-      g_array_append_val (dynamic_array, native_endian_metric);
+      g_array_append_val (dynamic_array, native_endian_event);
     }
   g_object_unref (stream);
   g_object_unref (file);

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -790,6 +790,7 @@ drain_metrics_file (EmerPersistentCache *self,
   GInputStream *stream = G_INPUT_STREAM (file_stream);
 
   GArray *dynamic_array = g_array_new (TRUE, FALSE, sizeof (GVariant *));
+  g_array_set_clear_func (dynamic_array, (GDestroyNotify) g_variant_unref);
 
   while (TRUE)
     {

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -28,7 +28,6 @@
 #include <glib-object.h>
 
 #include <errno.h>
-#include <stdio.h>
 
 #include <eosmetrics/eosmetrics.h>
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -29,7 +29,6 @@
 
 #include <errno.h>
 #include <stdio.h>
-#include <string.h>
 
 #include <eosmetrics/eosmetrics.h>
 
@@ -790,7 +789,7 @@ drain_metrics_file (EmerPersistentCache *self,
     }
   GInputStream *stream = G_INPUT_STREAM (file_stream);
 
-  GArray *dynamic_array = g_array_new (FALSE, FALSE, sizeof (GVariant *));
+  GArray *dynamic_array = g_array_new (TRUE, FALSE, sizeof (GVariant *));
 
   while (TRUE)
     {
@@ -863,14 +862,11 @@ drain_metrics_file (EmerPersistentCache *self,
       GVariant *regularized_event = regularize_variant (current_event);
       g_array_append_val (dynamic_array, regularized_event);
     }
+
   g_object_unref (stream);
   g_object_unref (file);
 
-  *return_list = g_new (GVariant *, dynamic_array->len + 1);
-  memcpy (*return_list, dynamic_array->data,
-          dynamic_array->len * sizeof (GVariant *));
-  (*return_list)[dynamic_array->len] = NULL;
-  g_array_free (dynamic_array, TRUE);
+  *return_list = (GVariant **) g_array_free (dynamic_array, FALSE);
 
   return TRUE;
 }

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -1022,7 +1022,9 @@ append_variant_to_string (EmerPersistentCache *self,
   gsize event_size_on_disk = sizeof (gsize) + g_variant_get_size (variant);
   if (cache_has_room (self, event_size_on_disk))
     {
+      g_variant_ref_sink (variant);
       GVariant *native_endian_variant = swap_bytes_if_big_endian (variant);
+      g_variant_unref (variant);
 
       GVariantWritable writable;
       writable.length = g_variant_get_size (native_endian_variant);
@@ -1106,12 +1108,8 @@ store_singulars (EmerPersistentCache *self,
     {
       SingularEvent *curr_singular = singular_buffer + i;
       GVariant *curr_singular_variant = singular_to_variant (curr_singular);
-
-      g_variant_ref_sink (curr_singular_variant);
       string_fit =
         append_variant_to_string (self, variant_string, curr_singular_variant);
-      g_variant_unref (curr_singular_variant);
-
       if (!string_fit)
         break;
     }
@@ -1148,12 +1146,8 @@ store_aggregates (EmerPersistentCache *self,
     {
       AggregateEvent *curr_aggregate = aggregate_buffer + i;
       GVariant *curr_aggregate_variant = aggregate_to_variant (curr_aggregate);
-
-      g_variant_ref_sink (curr_aggregate_variant);
       string_fit =
         append_variant_to_string (self, variant_string, curr_aggregate_variant);
-      g_variant_unref (curr_aggregate_variant);
-
       if (!string_fit)
         break;
     }
@@ -1190,12 +1184,8 @@ store_sequences (EmerPersistentCache *self,
     {
       SequenceEvent *curr_sequence = sequence_buffer + i;
       GVariant *curr_sequence_variant = sequence_to_variant (curr_sequence);
-
-      g_variant_ref_sink (curr_sequence_variant);
       string_fit =
         append_variant_to_string (self, variant_string, curr_sequence_variant);
-      g_variant_unref (curr_sequence_variant);
-
       if (!string_fit)
         break;
     }

--- a/shared/metrics-util.c
+++ b/shared/metrics-util.c
@@ -124,7 +124,7 @@ aggregate_to_variant (AggregateEvent *aggregate)
   get_uuid_builder (event.event_id, &event_id_builder);
   EventValue event_value = event.event_value;
   return g_variant_new ("(uayxxmv)", event.user_id, &event_id_builder,
-                        event_value.relative_timestamp, aggregate->num_events,
+                        aggregate->num_events, event_value.relative_timestamp,
                         event_value.auxiliary_payload);
 }
 

--- a/shared/metrics-util.c
+++ b/shared/metrics-util.c
@@ -178,7 +178,7 @@ void
 get_uuid_builder (uuid_t           uuid,
                   GVariantBuilder *uuid_builder)
 {
-  g_variant_builder_init (uuid_builder, G_VARIANT_TYPE ("ay"));
+  g_variant_builder_init (uuid_builder, G_VARIANT_TYPE_BYTESTRING);
   for (size_t i = 0; i < UUID_LENGTH; ++i)
     g_variant_builder_add (uuid_builder, "y", uuid[i]);
 }

--- a/shared/metrics-util.c
+++ b/shared/metrics-util.c
@@ -150,11 +150,11 @@ sequence_to_variant (SequenceEvent *sequence)
 }
 
 /*
- * Returns a new reference to a little-endian version of GVariant * regardless
- * of this machine's endianness. Crashes with a g_error if this machine is
- * middle-endian (a.k.a., mixed-endian).
+ * Returns a new reference to a little-endian version of the given GVariant
+ * regardless of this machine's endianness. Crashes with a g_error if this
+ * machine is middle-endian (a.k.a., mixed-endian).
  *
- * The returned GVariant * should have g_variant_unref() called on it when it is
+ * The returned GVariant should have g_variant_unref() called on it when it is
  * no longer needed.
  */
 GVariant *

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -64,7 +64,7 @@ tests_daemon_test_daemon_dbusdaemon_SOURCES = \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
 	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
 	daemon/emer-cache-version-provider.c daemon/emer-cache-version-provider.h \
-	daemon/emer-machine-id-provider.c daemon/emer-machine-id-provider.h \
+	tests/daemon/mock-machine-id-provider.c daemon/emer-machine-id-provider.h \
 	tests/daemon/mock-network-send-provider.c \
 	daemon/emer-network-send-provider.h \
 	tests/daemon/mock-permissions-provider.c \
@@ -76,6 +76,7 @@ tests_daemon_test_daemon_dbusdaemon_SOURCES = \
 tests_daemon_test_daemon_dbusdaemon_CPPFLAGS = \
 	$(DAEMON_TEST_FLAGS) \
 	-D_POSIX_C_SOURCE=200112L \
+	-DTEST_DIR="\"$(srcdir)/tests/\"" \
 	$(NULL)
 tests_daemon_test_daemon_dbusdaemon_LDADD = $(DAEMON_TEST_LIBS)
 
@@ -115,6 +116,7 @@ tests_daemon_test_persistent_cache_CPPFLAGS = \
 tests_daemon_test_persistent_cache_LDADD = $(DAEMON_TEST_LIBS)
 
 dist_noinst_SCRIPTS = \
+	tests/daemon/mock-server.py \
 	tests/launch-mock-dbus-tests.sh \
 	$(NULL)
 

--- a/tests/daemon/mock-machine-id-provider.c
+++ b/tests/daemon/mock-machine-id-provider.c
@@ -1,0 +1,62 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2015 Endless Mobile, Inc. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "emer-machine-id-provider.h"
+
+#include <glib.h>
+#include <uuid/uuid.h>
+
+#define MACHINE_ID "387c5206-24b5-4513-a34f-72689d5c0a0e"
+
+G_DEFINE_TYPE (EmerMachineIdProvider, emer_machine_id_provider, G_TYPE_OBJECT)
+
+static void
+emer_machine_id_provider_class_init (EmerMachineIdProviderClass *klass)
+{
+}
+
+static void
+emer_machine_id_provider_init (EmerMachineIdProvider *self)
+{
+}
+
+/* MOCK PUBLIC API */
+
+EmerMachineIdProvider *
+emer_machine_id_provider_new (void)
+{
+  return g_object_new (EMER_TYPE_MACHINE_ID_PROVIDER, NULL);
+}
+
+EmerMachineIdProvider *
+emer_machine_id_provider_new_full (const gchar *machine_id_file_path)
+{
+  return emer_machine_id_provider_new ();
+}
+
+gboolean
+emer_machine_id_provider_get_id (EmerMachineIdProvider *self,
+                                 uuid_t                 machine_id)
+{
+  g_assert_cmpint (uuid_parse (MACHINE_ID, machine_id), ==, 0);
+  return TRUE;
+}

--- a/tests/daemon/mock-permissions-provider.c
+++ b/tests/daemon/mock-permissions-provider.c
@@ -29,8 +29,7 @@
 typedef struct _EmerPermissionsProviderPrivate
 {
   gboolean mock_daemon_enabled;
-
-  gint get_daemon_enabled_called;
+  gboolean uploading_enabled;
 } EmerPermissionsProviderPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (EmerPermissionsProvider, emer_permissions_provider, G_TYPE_OBJECT)
@@ -47,6 +46,7 @@ emer_permissions_provider_init (EmerPermissionsProvider *self)
     emer_permissions_provider_get_instance_private (self);
 
   priv->mock_daemon_enabled = TRUE;
+  priv->uploading_enabled = TRUE;
 }
 
 /* MOCK PUBLIC API */
@@ -70,7 +70,6 @@ emer_permissions_provider_get_daemon_enabled (EmerPermissionsProvider *self)
   EmerPermissionsProviderPrivate *priv =
     emer_permissions_provider_get_instance_private (self);
 
-  priv->get_daemon_enabled_called++;
   return priv->mock_daemon_enabled;
 }
 
@@ -91,7 +90,10 @@ emer_permissions_provider_set_daemon_enabled (EmerPermissionsProvider *self,
 gboolean
 emer_permissions_provider_get_uploading_enabled (EmerPermissionsProvider *self)
 {
-  return TRUE;
+  EmerPermissionsProviderPrivate *priv =
+    emer_permissions_provider_get_instance_private (self);
+
+  return priv->uploading_enabled;
 }
 
 gchar *
@@ -102,12 +104,14 @@ emer_permissions_provider_get_environment (EmerPermissionsProvider *self)
 
 /* API OF MOCK OBJECT */
 
-/* Return number of calls to emer_permissions_provider_get_daemon_enabled(). */
-gint
-mock_permissions_provider_get_daemon_enabled_called (EmerPermissionsProvider *self)
+/* Sets the value to return from
+ * emer_permissions_provider_get_uploading_enabled(). */
+void
+mock_permissions_provider_set_uploading_enabled (EmerPermissionsProvider *self,
+                                                 gboolean                 uploading_enabled)
 {
   EmerPermissionsProviderPrivate *priv =
     emer_permissions_provider_get_instance_private (self);
 
-  return priv->get_daemon_enabled_called;
+  priv->uploading_enabled = uploading_enabled;
 }

--- a/tests/daemon/mock-permissions-provider.c
+++ b/tests/daemon/mock-permissions-provider.c
@@ -28,7 +28,7 @@
 
 typedef struct _EmerPermissionsProviderPrivate
 {
-  gboolean mock_daemon_enabled;
+  gboolean daemon_enabled;
   gboolean uploading_enabled;
 } EmerPermissionsProviderPrivate;
 
@@ -45,7 +45,7 @@ emer_permissions_provider_init (EmerPermissionsProvider *self)
   EmerPermissionsProviderPrivate *priv =
     emer_permissions_provider_get_instance_private (self);
 
-  priv->mock_daemon_enabled = TRUE;
+  priv->daemon_enabled = TRUE;
   priv->uploading_enabled = TRUE;
 }
 
@@ -70,7 +70,7 @@ emer_permissions_provider_get_daemon_enabled (EmerPermissionsProvider *self)
   EmerPermissionsProviderPrivate *priv =
     emer_permissions_provider_get_instance_private (self);
 
-  return priv->mock_daemon_enabled;
+  return priv->daemon_enabled;
 }
 
 void
@@ -80,7 +80,7 @@ emer_permissions_provider_set_daemon_enabled (EmerPermissionsProvider *self,
   EmerPermissionsProviderPrivate *priv =
     emer_permissions_provider_get_instance_private (self);
 
-  priv->mock_daemon_enabled = enabled;
+  priv->daemon_enabled = enabled;
 
   /* This works for faking a property notification even though there isn't a
   property by that name in this mock object */

--- a/tests/daemon/mock-permissions-provider.c
+++ b/tests/daemon/mock-permissions-provider.c
@@ -82,8 +82,9 @@ emer_permissions_provider_set_daemon_enabled (EmerPermissionsProvider *self,
 
   priv->daemon_enabled = enabled;
 
-  /* This works for faking a property notification even though there isn't a
-  property by that name in this mock object */
+  /* Emit a property notification even though there isn't a property by this
+   * name in this mock object.
+   */
   g_signal_emit_by_name (self, "notify::daemon-enabled", NULL);
 }
 

--- a/tests/daemon/mock-permissions-provider.h
+++ b/tests/daemon/mock-permissions-provider.h
@@ -29,7 +29,8 @@
 
 G_BEGIN_DECLS
 
-gint mock_permissions_provider_get_daemon_enabled_called (EmerPermissionsProvider *self);
+void mock_permissions_provider_set_uploading_enabled (EmerPermissionsProvider *self,
+                                                      gboolean                 uploading_enabled);
 
 G_END_DECLS
 

--- a/tests/daemon/mock-persistent-cache.h
+++ b/tests/daemon/mock-persistent-cache.h
@@ -29,6 +29,8 @@
 
 G_BEGIN_DECLS
 
+#define BOOT_TIME_OFFSET G_GINT64_CONSTANT (73)
+
 gint mock_persistent_cache_get_num_timestamp_updates (EmerPersistentCache *self);
 gint mock_persistent_cache_get_store_metrics_called  (EmerPersistentCache *self);
 

--- a/tests/daemon/mock-server.py
+++ b/tests/daemon/mock-server.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# Copyright 2015 Endless Mobile, Inc.
+
+# This file is part of eos-event-recorder-daemon.
+#
+# eos-event-recorder-daemon is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or (at your
+# option) any later version.
+#
+# eos-event-recorder-daemon is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with eos-event-recorder-daemon.  If not, see
+# <http://www.gnu.org/licenses/>.
+
+import http.client
+import http.server
+import sys
+
+class PrintingHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
+    def do_PUT(self):
+        print(self.path, flush=True)
+        content_length = int(self.headers['Content-Length'])
+        print(content_length, flush=True)
+        request_body = self.rfile.read(content_length)
+        sys.stdout.buffer.write(request_body)
+        sys.stdout.buffer.flush()
+        sys.stdin.readline()  # Block until test says to proceed.
+        self.send_response(http.client.OK)
+        self.end_headers()
+
+# A metrics server that simply prints the requests it receives to stdout
+class MockServer(http.server.HTTPServer):
+    def __init__(self):
+        SERVER_ADDRESS = ('localhost', 0)
+        super().__init__(SERVER_ADDRESS, PrintingHTTPRequestHandler)
+
+if __name__ == '__main__':
+    mock_server = MockServer()
+    print(mock_server.server_port, flush=True)
+    mock_server.serve_forever()

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -83,14 +83,13 @@ start_mock_logind_service (Fixture *fixture)
 static void
 terminate_mock_logind_service_and_wait (Fixture *fixture)
 {
-  GError *error = NULL;
-
   g_subprocess_send_signal (fixture->logind_mock, SIGTERM);
 
   /*
    * Make sure it was the SIGTERM that finished the process, and not something
    * else.
    */
+  GError *error = NULL;
   g_assert_false (g_subprocess_wait_check (fixture->logind_mock, NULL, &error));
   g_assert_error (error, G_SPAWN_ERROR, G_SPAWN_ERROR_FAILED);
   g_assert_cmpstr (error->message, ==, "Child process killed by signal 15");

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -42,6 +42,7 @@
 
 #define MACHINE_ID_PATH "/tmp/testing-machine-id"
 #define USER_ID 4200u
+#define NUM_EVENTS 101
 #define RELATIVE_TIMESTAMP G_GINT64_CONSTANT (123456789)
 
 #define TIMEOUT_SEC 5
@@ -379,14 +380,14 @@ test_daemon_can_record_aggregate_events (Fixture      *fixture,
   emer_daemon_record_aggregate_event (fixture->test_object,
                                       USER_ID,
                                       make_event_id_variant (),
-                                      101,
+                                      NUM_EVENTS,
                                       RELATIVE_TIMESTAMP,
                                       FALSE,
                                       g_variant_new_string ("This must be ignored."));
   emer_daemon_record_aggregate_event (fixture->test_object,
                                       USER_ID,
                                       make_event_id_variant (),
-                                      101,
+                                      NUM_EVENTS,
                                       RELATIVE_TIMESTAMP,
                                       TRUE,
                                       make_auxiliary_payload ());

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -201,7 +201,7 @@ get_pollable_input_stream (GSubprocess *subprocess)
   GInputStream *input_stream = g_subprocess_get_stdout_pipe (subprocess);
   GPollableInputStream *pollable_input_stream =
     G_POLLABLE_INPUT_STREAM (input_stream);
-  g_assert (g_pollable_input_stream_can_poll (pollable_input_stream));
+  g_assert_true (g_pollable_input_stream_can_poll (pollable_input_stream));
   return pollable_input_stream;
 }
 

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -448,8 +448,7 @@ static GVariant *
 make_event_id_variant (void)
 {
   uuid_t uuid;
-  if (uuid_parse (MEANINGLESS_EVENT, uuid) != 0)
-    g_error ("Failed to parse testing uuid.");
+  g_assert_cmpint (uuid_parse (MEANINGLESS_EVENT, uuid), ==, 0);
   GVariantBuilder event_id_builder;
   get_uuid_builder (uuid, &event_id_builder);
   return g_variant_builder_end (&event_id_builder);

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -30,20 +30,24 @@
 #include "mock-persistent-cache.h"
 #include "shared/metrics-util.h"
 
+#include <eosmetrics/eosmetrics.h>
 #include <glib.h>
+#include <glib-object.h>
 #include <glib/gstdio.h>
 #include <uuid/uuid.h>
 #include <stdio.h>
 #include <string.h>
 #include <signal.h>
 
+#define MOCK_SERVER_PATH TEST_DIR "daemon/mock-server.py"
+
 #define MEANINGLESS_EVENT "350ac4ff-3026-4c25-9e7e-e8103b4fd5d8"
 #define MEANINGLESS_EVENT_2 "d936cd5c-08de-4d4e-8a87-8df1f4a33cba"
 
-#define MACHINE_ID_PATH "/tmp/testing-machine-id"
 #define USER_ID 4200u
 #define NUM_EVENTS 101
 #define RELATIVE_TIMESTAMP G_GINT64_CONSTANT (123456789)
+#define OFFSET_TIMESTAMP (RELATIVE_TIMESTAMP + BOOT_TIME_OFFSET)
 
 #define TIMEOUT_SEC 5
 
@@ -56,45 +60,71 @@
 typedef struct
 {
   EmerDaemon *test_object;
+  EmerMachineIdProvider *mock_machine_id_provider;
   EmerNetworkSendProvider *mock_network_send_provider;
   EmerPermissionsProvider *mock_permissions_provider;
   EmerPersistentCache *mock_persistent_cache;
 
-  /* Mock logind service */
+  GSubprocess *mock_server;
   GSubprocess *logind_mock;
-  GString *logind_line;
 
-  GMainLoop *main_loop;
-  guint timeout_id;
+  gint64 relative_time;
+  gint64 absolute_time;
+  gchar *request_path;
 } Fixture;
+
+typedef void (*ProcessBytesSourceFunc) (GByteArray *, gpointer);
+typedef gboolean (*ProcessLineSourceFunc) (GString *, gpointer);
+
+typedef struct _ByteCollector
+{
+  GMainLoop *main_loop;
+  GByteArray *byte_array;
+  guint num_bytes_to_collect;
+  ProcessBytesSourceFunc source_func;
+  gpointer user_data;
+} ByteCollector;
+
+typedef struct _LineCollector
+{
+  GMainLoop *main_loop;
+  GString *line;
+  ProcessLineSourceFunc source_func;
+  gpointer user_data;
+} LineCollector;
+
+typedef struct _UploadEventsCallbackData
+{
+  GMainLoop *main_loop;
+  GSubprocess *mock_server;
+} UploadEventsCallbackData;
 
 // Helper methods first:
 
 static void
-start_mock_logind_service (Fixture *fixture)
+terminate_subprocess_and_wait (GSubprocess *subprocess)
 {
-  fixture->logind_mock = g_subprocess_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE, NULL,
-                                           "python3", "-m", "dbusmock",
-                                           "--system", "--template", "logind",
-                                           NULL);
-  g_assert_nonnull (fixture->logind_mock);
-}
-
-static void
-terminate_mock_logind_service_and_wait (Fixture *fixture)
-{
-  g_subprocess_send_signal (fixture->logind_mock, SIGTERM);
+  g_subprocess_send_signal (subprocess, SIGTERM);
 
   /*
    * Make sure it was the SIGTERM that finished the process, and not something
    * else.
    */
   GError *error = NULL;
-  g_assert_false (g_subprocess_wait_check (fixture->logind_mock, NULL, &error));
+  g_assert_false (g_subprocess_wait_check (subprocess, NULL, &error));
   g_assert_error (error, G_SPAWN_ERROR, G_SPAWN_ERROR_FAILED);
   g_assert_cmpstr (error->message, ==, "Child process killed by signal 15");
 
-  g_object_unref (fixture->logind_mock);
+  g_object_unref (subprocess);
+}
+
+static void
+start_mock_logind_service (Fixture *fixture)
+{
+  fixture->logind_mock =
+    g_subprocess_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE, NULL, "python3", "-m",
+                      "dbusmock", "--system", "--template", "logind", NULL);
+  g_assert_nonnull (fixture->logind_mock);
 }
 
 static gboolean
@@ -137,6 +167,34 @@ contains_dbus_call (const gchar *line,
   return given_args_index != NULL;
 }
 
+static gboolean
+process_logind_line (GString *line,
+                     gpointer unused)
+{
+  // Ensure that the only null byte in the line is the terminal null byte.
+  g_assert_cmpuint (line->len, ==, strlen (line->str));
+
+  return !contains_dbus_call (line->str, "Inhibit",
+                              EXPECTED_INHIBIT_SHUTDOWN_ARGS);
+}
+
+static gboolean
+remove_last_character (GString *line,
+                       gchar  **stripped_line)
+{
+  *stripped_line = g_strndup (line->str, line->len - 1);
+  return G_SOURCE_REMOVE;
+}
+
+static gboolean
+read_content_length (GString *line,
+                     guint   *content_length)
+{
+  gint num_conversions = sscanf (line->str, "%u\n", content_length);
+  g_assert_cmpint (num_conversions, ==, 1);
+  return G_SOURCE_REMOVE;
+}
+
 static GPollableInputStream *
 get_pollable_input_stream (GSubprocess *subprocess)
 {
@@ -147,21 +205,21 @@ get_pollable_input_stream (GSubprocess *subprocess)
   return pollable_input_stream;
 }
 
-/*
- * Append 1 byte from the given stream to the given byte array without blocking.
- * Returns TRUE if a character other than a newline was successfully appended.
- * Returns FALSE if a byte can't be obtained from the given stream without
- * blocking or a newline is read.
+/* Read 1 byte from the given stream without blocking. Returns TRUE if a byte
+ * was successfully read. Returns FALSE if a byte can't be obtained from the
+ * given stream without blocking. Pass NULL for byte to ignore the byte read
+ * from the stream.
  */
 static gboolean
-append_byte (GPollableInputStream *pollable_input_stream,
-             GString              *line)
+read_byte (GPollableInputStream *pollable_input_stream,
+           guint8               *byte)
 {
-  guint8 byte;
+  guint8 byte_read;
   GError *error = NULL;
   gssize num_bytes_read =
-    g_pollable_input_stream_read_nonblocking (pollable_input_stream, &byte, 1,
-                                              NULL /* GCancellable */, &error);
+    g_pollable_input_stream_read_nonblocking (pollable_input_stream, &byte_read,
+                                              1, NULL /* GCancellable */,
+                                              &error);
   switch (num_bytes_read)
     {
     case -1:
@@ -170,73 +228,200 @@ append_byte (GPollableInputStream *pollable_input_stream,
     case 0:
       return FALSE;
     case 1:
-      g_assert (byte != '\0');
-      g_string_append_c (line, byte);
-      return byte != '\n';
+      if (byte != NULL)
+        *byte = byte_read;
+      return TRUE;
     default:
       g_assert_not_reached ();
     }
 }
 
-/*
- * Append 1 line from the given stream to the given byte array without blocking.
+/* Appends 1 character from the given stream to the given string without
+ * blocking. Returns TRUE if a character was successfully appended. Returns
+ * FALSE if a character can't be obtained from the given stream without
+ * blocking.
+ */
+static gboolean
+append_char (GPollableInputStream *pollable_input_stream,
+             GString              *string)
+{
+  guint8 character;
+  if (!read_byte (pollable_input_stream, &character))
+    return FALSE;
+
+  g_string_append_c (string, character);
+  return TRUE;
+}
+
+/* Appends 1 line from the given stream to the given string without blocking.
  * Returns TRUE if a full line was successfully appended. Returns FALSE if less
- * than 1 line can be obtained from the given stream without blocking and
- * appends whatever data was available for immediate consumption.
+ * than 1 line can be obtained from the given stream without blocking, appending
+ * whatever data was available for immediate consumption.
  */
 static gboolean
 append_line (GPollableInputStream *pollable_input_stream,
              GString              *line)
 {
-  while (append_byte (pollable_input_stream, line)) {}
-  return line->str[line->len - 1] == '\n';
+  while (append_char (pollable_input_stream, line))
+    {
+      if (line->str[line->len - 1] == '\n')
+        return TRUE;
+    }
+
+  return FALSE;
+}
+
+/* Appends bytes from the given stream to the given byte array. Returns TRUE
+ * once the given string reaches the given length. Returns FALSE if insufficient
+ * data can be obtained from the given stream without blocking, appending
+ * whatever data was available for immediate consumption. Assumes byte_array
+ * already has space for the given number of bytes. See g_byte_array_sized_new.
+ */
+static gboolean
+append_bytes (GPollableInputStream *pollable_input_stream,
+              GByteArray           *byte_array,
+              guint                 num_bytes_to_collect)
+{
+  guint num_bytes_remaining = num_bytes_to_collect - byte_array->len;
+  guint8 *destination = byte_array->data + byte_array->len;
+  GError *error = NULL;
+  gssize num_bytes_read =
+    g_pollable_input_stream_read_nonblocking (pollable_input_stream,
+                                              destination, num_bytes_remaining,
+                                              NULL /* GCancellable */, &error);
+  if (num_bytes_read == -1)
+    {
+      gboolean would_block =
+        g_error_matches (error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK);
+      g_assert_true (would_block);
+      g_error_free (error);
+      return FALSE;
+    }
+
+  guint new_length = byte_array->len + num_bytes_read;
+  g_byte_array_set_size (byte_array, new_length);
+  return num_bytes_read == num_bytes_remaining;
 }
 
 static gboolean
-on_output_received (GPollableInputStream *pollable_input_stream,
-                    Fixture              *fixture)
+collect_lines (GPollableInputStream  *pollable_input_stream,
+               LineCollector         *line_collector)
 {
-  while (append_line (pollable_input_stream, fixture->logind_line))
+  while (append_line (pollable_input_stream, line_collector->line))
     {
-      gboolean shutdown_inhibited =
-        contains_dbus_call (fixture->logind_line->str, "Inhibit",
-                            EXPECTED_INHIBIT_SHUTDOWN_ARGS);
-      if (shutdown_inhibited)
+      gboolean continue_listening =
+        line_collector->source_func (line_collector->line,
+                                     line_collector->user_data);
+      if (!continue_listening)
         {
-          g_source_remove (fixture->timeout_id);
-          g_main_loop_quit (fixture->main_loop);
+          g_main_loop_quit (line_collector->main_loop);
           return G_SOURCE_REMOVE;
         }
 
-      g_string_truncate (fixture->logind_line, 0);
+      g_string_truncate (line_collector->line, 0);
     }
 
   return G_SOURCE_CONTINUE;
 }
 
-static void
-await_shutdown_inhibit (Fixture *fixture)
+static gboolean
+collect_bytes (GPollableInputStream  *pollable_input_stream,
+               ByteCollector         *byte_collector)
 {
-  GPollableInputStream *logind_pollable_stream =
-    get_pollable_input_stream (fixture->logind_mock);
+  if (!append_bytes (pollable_input_stream, byte_collector->byte_array,
+                     byte_collector->num_bytes_to_collect))
+    return G_SOURCE_CONTINUE;
+
+  byte_collector->source_func (byte_collector->byte_array,
+                               byte_collector->user_data);
+
+  g_main_loop_quit (byte_collector->main_loop);
+  return G_SOURCE_REMOVE;
+}
+
+/* Reads line by line from stdout of the given subprocess, blocking until either
+ * the desired data becomes available or a timeout expires. Calls source_func
+ * with a GString containing a line, including the terminal newline character,
+ * as the first parameter. Passes the given callback data as the second
+ * parameter. Each time source_func returns G_SOURCE_CONTINUE, another line is
+ * read and passed to source_func. This function only returns once source_func
+ * returns G_SOURCE_REMOVE.
+ */
+static void
+read_lines_from_stdout (GSubprocess          *subprocess,
+                        ProcessLineSourceFunc source_func,
+                        gpointer              user_data)
+{
+  GPollableInputStream *pollable_input_stream =
+    get_pollable_input_stream (subprocess);
+
   GSource *stdout_source =
-    g_pollable_input_stream_create_source (logind_pollable_stream,
+    g_pollable_input_stream_create_source (pollable_input_stream,
                                            NULL /* GCancellable */);
 
-  fixture->main_loop = g_main_loop_new (NULL /* GMainContext */, FALSE);
-  fixture->logind_line = g_string_new ("");
-  g_source_set_callback (stdout_source, (GSourceFunc) on_output_received,
-                         fixture, NULL /* GDestroyNotify */);
+  LineCollector line_collector =
+    {
+      g_main_loop_new (NULL /* GMainContext */, FALSE),
+      g_string_new (""),
+      source_func,
+      user_data,
+    };
+
+  g_source_set_callback (stdout_source, (GSourceFunc) collect_lines,
+                         &line_collector, NULL /* GDestroyNotify */);
   g_source_attach (stdout_source, NULL /* GMainContext */);
   g_source_unref (stdout_source);
 
-  fixture->timeout_id =
+  guint timeout_id =
     g_timeout_add_seconds (TIMEOUT_SEC, timeout, NULL /* user data */);
 
-  g_main_loop_run (fixture->main_loop);
+  g_main_loop_run (line_collector.main_loop);
 
-  g_main_loop_unref (fixture->main_loop);
-  g_string_free (fixture->logind_line, TRUE);
+  g_source_remove (timeout_id);
+  g_main_loop_unref (line_collector.main_loop);
+  g_string_free (line_collector.line, TRUE);
+}
+
+/* Reads the given number of bytes from stdout of the given subprocess, blocking
+ * until either sufficient data becomes available or a timeout expires. Calls
+ * source_func with a GByteArray containing the bytes read as the first
+ * parameter and the given callback data as the second parameter.
+ */
+static void
+read_bytes_from_stdout (GSubprocess           *subprocess,
+                        guint                  num_bytes,
+                        ProcessBytesSourceFunc source_func,
+                        gpointer               user_data)
+{
+  GPollableInputStream *pollable_input_stream =
+    get_pollable_input_stream (subprocess);
+
+  GSource *stdout_source =
+    g_pollable_input_stream_create_source (pollable_input_stream,
+                                           NULL /* GCancellable */);
+
+  ByteCollector byte_collector =
+    {
+      g_main_loop_new (NULL /* GMainContext */, FALSE),
+      g_byte_array_sized_new (num_bytes),
+      num_bytes,
+      source_func,
+      user_data,
+    };
+
+  g_source_set_callback (stdout_source, (GSourceFunc) collect_bytes,
+                         &byte_collector, NULL /* GDestroyNotify */);
+  g_source_attach (stdout_source, NULL /* GMainContext */);
+  g_source_unref (stdout_source);
+
+  guint timeout_id =
+    g_timeout_add_seconds (TIMEOUT_SEC, timeout, NULL /* user data */);
+
+  g_main_loop_run (byte_collector.main_loop);
+
+  g_source_remove (timeout_id);
+  g_main_loop_unref (byte_collector.main_loop);
+  g_byte_array_unref (byte_collector.byte_array);
 }
 
 static void
@@ -297,74 +482,196 @@ make_event_values_variant (void)
   return g_variant_new ("a(xbv)", &builder);
 }
 
-// Setup/Teardown functions next:
-
 static void
-setup (Fixture      *fixture,
-       gconstpointer unused)
+assert_no_data_uploaded (EmerDaemon               *daemon,
+                         GAsyncResult             *result,
+                         UploadEventsCallbackData *callback_data)
 {
-  EmerMachineIdProvider *machine_id_provider =
-    emer_machine_id_provider_new_full (MACHINE_ID_PATH);
-  fixture->mock_network_send_provider = emer_network_send_provider_new ();
-  fixture->mock_permissions_provider = emer_permissions_provider_new ();
-  fixture->mock_persistent_cache = emer_persistent_cache_new (NULL, NULL);
-  fixture->test_object =
-    emer_daemon_new_full (g_rand_new_with_seed (18),
-                          5, // Network Send Interval
-                          machine_id_provider,
-                          fixture->mock_network_send_provider,
-                          fixture->mock_permissions_provider,
-                          fixture->mock_persistent_cache,
-                          20); // Buffer length
-  g_object_unref (machine_id_provider);
+  GError *error = NULL;
+  g_assert_false (emer_daemon_upload_events_finish (daemon, result, &error));
+  g_assert_error (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED);
+  g_error_free (error);
+
+  GPollableInputStream *pollable_input_stream =
+    get_pollable_input_stream (callback_data->mock_server);
+  g_assert_false (read_byte (pollable_input_stream, NULL /* byte */));
+
+  g_main_loop_quit (callback_data->main_loop);
 }
 
 static void
-teardown (Fixture      *fixture,
-          gconstpointer unused)
+assert_uploading_disabled (Fixture *fixture)
 {
-  g_object_unref (fixture->test_object);
-  g_object_unref (fixture->mock_network_send_provider);
-  g_object_unref (fixture->mock_permissions_provider);
-  g_object_unref (fixture->mock_persistent_cache);
-  g_unlink (MACHINE_ID_PATH);
-}
+  UploadEventsCallbackData callback_data =
+    {
+      g_main_loop_new (NULL /* GMainContext */, FALSE),
+      fixture->mock_server,
+    };
 
-// Unit Tests next:
+  emer_daemon_upload_events (fixture->test_object,
+                             (GAsyncReadyCallback) assert_no_data_uploaded,
+                             &callback_data);
 
-static void
-test_daemon_new_succeeds (Fixture      *fixture,
-                          gconstpointer unused)
-{
-  EmerDaemon *daemon = emer_daemon_new ();
-  g_assert (daemon != NULL);
-  g_object_unref (daemon);
-}
+  guint timeout_id =
+    g_timeout_add_seconds (TIMEOUT_SEC, timeout, NULL /* user data */);
 
-static void
-test_daemon_new_full_succeeds (Fixture      *fixture,
-                               gconstpointer unused)
-{
-  g_assert (fixture->test_object != NULL);
+  g_main_loop_run (callback_data.main_loop);
+
+  g_source_remove (timeout_id);
+  g_main_loop_unref (callback_data.main_loop);
 }
 
 static void
-test_daemon_can_record_singular_event (Fixture      *fixture,
-                                       gconstpointer unused)
+assert_variants_equal (GVariant *variant_one,
+                       GVariant *variant_two)
 {
-  emer_daemon_record_singular_event (fixture->test_object,
+  if (variant_one == NULL)
+    {
+      g_assert_null (variant_two);
+    }
+  else
+    {
+      g_assert_nonnull (variant_two);
+      g_assert_true (g_variant_equal (variant_one, variant_two));
+    }
+}
+
+static void assert_machine_id_matches (GVariant              *machine_id_variant,
+                                       EmerMachineIdProvider *machine_id_provider)
+{
+  gsize actual_length;
+  const guchar *actual_machine_id =
+    g_variant_get_fixed_array (machine_id_variant, &actual_length,
+                               sizeof (guchar));
+  g_assert_cmpuint (actual_length, ==, UUID_LENGTH);
+
+  uuid_t expected_machine_id;
+  emer_machine_id_provider_get_id (machine_id_provider, expected_machine_id);
+
+  gint compare_result = uuid_compare (actual_machine_id, expected_machine_id);
+  g_assert_cmpint (compare_result, ==, 0);
+}
+
+
+static void
+assert_singular_matches (GVariantIter *singular_iterator,
+                         GVariant     *expected_auxiliary_payload)
+{
+  guint32 user_id;
+  GVariant *actual_event_id;
+  gint64 relative_time;
+  GVariant *actual_auxiliary_payload;
+  gboolean singulars_remain =
+    g_variant_iter_next (singular_iterator, "(u@ayxmv)", &user_id,
+                         &actual_event_id, &relative_time,
+                         &actual_auxiliary_payload);
+
+  g_assert_true (singulars_remain);
+  g_assert_cmpuint (user_id, ==, USER_ID);
+
+  GVariant *expected_event_id = make_event_id_variant ();
+  g_assert_true (g_variant_equal (actual_event_id, expected_event_id));
+  g_clear_pointer (&actual_event_id, g_variant_unref);
+  g_clear_pointer (&expected_event_id, g_variant_unref);
+
+  g_assert_cmpint (relative_time, ==, OFFSET_TIMESTAMP);
+
+  assert_variants_equal (actual_auxiliary_payload, expected_auxiliary_payload);
+  g_clear_pointer (&actual_auxiliary_payload, g_variant_unref);
+  g_clear_pointer (&expected_auxiliary_payload, g_variant_unref);
+}
+
+static void
+assert_aggregate_matches (GVariantIter *aggregate_iterator,
+                          GVariant     *expected_auxiliary_payload)
+{
+  guint32 user_id;
+  GVariant *actual_event_id;
+  gint64 num_events;
+  gint64 relative_time;
+  GVariant *actual_auxiliary_payload;
+  gboolean aggregates_remain =
+    g_variant_iter_next (aggregate_iterator, "(u@ayxxmv)", &user_id,
+                         &actual_event_id, &num_events, &relative_time,
+                         &actual_auxiliary_payload);
+
+  g_assert_true (aggregates_remain);
+  g_assert_cmpuint (user_id, ==, USER_ID);
+
+  GVariant *expected_event_id = make_event_id_variant ();
+  g_assert_true (g_variant_equal (actual_event_id, expected_event_id));
+  g_variant_unref (actual_event_id);
+  g_variant_unref (expected_event_id);
+
+  g_assert_cmpint (num_events, ==, NUM_EVENTS);
+  g_assert_cmpint (relative_time, ==, OFFSET_TIMESTAMP);
+
+  assert_variants_equal (actual_auxiliary_payload, expected_auxiliary_payload);
+  g_clear_pointer (&actual_auxiliary_payload, g_variant_unref);
+  g_clear_pointer (&expected_auxiliary_payload, g_variant_unref);
+}
+
+static void
+assert_event_value_matches (GVariantIter *event_value_iterator,
+                            GVariant     *expected_auxiliary_payload)
+{
+  gint64 relative_time;
+  GVariant *actual_auxiliary_payload;
+  gboolean event_values_remain =
+    g_variant_iter_next (event_value_iterator, "(xmv)", &relative_time,
+                         &actual_auxiliary_payload);
+  g_assert_true (event_values_remain);
+
+  g_assert_cmpint (relative_time, ==, OFFSET_TIMESTAMP);
+
+  assert_variants_equal (actual_auxiliary_payload, expected_auxiliary_payload);
+  g_clear_pointer (&actual_auxiliary_payload, g_variant_unref);
+  g_clear_pointer (&expected_auxiliary_payload, g_variant_unref);
+}
+
+static void
+assert_sequence_matches (GVariantIter *sequence_iterator)
+{
+  guint32 user_id;
+  GVariant *actual_event_id;
+  GVariantIter *event_values_iterator;
+  gboolean sequences_remain =
+    g_variant_iter_next (sequence_iterator, "(u@aya(xmv))", &user_id,
+                         &actual_event_id, &event_values_iterator);
+
+  g_assert_true (sequences_remain);
+  g_assert_cmpuint (user_id, ==, USER_ID);
+
+  GVariant *expected_event_id = make_event_id_variant ();
+  g_assert_true (g_variant_equal (actual_event_id, expected_event_id));
+  g_variant_unref (actual_event_id);
+  g_variant_unref (expected_event_id);
+
+  gsize num_event_values = g_variant_iter_n_children (event_values_iterator);
+  g_assert_cmpuint (num_event_values, ==, 2u);
+  assert_event_value_matches (event_values_iterator,
+                              NULL /* auxiliary_payload */);
+  assert_event_value_matches (event_values_iterator,
+                              g_variant_new_boolean (TRUE));
+  g_variant_iter_free (event_values_iterator);
+}
+
+static void
+record_singulars (EmerDaemon *daemon)
+{
+  emer_daemon_record_singular_event (daemon,
                                      USER_ID,
                                      make_event_id_variant (),
                                      RELATIVE_TIMESTAMP,
                                      FALSE,
                                      g_variant_new_string ("This must be ignored."));
-  emer_daemon_record_singular_event (fixture->test_object,
+  emer_daemon_record_singular_event (daemon,
                                      USER_ID,
                                      make_event_id_variant (),
                                      RELATIVE_TIMESTAMP,
                                      FALSE,
                                      g_variant_new_string ("This must be ignored."));
-  emer_daemon_record_singular_event (fixture->test_object,
+  emer_daemon_record_singular_event (daemon,
                                      USER_ID,
                                      make_event_id_variant (),
                                      RELATIVE_TIMESTAMP,
@@ -373,17 +680,16 @@ test_daemon_can_record_singular_event (Fixture      *fixture,
 }
 
 static void
-test_daemon_can_record_aggregate_events (Fixture      *fixture,
-                                         gconstpointer unused)
+record_aggregates (EmerDaemon *daemon)
 {
-  emer_daemon_record_aggregate_event (fixture->test_object,
+  emer_daemon_record_aggregate_event (daemon,
                                       USER_ID,
                                       make_event_id_variant (),
                                       NUM_EVENTS,
                                       RELATIVE_TIMESTAMP,
                                       FALSE,
                                       g_variant_new_string ("This must be ignored."));
-  emer_daemon_record_aggregate_event (fixture->test_object,
+  emer_daemon_record_aggregate_event (daemon,
                                       USER_ID,
                                       make_event_id_variant (),
                                       NUM_EVENTS,
@@ -393,71 +699,431 @@ test_daemon_can_record_aggregate_events (Fixture      *fixture,
 }
 
 static void
-test_daemon_can_record_event_sequence (Fixture      *fixture,
-                                       gconstpointer unused)
+record_sequence (EmerDaemon *daemon)
 {
-  emer_daemon_record_event_sequence (fixture->test_object,
+  emer_daemon_record_event_sequence (daemon,
                                      USER_ID,
                                      make_event_id_variant (),
                                      make_event_values_variant ());
 }
 
 static void
-test_daemon_does_not_record_singular_event_if_not_allowed (Fixture      *fixture,
-                                                           gconstpointer unused)
+get_events_from_request (GByteArray    *request,
+                         Fixture       *fixture,
+                         GVariantIter **singular_iterator,
+                         GVariantIter **aggregate_iterator,
+                         GVariantIter **sequence_iterator)
 {
-  gint num_calls_before =
-    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_provider);
+  gint64 curr_relative_time;
+  gboolean get_succeeded =
+    emtr_util_get_current_time (CLOCK_BOOTTIME, &curr_relative_time);
+  g_assert_true (get_succeeded);
 
-  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_provider,
-                                                FALSE);
-  test_daemon_can_record_singular_event (fixture, unused);
+  gint64 curr_absolute_time;
+  get_succeeded =
+    emtr_util_get_current_time (CLOCK_REALTIME, &curr_absolute_time);
+  g_assert_true (get_succeeded);
 
-  gint num_calls_after =
-    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_provider);
+  GBytes *request_bytes = g_bytes_new (request->data, request->len);
 
-  /*
-   * FIXME: Nothing can currently be asserted about whether the EmerDaemon tries
-   * to send its metrics, but at least we can confirm that it read the enabled
-   * property.
-   */
-  g_assert_cmpint (num_calls_after, >=, num_calls_before + 1);
+  gchar *checksum =
+    g_compute_checksum_for_bytes (G_CHECKSUM_SHA512, request_bytes);
+  gchar *expected_request_path = g_strconcat ("/2/", checksum, NULL);
+  g_free (checksum);
+  g_assert_cmpstr (fixture->request_path, ==, expected_request_path);
+  g_free (expected_request_path);
+
+  const GVariantType *REQUEST_FORMAT =
+    G_VARIANT_TYPE ("(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))");
+  GVariant *request_variant =
+    g_variant_new_from_bytes (REQUEST_FORMAT, request_bytes, FALSE);
+
+  g_bytes_unref (request_bytes);
+
+  g_assert_true (g_variant_is_normal_form (request_variant));
+
+  g_variant_ref_sink (request_variant);
+  GVariant *native_endian_request =
+    swap_bytes_if_big_endian (request_variant);
+  g_variant_unref (request_variant);
+
+  gint32 actual_network_send_number;
+  gint64 client_relative_time, client_absolute_time;
+  GVariant *machine_id;
+  g_variant_get (native_endian_request,
+                 "(ixx@aya(uayxmv)a(uayxxmv)a(uaya(xmv)))",
+                 &actual_network_send_number, &client_relative_time,
+                 &client_absolute_time, &machine_id, singular_iterator,
+                 aggregate_iterator, sequence_iterator);
+
+  gint curr_network_send_number =
+    emer_network_send_provider_get_send_number (fixture->mock_network_send_provider);
+  gint expected_network_send_number = curr_network_send_number - 1;
+  g_assert_cmpint (actual_network_send_number, ==,
+                   expected_network_send_number);
+
+  g_assert_cmpint (client_relative_time, >=, fixture->relative_time);
+  g_assert_cmpint (client_relative_time, <=, curr_relative_time);
+
+  g_assert_cmpint (client_absolute_time, >=, fixture->absolute_time);
+  g_assert_cmpint (client_absolute_time, <=, curr_absolute_time);
+
+  assert_machine_id_matches (machine_id, fixture->mock_machine_id_provider);
+  g_variant_unref (machine_id);
+
+  g_variant_unref (native_endian_request);
 }
 
 static void
-test_daemon_does_not_record_aggregate_event_if_not_allowed (Fixture      *fixture,
+assert_no_events_received (GByteArray *request,
+                           Fixture    *fixture)
+{
+  GVariantIter *singular_iterator, *aggregate_iterator, *sequence_iterator;
+  get_events_from_request (request, fixture, &singular_iterator,
+                           &aggregate_iterator, &sequence_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (singular_iterator), ==, 0u);
+  g_variant_iter_free (singular_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (aggregate_iterator), ==, 0u);
+  g_variant_iter_free (aggregate_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (sequence_iterator), ==, 0u);
+  g_variant_iter_free (sequence_iterator);
+}
+
+static void
+assert_singulars_received (GByteArray *request,
+                           Fixture    *fixture)
+{
+  GVariantIter *singular_iterator, *aggregate_iterator, *sequence_iterator;
+  get_events_from_request (request, fixture, &singular_iterator,
+                           &aggregate_iterator, &sequence_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (singular_iterator), ==, 3u);
+  assert_singular_matches (singular_iterator, NULL /* auxiliary_payload */);
+  assert_singular_matches (singular_iterator, NULL /* auxiliary_payload */);
+  assert_singular_matches (singular_iterator, make_auxiliary_payload ());
+  g_variant_iter_free (singular_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (aggregate_iterator), ==, 0u);
+  g_variant_iter_free (aggregate_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (sequence_iterator), ==, 0u);
+  g_variant_iter_free (sequence_iterator);
+}
+
+static void
+assert_aggregates_received (GByteArray *request,
+                            Fixture    *fixture)
+{
+  GVariantIter *singular_iterator, *aggregate_iterator, *sequence_iterator;
+  get_events_from_request (request, fixture, &singular_iterator,
+                           &aggregate_iterator, &sequence_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (singular_iterator), ==, 0u);
+  g_variant_iter_free (singular_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (aggregate_iterator), ==, 2u);
+  assert_aggregate_matches (aggregate_iterator, NULL /* auxiliary_payload */);
+  assert_aggregate_matches (aggregate_iterator, make_auxiliary_payload ());
+  g_variant_iter_free (aggregate_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (sequence_iterator), ==, 0u);
+  g_variant_iter_free (sequence_iterator);
+}
+
+static void
+assert_sequence_received (GByteArray *request,
+                          Fixture    *fixture)
+{
+  GVariantIter *singular_iterator, *aggregate_iterator, *sequence_iterator;
+  get_events_from_request (request, fixture, &singular_iterator,
+                           &aggregate_iterator, &sequence_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (singular_iterator), ==, 0u);
+  g_variant_iter_free (singular_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (aggregate_iterator), ==, 0u);
+  g_variant_iter_free (aggregate_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (sequence_iterator), ==, 1u);
+  assert_sequence_matches (sequence_iterator);
+  g_variant_iter_free (sequence_iterator);
+}
+
+/* Writes a single newline character to stdin of the given server, instructing
+ * it to stop waiting and respond to the client.
+ */
+static void
+tell_server_to_proceed (GSubprocess *server)
+{
+  GOutputStream *output_stream = g_subprocess_get_stdin_pipe (server);
+  gssize num_bytes_written =
+    g_output_stream_write (output_stream, "\n", 1, NULL /* GCancellable */,
+                           NULL /* GError */);
+  g_assert_cmpint (num_bytes_written, ==, 1);
+
+  gboolean flush_succeeded =
+    g_output_stream_flush (output_stream, NULL /* GCancellable */,
+                           NULL /* GError */);
+  g_assert_true (flush_succeeded);
+}
+
+static void
+handle_upload_finished (EmerDaemon *test_object,
+                        GMainLoop  *main_loop)
+{
+  g_main_loop_quit (main_loop);
+}
+
+/* Reads a network request from stdout of the given server. Assumes the server
+ * prints the path to which the request was made on a single line, followed by
+ * the length in bytes of the request received on a single line, followed by the
+ * request body without a terminal newline. Assumes the server does not respond
+ * to the request until instructed to proceed. Blocks until the client has
+ * finished handling the server's acknowledgement of its request. Sets
+ * fixture->relative_time and fixture->absolute_time to the relative and
+ * absolute times at which this function was called. Sets fixture->request_path
+ * to the path to which the request was sent. Calls source_func with a
+ * GByteArray containing the request body as the first parameter and the
+ * modified fixture as the second parameter.
+ */
+static void
+read_network_request (GSubprocess           *server,
+                      ProcessBytesSourceFunc source_func,
+                      Fixture               *fixture)
+{
+  gboolean get_succeeded =
+    emtr_util_get_current_time (CLOCK_BOOTTIME, &fixture->relative_time);
+  g_assert_true (get_succeeded);
+  get_succeeded =
+    emtr_util_get_current_time (CLOCK_REALTIME, &fixture->absolute_time);
+  g_assert_true (get_succeeded);
+
+  read_lines_from_stdout (server, (ProcessLineSourceFunc) remove_last_character,
+                          &fixture->request_path);
+
+  guint content_length;
+  read_lines_from_stdout (server, (ProcessLineSourceFunc) read_content_length,
+                          &content_length);
+
+  read_bytes_from_stdout (server, content_length, source_func, fixture);
+  g_free (fixture->request_path);
+
+  GMainLoop *main_loop = g_main_loop_new (NULL /* GMainContext */, FALSE);
+  guint handler_id =
+    g_signal_connect (fixture->test_object, "upload-finished",
+                      G_CALLBACK (handle_upload_finished), main_loop);
+  tell_server_to_proceed (server);
+
+  guint timeout_id =
+    g_timeout_add_seconds (TIMEOUT_SEC, timeout, NULL /* user data */);
+
+  // Wait until client has handled server's acknowledgement.
+  g_main_loop_run (main_loop);
+
+  g_source_remove (timeout_id);
+  g_signal_handler_disconnect (fixture->test_object, handler_id);
+  g_main_loop_unref (main_loop);
+}
+
+static gchar *
+get_server_uri (GSubprocess *mock_server)
+{
+  gchar *port_number;
+  read_lines_from_stdout (mock_server,
+                          (ProcessLineSourceFunc) remove_last_character,
+                          &port_number);
+  gchar *server_uri = g_strconcat ("http://localhost:", port_number, "/", NULL);
+  g_free (port_number);
+  return server_uri;
+}
+
+// Setup/Teardown functions next:
+
+static void
+setup (Fixture      *fixture,
+       gconstpointer unused)
+{
+  fixture->mock_server =
+    g_subprocess_new (G_SUBPROCESS_FLAGS_STDIN_PIPE |
+                        G_SUBPROCESS_FLAGS_STDOUT_PIPE,
+                      NULL, MOCK_SERVER_PATH, NULL);
+  g_assert_nonnull (fixture->mock_server);
+
+  gchar *server_uri = get_server_uri (fixture->mock_server);
+
+  fixture->mock_machine_id_provider = emer_machine_id_provider_new ();
+  fixture->mock_network_send_provider = emer_network_send_provider_new ();
+  fixture->mock_permissions_provider = emer_permissions_provider_new ();
+  fixture->mock_persistent_cache = emer_persistent_cache_new (NULL, NULL);
+  fixture->test_object =
+    emer_daemon_new_full (g_rand_new_with_seed (18),
+                          server_uri,
+                          2, // Network Send Interval
+                          fixture->mock_machine_id_provider,
+                          fixture->mock_network_send_provider,
+                          fixture->mock_permissions_provider,
+                          fixture->mock_persistent_cache,
+                          20); // Buffer length
+  g_free (server_uri);
+}
+
+static void
+teardown (Fixture      *fixture,
+          gconstpointer unused)
+{
+  g_object_unref (fixture->test_object);
+  g_object_unref (fixture->mock_machine_id_provider);
+  g_object_unref (fixture->mock_network_send_provider);
+  g_object_unref (fixture->mock_permissions_provider);
+  g_object_unref (fixture->mock_persistent_cache);
+  terminate_subprocess_and_wait (fixture->mock_server);
+}
+
+// Unit Tests next:
+
+static void
+test_daemon_new_succeeds (Fixture      *fixture,
+                          gconstpointer unused)
+{
+  EmerDaemon *daemon = emer_daemon_new ();
+  g_assert_nonnull (daemon);
+  g_object_unref (daemon);
+}
+
+static void
+test_daemon_new_full_succeeds (Fixture      *fixture,
+                               gconstpointer unused)
+{
+  g_assert_nonnull (fixture->test_object);
+}
+
+static void
+test_daemon_records_singulars (Fixture      *fixture,
+                               gconstpointer unused)
+{
+  record_singulars (fixture->test_object);
+  read_network_request (fixture->mock_server,
+                        (ProcessBytesSourceFunc) assert_singulars_received,
+                        fixture);
+}
+
+static void
+test_daemon_records_aggregates (Fixture      *fixture,
+                                gconstpointer unused)
+{
+  record_aggregates (fixture->test_object);
+  read_network_request (fixture->mock_server,
+                        (ProcessBytesSourceFunc) assert_aggregates_received,
+                        fixture);
+}
+
+static void
+test_daemon_records_sequence (Fixture      *fixture,
+                              gconstpointer unused)
+{
+  record_sequence (fixture->test_object);
+  read_network_request (fixture->mock_server,
+                        (ProcessBytesSourceFunc) assert_sequence_received,
+                        fixture);
+}
+
+static void
+test_daemon_only_reports_singulars_when_uploading_enabled (Fixture      *fixture,
+                                                           gconstpointer unused)
+{
+  mock_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
+                                                   FALSE);
+  record_singulars (fixture->test_object);
+  assert_uploading_disabled (fixture);
+
+  mock_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
+                                                   TRUE);
+  read_network_request (fixture->mock_server,
+                        (ProcessBytesSourceFunc) assert_singulars_received,
+                        fixture);
+}
+
+static void
+test_daemon_only_reports_aggregates_when_uploading_enabled (Fixture      *fixture,
                                                             gconstpointer unused)
 {
-  gint num_calls_before =
-    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_provider);
+  mock_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
+                                                   FALSE);
+  record_aggregates (fixture->test_object);
+  assert_uploading_disabled (fixture);
 
-  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_provider,
-                                                FALSE);
-  test_daemon_can_record_aggregate_events (fixture, unused);
-
-  gint num_calls_after =
-    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_provider);
-
-  /* FIXME: See note above. */
-  g_assert_cmpint (num_calls_after, >=, num_calls_before + 1);
+  mock_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
+                                                   TRUE);
+  read_network_request (fixture->mock_server,
+                        (ProcessBytesSourceFunc) assert_aggregates_received,
+                        fixture);
 }
 
 static void
-test_daemon_does_not_record_event_sequence_if_not_allowed (Fixture      *fixture,
+test_daemon_only_reports_sequences_when_uploading_enabled (Fixture      *fixture,
                                                            gconstpointer unused)
 {
-  gint num_calls_before =
-    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_provider);
+  mock_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
+                                                   FALSE);
+  record_sequence (fixture->test_object);
+  assert_uploading_disabled (fixture);
 
+  mock_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
+                                                   TRUE);
+  read_network_request (fixture->mock_server,
+                        (ProcessBytesSourceFunc) assert_sequence_received,
+                        fixture);
+}
+
+static void
+test_daemon_does_not_record_singulars_when_daemon_disabled (Fixture      *fixture,
+                                                            gconstpointer unused)
+{
   emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_provider,
                                                 FALSE);
-  test_daemon_can_record_event_sequence (fixture, unused);
+  record_singulars (fixture->test_object);
+  assert_uploading_disabled (fixture);
 
-  gint num_calls_after =
-    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_provider);
+  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_provider,
+                                                TRUE);
+  read_network_request (fixture->mock_server,
+                        (ProcessBytesSourceFunc) assert_no_events_received,
+                        fixture);
+}
 
-  /* FIXME: See note above. */
-  g_assert_cmpint (num_calls_after, >=, num_calls_before + 1);
+static void
+test_daemon_does_not_record_aggregates_when_daemon_disabled (Fixture      *fixture,
+                                                             gconstpointer unused)
+{
+  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_provider,
+                                                FALSE);
+  record_aggregates (fixture->test_object);
+  assert_uploading_disabled (fixture);
+
+  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_provider,
+                                                TRUE);
+  read_network_request (fixture->mock_server,
+                        (ProcessBytesSourceFunc) assert_no_events_received,
+                        fixture);
+}
+
+static void
+test_daemon_does_not_record_sequences_when_daemon_disabled (Fixture      *fixture,
+                                                            gconstpointer unused)
+{
+  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_provider,
+                                                FALSE);
+  record_sequence (fixture->test_object);
+  assert_uploading_disabled (fixture);
+
+  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_provider,
+                                                TRUE);
+  read_network_request (fixture->mock_server,
+                        (ProcessBytesSourceFunc) assert_no_events_received,
+                        fixture);
 }
 
 static void
@@ -465,8 +1131,10 @@ test_daemon_inhibits_shutdown (Fixture      *fixture,
                                gconstpointer unused)
 {
   start_mock_logind_service (fixture);
-  await_shutdown_inhibit (fixture);
-  terminate_mock_logind_service_and_wait (fixture);
+  read_lines_from_stdout (fixture->logind_mock,
+                          (ProcessLineSourceFunc) process_logind_line,
+                          NULL /* user_data */);
+  terminate_subprocess_and_wait (fixture->logind_mock);
 }
 
 static void
@@ -478,7 +1146,9 @@ test_daemon_updates_timestamps_on_shutdown (Fixture      *fixture,
   gint num_timestamp_updates_before =
     mock_persistent_cache_get_num_timestamp_updates (fixture->mock_persistent_cache);
 
-  await_shutdown_inhibit (fixture);
+  read_lines_from_stdout (fixture->logind_mock,
+                          (ProcessLineSourceFunc) process_logind_line,
+                          NULL /* user_data */);
   emit_shutdown_signal (TRUE);
 
   // Wait for EmerDaemon to handle the signal.
@@ -489,7 +1159,7 @@ test_daemon_updates_timestamps_on_shutdown (Fixture      *fixture,
     mock_persistent_cache_get_num_timestamp_updates (fixture->mock_persistent_cache);
   g_assert_cmpint (num_timestamp_updates_after, ==, num_timestamp_updates_before + 1);
 
-  terminate_mock_logind_service_and_wait (fixture);
+  terminate_subprocess_and_wait (fixture->logind_mock);
 }
 
 static void
@@ -501,7 +1171,9 @@ test_daemon_flushes_to_persistent_cache_on_shutdown (Fixture      *fixture,
   gint num_calls_before =
     mock_persistent_cache_get_store_metrics_called (fixture->mock_persistent_cache);
 
-  await_shutdown_inhibit (fixture);
+  read_lines_from_stdout (fixture->logind_mock,
+                          (ProcessLineSourceFunc) process_logind_line,
+                          NULL /* user_data */);
   emit_shutdown_signal (TRUE);
 
   // Wait for EmerDaemon to handle the signal.
@@ -512,7 +1184,7 @@ test_daemon_flushes_to_persistent_cache_on_shutdown (Fixture      *fixture,
     mock_persistent_cache_get_store_metrics_called (fixture->mock_persistent_cache);
   g_assert_cmpint (num_calls_after, ==, num_calls_before + 1);
 
-  terminate_mock_logind_service_and_wait (fixture);
+  terminate_subprocess_and_wait (fixture->logind_mock);
 }
 
 static void
@@ -521,7 +1193,9 @@ test_daemon_reinhibits_shutdown_on_shutdown_cancel (Fixture      *fixture,
 {
   start_mock_logind_service (fixture);
 
-  await_shutdown_inhibit (fixture);
+  read_lines_from_stdout (fixture->logind_mock,
+                          (ProcessLineSourceFunc) process_logind_line,
+                          NULL /* user_data */);
   emit_shutdown_signal (TRUE);
 
   // Wait for EmerDaemon to handle the signal.
@@ -529,9 +1203,11 @@ test_daemon_reinhibits_shutdown_on_shutdown_cancel (Fixture      *fixture,
     g_main_context_iteration (NULL, TRUE);
 
   emit_shutdown_signal (FALSE);
-  await_shutdown_inhibit (fixture);
+  read_lines_from_stdout (fixture->logind_mock,
+                          (ProcessLineSourceFunc) process_logind_line,
+                          NULL /* user_data */);
 
-  terminate_mock_logind_service_and_wait (fixture);
+  terminate_subprocess_and_wait (fixture->logind_mock);
 }
 
 int
@@ -545,18 +1221,22 @@ main (int                argc,
 
   ADD_DAEMON_TEST ("/daemon/new-succeeds", test_daemon_new_succeeds);
   ADD_DAEMON_TEST ("/daemon/new-full-succeeds", test_daemon_new_full_succeeds);
-  ADD_DAEMON_TEST ("/daemon/can-record-singular-event",
-                   test_daemon_can_record_singular_event);
-  ADD_DAEMON_TEST ("/daemon/can-record-aggregate-events",
-                   test_daemon_can_record_aggregate_events);
-  ADD_DAEMON_TEST ("/daemon/can-record-event-sequence",
-                   test_daemon_can_record_event_sequence);
-  ADD_DAEMON_TEST ("/daemon/does-not-record-singular-event-if-not-allowed",
-                   test_daemon_does_not_record_singular_event_if_not_allowed);
-  ADD_DAEMON_TEST ("/daemon/does-not-record-aggregate-event-if-not-allowed",
-                   test_daemon_does_not_record_aggregate_event_if_not_allowed);
-  ADD_DAEMON_TEST ("/daemon/does-not-record-event-sequence-if-not-allowed",
-                   test_daemon_does_not_record_event_sequence_if_not_allowed);
+  ADD_DAEMON_TEST ("/daemon/records-singulars", test_daemon_records_singulars);
+  ADD_DAEMON_TEST ("/daemon/records-aggregates",
+                   test_daemon_records_aggregates);
+  ADD_DAEMON_TEST ("/daemon/records-sequence", test_daemon_records_sequence);
+  ADD_DAEMON_TEST ("/daemon/only-reports-singulars-when-uploading-enabled",
+                   test_daemon_only_reports_singulars_when_uploading_enabled);
+  ADD_DAEMON_TEST ("/daemon/only-reports-aggregates-when-uploading-enabled",
+                   test_daemon_only_reports_aggregates_when_uploading_enabled);
+  ADD_DAEMON_TEST ("/daemon/only-reports-sequences-when-uploading-enabled",
+                   test_daemon_only_reports_sequences_when_uploading_enabled);
+  ADD_DAEMON_TEST ("/daemon/does-not-record-singulars-when-daemon-disabled",
+                   test_daemon_does_not_record_singulars_when_daemon_disabled);
+  ADD_DAEMON_TEST ("/daemon/does-not-record-aggregates-when-daemon-disabled",
+                   test_daemon_does_not_record_aggregates_when_daemon_disabled);
+  ADD_DAEMON_TEST ("/daemon/does-not-record-sequences-when-daemon-disabled",
+                   test_daemon_does_not_record_sequences_when_daemon_disabled);
   ADD_DAEMON_TEST ("/daemon/inhibits-shutdown", test_daemon_inhibits_shutdown);
   ADD_DAEMON_TEST ("/daemon/updates-timestamps-on-shutdown",
                    test_daemon_updates_timestamps_on_shutdown);

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -42,8 +42,10 @@
 
 #define MACHINE_ID_PATH "/tmp/testing-machine-id"
 #define USER_ID 4200u
-#define IO_OPERATION_TIMEOUT_MS 5000  /* 5 seconds */
 #define RELATIVE_TIMESTAMP G_GINT64_CONSTANT (123456789)
+
+#define TIMEOUT_SEC 5
+
 #define EXPECTED_INHIBIT_SHUTDOWN_ARGS \
   "\"shutdown\" " \
   "\"EndlessOS Event Recorder Daemon\" " \
@@ -229,7 +231,7 @@ await_shutdown_inhibit (Fixture *fixture)
   g_source_unref (stdout_source);
 
   fixture->timeout_id =
-    g_timeout_add_seconds (5, timeout, NULL /* user data */);
+    g_timeout_add_seconds (TIMEOUT_SEC, timeout, NULL /* user data */);
 
   g_main_loop_run (fixture->main_loop);
 
@@ -254,7 +256,7 @@ emit_shutdown_signal (gboolean shutdown)
                                                 "PrepareForShutdown", "b",
                                                 &args_builder),
                                  NULL, G_DBUS_CALL_FLAGS_NO_AUTO_START,
-                                 IO_OPERATION_TIMEOUT_MS,
+                                 TIMEOUT_SEC * 1000,
                                  NULL, NULL);
   g_assert_nonnull (response);
 }

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -56,8 +56,8 @@
 typedef struct
 {
   EmerDaemon *test_object;
-  EmerNetworkSendProvider *mock_network_send_prov;
-  EmerPermissionsProvider *mock_permissions_prov;
+  EmerNetworkSendProvider *mock_network_send_provider;
+  EmerPermissionsProvider *mock_permissions_provider;
   EmerPersistentCache *mock_persistent_cache;
 
   /* Mock logind service */
@@ -304,20 +304,20 @@ static void
 setup (Fixture      *fixture,
        gconstpointer unused)
 {
-  EmerMachineIdProvider *id_prov =
+  EmerMachineIdProvider *machine_id_provider =
     emer_machine_id_provider_new_full (MACHINE_ID_PATH);
-  fixture->mock_permissions_prov = emer_permissions_provider_new ();
+  fixture->mock_network_send_provider = emer_network_send_provider_new ();
+  fixture->mock_permissions_provider = emer_permissions_provider_new ();
   fixture->mock_persistent_cache = emer_persistent_cache_new (NULL, NULL);
-  fixture->mock_network_send_prov = emer_network_send_provider_new ();
   fixture->test_object =
     emer_daemon_new_full (g_rand_new_with_seed (18),
                           5, // Network Send Interval
-                          id_prov, // MachineIdProvider
-                          fixture->mock_network_send_prov,
-                          fixture->mock_permissions_prov,
+                          machine_id_provider,
+                          fixture->mock_network_send_provider,
+                          fixture->mock_permissions_provider,
                           fixture->mock_persistent_cache,
                           20); // Buffer length
-  g_object_unref (id_prov);
+  g_object_unref (machine_id_provider);
 }
 
 static void
@@ -325,8 +325,8 @@ teardown (Fixture      *fixture,
           gconstpointer unused)
 {
   g_object_unref (fixture->test_object);
-  g_object_unref (fixture->mock_network_send_prov);
-  g_object_unref (fixture->mock_permissions_prov);
+  g_object_unref (fixture->mock_network_send_provider);
+  g_object_unref (fixture->mock_permissions_provider);
   g_object_unref (fixture->mock_persistent_cache);
   g_unlink (MACHINE_ID_PATH);
 }
@@ -408,13 +408,14 @@ test_daemon_does_not_record_singular_event_if_not_allowed (Fixture      *fixture
                                                            gconstpointer unused)
 {
   gint num_calls_before =
-    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_prov);
+    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_provider);
 
-  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_prov, FALSE);
+  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_provider,
+                                                FALSE);
   test_daemon_can_record_singular_event (fixture, unused);
 
   gint num_calls_after =
-    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_prov);
+    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_provider);
 
   /*
    * FIXME: Nothing can currently be asserted about whether the EmerDaemon tries
@@ -429,13 +430,14 @@ test_daemon_does_not_record_aggregate_event_if_not_allowed (Fixture      *fixtur
                                                             gconstpointer unused)
 {
   gint num_calls_before =
-    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_prov);
+    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_provider);
 
-  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_prov, FALSE);
+  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_provider,
+                                                FALSE);
   test_daemon_can_record_aggregate_events (fixture, unused);
 
   gint num_calls_after =
-    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_prov);
+    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_provider);
 
   /* FIXME: See note above. */
   g_assert_cmpint (num_calls_after, >=, num_calls_before + 1);
@@ -446,13 +448,14 @@ test_daemon_does_not_record_event_sequence_if_not_allowed (Fixture      *fixture
                                                            gconstpointer unused)
 {
   gint num_calls_before =
-    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_prov);
+    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_provider);
 
-  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_prov, FALSE);
+  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_provider,
+                                                FALSE);
   test_daemon_can_record_event_sequence (fixture, unused);
 
   gint num_calls_after =
-    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_prov);
+    mock_permissions_provider_get_daemon_enabled_called (fixture->mock_permissions_provider);
 
   /* FIXME: See note above. */
   g_assert_cmpint (num_calls_after, >=, num_calls_before + 1);

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -476,7 +476,7 @@ make_event_values_variant (void)
                          RELATIVE_TIMESTAMP,
                          TRUE,
                          g_variant_new_boolean (TRUE));
-  return g_variant_new ("a(xbv)", &builder);
+  return g_variant_builder_end (&builder);
 }
 
 static void

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -262,7 +262,7 @@ emit_shutdown_signal (gboolean shutdown)
 }
 
 static GVariant *
-make_event_id_gvariant (void)
+make_event_id_variant (void)
 {
   uuid_t uuid;
   if (uuid_parse (MEANINGLESS_EVENT, uuid) != 0)
@@ -273,14 +273,14 @@ make_event_id_gvariant (void)
 }
 
 static GVariant *
-make_variant_payload (void)
+make_auxiliary_payload (void)
 {
   GVariant *sword_of_a_thousand = g_variant_new_boolean (TRUE);
   return g_variant_new_variant (sword_of_a_thousand);
 }
 
 static GVariant *
-make_event_values_gvariant (void)
+make_event_values_variant (void)
 {
   GVariantBuilder builder;
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("a(xbv)"));
@@ -354,22 +354,22 @@ test_daemon_can_record_singular_event (Fixture      *fixture,
 {
   emer_daemon_record_singular_event (fixture->test_object,
                                      USER_ID,
-                                     make_event_id_gvariant (),
+                                     make_event_id_variant (),
                                      RELATIVE_TIMESTAMP,
                                      FALSE,
                                      g_variant_new_string ("This must be ignored."));
   emer_daemon_record_singular_event (fixture->test_object,
                                      USER_ID,
-                                     make_event_id_gvariant (),
+                                     make_event_id_variant (),
                                      RELATIVE_TIMESTAMP,
                                      FALSE,
                                      g_variant_new_string ("This must be ignored."));
   emer_daemon_record_singular_event (fixture->test_object,
                                      USER_ID,
-                                     make_event_id_gvariant (),
+                                     make_event_id_variant (),
                                      RELATIVE_TIMESTAMP,
                                      TRUE,
-                                     make_variant_payload ());
+                                     make_auxiliary_payload ());
 }
 
 static void
@@ -378,18 +378,18 @@ test_daemon_can_record_aggregate_events (Fixture      *fixture,
 {
   emer_daemon_record_aggregate_event (fixture->test_object,
                                       USER_ID,
-                                      make_event_id_gvariant (),
+                                      make_event_id_variant (),
                                       101,
                                       RELATIVE_TIMESTAMP,
                                       FALSE,
                                       g_variant_new_string ("This must be ignored."));
   emer_daemon_record_aggregate_event (fixture->test_object,
                                       USER_ID,
-                                      make_event_id_gvariant (),
+                                      make_event_id_variant (),
                                       101,
                                       RELATIVE_TIMESTAMP,
                                       TRUE,
-                                      make_variant_payload ());
+                                      make_auxiliary_payload ());
 }
 
 static void
@@ -398,8 +398,8 @@ test_daemon_can_record_event_sequence (Fixture      *fixture,
 {
   emer_daemon_record_event_sequence (fixture->test_object,
                                      USER_ID,
-                                     make_event_id_gvariant (),
-                                     make_event_values_gvariant ());
+                                     make_event_id_variant (),
+                                     make_event_values_variant ());
 }
 
 static void

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -57,7 +57,7 @@
   "\"Flushing events to disk\" " \
   "\"delay\""
 
-typedef struct
+typedef struct _Fixture
 {
   EmerDaemon *test_object;
   EmerMachineIdProvider *mock_machine_id_provider;

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -223,7 +223,7 @@ read_byte (GPollableInputStream *pollable_input_stream,
   switch (num_bytes_read)
     {
     case -1:
-      g_assert (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK));
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK);
       g_error_free (error); // Fall through.
     case 0:
       return FALSE;
@@ -291,9 +291,7 @@ append_bytes (GPollableInputStream *pollable_input_stream,
                                               NULL /* GCancellable */, &error);
   if (num_bytes_read == -1)
     {
-      gboolean would_block =
-        g_error_matches (error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK);
-      g_assert_true (would_block);
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK);
       g_error_free (error);
       return FALSE;
     }

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -21,7 +21,6 @@
 #include "daemon/emer-persistent-cache.h"
 
 #include <glib.h>
-#include <stdio.h>
 #include <glib/gstdio.h>
 
 #include <eosmetrics/eosmetrics.h>

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -106,13 +106,14 @@ static void
 write_default_cache_version_key_file (void)
 {
   GKeyFile *key_file = g_key_file_new ();
-  g_assert (g_key_file_load_from_data (key_file,
-                                       DEFAULT_CACHE_VERSION_KEY_FILE_DATA,
-                                       -1, G_KEY_FILE_NONE, NULL));
+  gboolean load_succeeded =
+    g_key_file_load_from_data (key_file, DEFAULT_CACHE_VERSION_KEY_FILE_DATA,
+                               -1, G_KEY_FILE_NONE, NULL);
+  g_assert_true (load_succeeded);
 
-  g_assert (g_key_file_save_to_file (key_file,
-                                     TEST_DIRECTORY TEST_CACHE_VERSION_FILE,
-                                     NULL));
+  gboolean save_succeeded =
+    g_key_file_save_to_file (key_file, TEST_DIRECTORY TEST_CACHE_VERSION_FILE, NULL);
+  g_assert_true (save_succeeded);
   g_key_file_unref (key_file);
 }
 
@@ -198,8 +199,9 @@ load_testing_key_file (void)
   GKeyFile *key_file = g_key_file_new ();
   gchar *full_path =
     g_strconcat (TEST_DIRECTORY, BOOT_OFFSET_METADATA_FILE, NULL);
-  g_assert (g_key_file_load_from_file (key_file, full_path, G_KEY_FILE_NONE,
-                                       NULL));
+  gboolean load_succeeded =
+    g_key_file_load_from_file (key_file, full_path, G_KEY_FILE_NONE, NULL);
+  g_assert_true (load_succeeded);
   return key_file;
 }
 
@@ -217,9 +219,10 @@ set_boot_offset_in_metadata_file (gint64 new_offset)
                         CACHE_BOOT_OFFSET_KEY,
                         new_offset);
 
-  g_assert (g_key_file_save_to_file (key_file,
-                                     TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
-                                     NULL));
+  gboolean save_succeeded =
+    g_key_file_save_to_file (key_file, TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
+                             NULL);
+  g_assert_true (save_succeeded);
   g_key_file_unref (key_file);
 }
 
@@ -233,13 +236,15 @@ static void
 write_default_boot_offset_key_file_to_disk (void)
 {
   GKeyFile *key_file = g_key_file_new ();
-  g_assert (g_key_file_load_from_data (key_file,
-                                       DEFAULT_BOOT_OFFSET_KEY_FILE_DATA,
-                                       -1, G_KEY_FILE_NONE, NULL));
+  gboolean load_succeeded =
+    g_key_file_load_from_data (key_file, DEFAULT_BOOT_OFFSET_KEY_FILE_DATA, -1,
+                               G_KEY_FILE_NONE, NULL);
+  g_assert_true (load_succeeded);
 
-  g_assert (g_key_file_save_to_file (key_file,
-                                     TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
-                                     NULL));
+  gboolean save_succeeded =
+    g_key_file_save_to_file (key_file, TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
+                             NULL);
+  g_assert_true (save_succeeded);
 }
 
 /*
@@ -255,9 +260,10 @@ set_boot_id_in_metadata_file (gchar *boot_id)
                          CACHE_LAST_BOOT_ID_KEY,
                          boot_id);
 
-  g_assert (g_key_file_save_to_file (key_file,
-                                     TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
-                                     NULL));
+  gboolean save_succeeded =
+    g_key_file_save_to_file (key_file, TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
+                             NULL);
+  g_assert_true (save_succeeded);
   g_key_file_unref (key_file);
 }
 
@@ -269,12 +275,15 @@ static void
 remove_offset (void)
 {
   GKeyFile *key_file = load_testing_key_file ();
-  g_assert (g_key_file_remove_key (key_file, CACHE_TIMING_GROUP_NAME,
-                                   CACHE_BOOT_OFFSET_KEY, NULL));
+  gboolean remove_succeeded =
+    g_key_file_remove_key (key_file, CACHE_TIMING_GROUP_NAME,
+                           CACHE_BOOT_OFFSET_KEY, NULL);
+  g_assert_true (remove_succeeded);
 
-  g_assert (g_key_file_save_to_file (key_file,
-                                     TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
-                                     NULL));
+  gboolean save_succeeded =
+    g_key_file_save_to_file (key_file, TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
+                             NULL);
+  g_assert_true (save_succeeded);
   g_key_file_unref (key_file);
 }
 
@@ -359,10 +368,15 @@ boot_timestamp_is_valid (gint64 previous_relative_time,
   gint64 stored_relative_time = read_relative_time ();
   gint64 stored_absolute_time = read_absolute_time ();
 
-  gint64 after_relative_time, after_absolute_time;
+  gint64 after_relative_time;
+  gboolean get_succeeded =
+    emtr_util_get_current_time (CLOCK_BOOTTIME, &after_relative_time);
+  g_assert_true (get_succeeded);
 
-  g_assert (emtr_util_get_current_time (CLOCK_BOOTTIME, &after_relative_time) &&
-            emtr_util_get_current_time (CLOCK_REALTIME, &after_absolute_time));
+  gint64 after_absolute_time;
+  get_succeeded =
+    emtr_util_get_current_time (CLOCK_REALTIME, &after_absolute_time);
+  g_assert_true (get_succeeded);
 
   // The actual testing:
   return (previous_relative_time <= stored_relative_time &&
@@ -923,10 +937,10 @@ assert_singulars_equal_variants (SingularEvent *singular_array,
 {
   for (gint i = 0; i < singular_array_length || variants[i] != NULL; i++)
     {
-      g_assert (i < singular_array_length && variants[i] != NULL);
+      g_assert_true (i < singular_array_length && variants[i] != NULL);
 
       GVariant *singular_variant = singular_to_variant (singular_array + i);
-      g_assert (g_variant_equal (singular_variant, variants[i]));
+      g_assert_true (g_variant_equal (singular_variant, variants[i]));
       g_variant_unref (singular_variant);
     }
 }
@@ -938,10 +952,10 @@ assert_aggregates_equal_variants (AggregateEvent *aggregate_array,
 {
   for (gint i = 0; i < aggregate_array_length || variants[i] != NULL; i++)
     {
-      g_assert (i < aggregate_array_length && variants[i] != NULL);
+      g_assert_true (i < aggregate_array_length && variants[i] != NULL);
 
       GVariant *aggregate_variant = aggregate_to_variant (aggregate_array + i);
-      g_assert (g_variant_equal (aggregate_variant, variants[i]));
+      g_assert_true (g_variant_equal (aggregate_variant, variants[i]));
       g_variant_unref (aggregate_variant);
     }
 }
@@ -953,10 +967,10 @@ assert_sequences_equal_variants (SequenceEvent *sequence_array,
 {
   for (gint i = 0; i < sequence_array_length || variants[i] != NULL; i++)
     {
-      g_assert (i < sequence_array_length && variants[i] != NULL);
+      g_assert_true (i < sequence_array_length && variants[i] != NULL);
 
       GVariant *sequence_variant = sequence_to_variant (sequence_array + i);
-      g_assert (g_variant_equal (sequence_variant, variants[i]));
+      g_assert_true (g_variant_equal (sequence_variant, variants[i]));
       g_variant_unref (sequence_variant);
     }
 }
@@ -996,15 +1010,15 @@ test_persistent_cache_store_sets_out_parameters (gboolean     *unused,
   gint num_aggregates_stored = -50;
   gint num_sequences_stored = 555;
 
-  g_assert (emer_persistent_cache_store_metrics (cache,
-                                                 singular_array,
-                                                 aggregate_array,
-                                                 sequence_array,
-                                                 0, 0, 0,
-                                                 &num_singulars_stored,
-                                                 &num_aggregates_stored,
-                                                 &num_sequences_stored,
-                                                 &capacity));
+  g_assert_true (emer_persistent_cache_store_metrics (cache,
+                                                      singular_array,
+                                                      aggregate_array,
+                                                      sequence_array,
+                                                      0, 0, 0,
+                                                      &num_singulars_stored,
+                                                      &num_aggregates_stored,
+                                                      &num_sequences_stored,
+                                                      &capacity));
 
   // An empty cache should be in the LOW capacity state.
   g_assert_cmpint (capacity, ==, CAPACITY_LOW);
@@ -1021,7 +1035,7 @@ test_persistent_cache_store_one_singular_event_succeeds (gboolean     *unused,
 {
   EmerPersistentCache *cache = make_testing_cache ();
   capacity_t capacity;
-  g_assert (store_single_singular_event (cache, &capacity));
+  g_assert_true (store_single_singular_event (cache, &capacity));
   g_object_unref (cache);
   g_assert_cmpint (capacity, ==, CAPACITY_LOW);
 }
@@ -1032,7 +1046,7 @@ test_persistent_cache_store_one_aggregate_event_succeeds (gboolean     *unused,
 {
   EmerPersistentCache *cache = make_testing_cache ();
   capacity_t capacity;
-  g_assert (store_single_aggregate_event (cache, &capacity));
+  g_assert_true (store_single_aggregate_event (cache, &capacity));
   g_object_unref (cache);
   g_assert_cmpint (capacity, ==, CAPACITY_LOW);
 }
@@ -1043,7 +1057,7 @@ test_persistent_cache_store_one_sequence_event_succeeds (gboolean     *unused,
 {
   EmerPersistentCache *cache = make_testing_cache ();
   capacity_t capacity;
-  g_assert (store_single_sequence_event (cache, &capacity));
+  g_assert_true (store_single_sequence_event (cache, &capacity));
   g_object_unref (cache);
   g_assert_cmpint (capacity, ==, CAPACITY_LOW);
 }
@@ -1080,7 +1094,7 @@ test_persistent_cache_store_one_of_each_succeeds (gboolean     *unused,
 
   g_free (sequence_array[0].event_values);
 
-  g_assert (success);
+  g_assert_true (success);
 
   g_assert_cmpint (num_singulars_stored, ==, 1);
   g_assert_cmpint (num_aggregates_stored, ==, 1);
@@ -1103,7 +1117,7 @@ test_persistent_cache_store_many_succeeds (gboolean     *unused,
                 &num_sequences_made, &num_singulars_stored,
                 &num_aggregates_stored, &num_sequences_stored, &capacity);
   g_object_unref (cache);
-  g_assert (success);
+  g_assert_true (success);
 
   g_assert_cmpint (num_singulars_stored, ==, num_singulars_made);
   g_assert_cmpint (num_aggregates_stored, ==, num_aggregates_made);
@@ -1147,7 +1161,7 @@ test_persistent_cache_store_when_full_succeeds (gboolean     *unused,
         store_many (cache, &num_singulars_made, &num_aggregates_made,
                     &num_sequences_made, &num_singulars_stored,
                     &num_aggregates_stored, &num_sequences_stored, &capacity);
-      g_assert (success);
+      g_assert_true (success);
 
       if (capacity == CAPACITY_MAX)
         {
@@ -1200,7 +1214,7 @@ test_persistent_cache_drain_one_singular_event_succeeds (gboolean     *unused,
                                                           MAX_BYTES_TO_READ);
   g_object_unref (cache);
 
-  g_assert (success);
+  g_assert_true (success);
 
   assert_singulars_equal_variants (singulars_stored, 1, singulars_drained);
   g_assert_cmpint (c_array_len (aggregates_drained), ==, 0);
@@ -1248,7 +1262,7 @@ test_persistent_cache_drain_one_aggregate_event_succeeds (gboolean     *unused,
                                                           MAX_BYTES_TO_READ);
   g_object_unref (cache);
 
-  g_assert (success);
+  g_assert_true (success);
 
   g_assert_cmpint (c_array_len (singulars_drained), ==, 0);
   assert_aggregates_equal_variants (aggregates_stored, 1, aggregates_drained);
@@ -1298,7 +1312,7 @@ test_persistent_cache_drain_one_sequence_event_succeeds (gboolean     *unused,
                                                           MAX_BYTES_TO_READ);
   g_object_unref (cache);
 
-  g_assert (success);
+  g_assert_true (success);
 
   g_assert_cmpint (c_array_len (singulars_drained), ==, 0);
   g_assert_cmpint (c_array_len (aggregates_drained), ==, 0);
@@ -1359,7 +1373,7 @@ test_persistent_cache_drain_many_succeeds (gboolean     *unused,
                                                           MAX_BYTES_TO_READ);
   g_object_unref (cache);
 
-  g_assert (success);
+  g_assert_true (success);
   assert_singulars_equal_variants (singulars_stored, num_singulars_made,
                                    singulars_drained);
   assert_aggregates_equal_variants (aggregates_stored, num_aggregates_made,
@@ -1390,7 +1404,7 @@ test_persistent_cache_drain_empty_succeeds (gboolean     *unused,
                                                           MAX_BYTES_TO_READ);
   g_object_unref (cache);
 
-  g_assert (success);
+  g_assert_true (success);
 
   g_assert_cmpint (c_array_len (singulars_drained), ==, 0);
   g_assert_cmpint (c_array_len (aggregates_drained), ==, 0);
@@ -1431,11 +1445,16 @@ test_persistent_cache_purges_when_out_of_date_succeeds (gboolean     *unused,
               &num_aggregates_stored, &num_sequences_stored, &capacity);
 
   gint current_version;
-  g_assert (emer_cache_version_provider_get_version (cache_version_provider,
-                                                     &current_version));
-  g_assert (emer_cache_version_provider_set_version (cache_version_provider,
-                                                     current_version - 1,
-                                                     &error));
+  gboolean get_succeeded =
+    emer_cache_version_provider_get_version (cache_version_provider,
+                                             &current_version);
+  g_assert_true (get_succeeded);
+
+  gboolean set_succeeded =
+    emer_cache_version_provider_set_version (cache_version_provider,
+                                             current_version - 1, &error);
+  g_assert_true (set_succeeded);
+
   g_assert_no_error (error);
   g_object_unref (cache_version_provider);
   g_object_unref (cache);
@@ -1536,13 +1555,15 @@ test_persistent_cache_resets_boot_metadata_file_when_boot_offset_corrupted (gboo
                          "valid boot offset in the metadata file. Error: *.");
 
   // This call should detect corruption and reset the metadata file.
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
-                                                        TRUE));
+  gboolean get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
+
+  g_assert_true (get_succeeded);
 
   g_test_assert_expected_messages ();
   g_assert_no_error (error);
 
-  g_assert (boot_offset_was_reset ());
+  g_assert_true (boot_offset_was_reset ());
 
   g_object_unref (cache);
 }
@@ -1568,14 +1589,17 @@ test_persistent_cache_does_not_compute_offset_when_boot_id_is_same (gboolean    
   EmerPersistentCache *cache = make_testing_cache ();
 
   GError *error = NULL;
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
-                                                        TRUE));
+  gboolean get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
+  g_assert_true (get_succeeded);
   g_assert_no_error (error);
-  g_assert (boot_offset_was_reset ());
+  g_assert_true (boot_offset_was_reset ());
 
-  gint64 absolute_time, relative_time;
-  g_assert (emtr_util_get_current_time (CLOCK_BOOTTIME, &relative_time) &&
-            emtr_util_get_current_time (CLOCK_REALTIME, &absolute_time));
+  gint64 relative_time;
+  g_assert_true (emtr_util_get_current_time (CLOCK_BOOTTIME, &relative_time));
+
+  gint64 absolute_time;
+  g_assert_true (emtr_util_get_current_time (CLOCK_REALTIME, &absolute_time));
 
   g_object_unref (cache);
   set_boot_id_in_metadata_file (FAKE_BOOT_ID);
@@ -1583,11 +1607,13 @@ test_persistent_cache_does_not_compute_offset_when_boot_id_is_same (gboolean    
   EmerPersistentCache *cache2 = make_testing_cache ();
 
   // This call should have to compute the boot offset itself.
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache2, NULL, &error,
-                                                        TRUE));
+  get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache2, NULL, &error, TRUE);
+
+  g_assert_true (get_succeeded);
   g_assert_no_error (error);
 
-  g_assert (boot_timestamp_is_valid (relative_time, absolute_time));
+  g_assert_true (boot_timestamp_is_valid (relative_time, absolute_time));
   gint64 second_offset = read_offset ();
 
   // This should not have simply reset the metadata file again.
@@ -1596,8 +1622,9 @@ test_persistent_cache_does_not_compute_offset_when_boot_id_is_same (gboolean    
   g_object_unref (cache2);
   EmerPersistentCache *cache3 = make_testing_cache ();
 
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache3, NULL, &error,
-                                                        TRUE));
+  get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache3, NULL, &error, TRUE);
+  g_assert_true (get_succeeded);
   g_assert_no_error (error);
 
   gint64 third_offset = read_offset ();
@@ -1623,11 +1650,13 @@ test_persistent_cache_computes_reasonable_offset (gboolean     *unused,
   store_single_singular_event (cache, &capacity);
 
   gint64 first_offset = read_offset ();
-  g_assert (boot_offset_was_reset ());
+  g_assert_true (boot_offset_was_reset ());
 
-  gint64 absolute_time, relative_time;
-  g_assert (emtr_util_get_current_time (CLOCK_BOOTTIME, &relative_time) &&
-            emtr_util_get_current_time (CLOCK_REALTIME, &absolute_time));
+  gint64 relative_time;
+  g_assert_true (emtr_util_get_current_time (CLOCK_BOOTTIME, &relative_time));
+
+  gint64 absolute_time;
+  g_assert_true (emtr_util_get_current_time (CLOCK_REALTIME, &absolute_time));
 
   g_object_unref (cache);
   EmerPersistentCache *cache2 = make_testing_cache ();
@@ -1637,7 +1666,7 @@ test_persistent_cache_computes_reasonable_offset (gboolean     *unused,
 
   store_single_aggregate_event (cache2, &capacity);
 
-  g_assert (boot_timestamp_is_valid (relative_time, absolute_time));
+  g_assert_true (boot_timestamp_is_valid (relative_time, absolute_time));
   gint64 second_offset = read_offset ();
   gint64 max_second_offset = first_offset + ACCEPTABLE_OFFSET_VARIANCE;
   gint64 min_second_offset = first_offset - ACCEPTABLE_OFFSET_VARIANCE;
@@ -1645,7 +1674,7 @@ test_persistent_cache_computes_reasonable_offset (gboolean     *unused,
   g_assert_cmpint (second_offset, >=, min_second_offset);
 
   // This should not have simply reset the metadata file again.
-  g_assert (!boot_offset_was_reset ());
+  g_assert_false (boot_offset_was_reset ());
 
   g_object_unref (cache2);
 }
@@ -1665,26 +1694,30 @@ test_persistent_cache_builds_boot_metadata_file (gboolean     *unused,
   EmerPersistentCache *cache = make_testing_cache ();
 
   GError *error = NULL;
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
-                                                        TRUE));
+  gboolean get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
+  g_assert_true (get_succeeded);
   g_assert_no_error (error);
 
   gint64 first_offset = read_offset ();
 
-  gint64 absolute_time, relative_time;
-  g_assert (emtr_util_get_current_time (CLOCK_BOOTTIME, &relative_time) &&
-            emtr_util_get_current_time (CLOCK_REALTIME, &absolute_time));
+  gint64 relative_time;
+  g_assert_true (emtr_util_get_current_time (CLOCK_BOOTTIME, &relative_time));
 
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
-                                                        TRUE));
+  gint64 absolute_time;
+  g_assert_true (emtr_util_get_current_time (CLOCK_REALTIME, &absolute_time));
+
+  get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
+  g_assert_true (get_succeeded);
   g_assert_no_error (error);
 
-  g_assert (boot_timestamp_is_valid (relative_time, absolute_time));
+  g_assert_true (boot_timestamp_is_valid (relative_time, absolute_time));
   gint64 second_offset = read_offset();
 
   // The offset should not have changed.
   g_assert_cmpint (first_offset, ==, second_offset);
-  g_assert (boot_offset_was_reset ());
+  g_assert_true (boot_offset_was_reset ());
 
   g_object_unref (cache);
 }
@@ -1702,13 +1735,17 @@ test_persistent_cache_reads_cached_boot_offset (gboolean     *unused,
 
   gint64 first_offset;
   GError *error = NULL;
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, &first_offset,
-                                                        &error, TRUE));
+  gboolean get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache, &first_offset, &error,
+                                                TRUE);
+  g_assert_true (get_succeeded);
   g_assert_no_error (error);
 
-  gint64 absolute_time, relative_time;
-  g_assert (emtr_util_get_current_time (CLOCK_BOOTTIME, &relative_time) &&
-            emtr_util_get_current_time (CLOCK_REALTIME, &absolute_time));
+  gint64 relative_time;
+  g_assert_true (emtr_util_get_current_time (CLOCK_BOOTTIME, &relative_time));
+
+  gint64 absolute_time;
+  g_assert_true (emtr_util_get_current_time (CLOCK_REALTIME, &absolute_time));
 
   /*
    * This value should never be read because the persistent cache should read
@@ -1722,11 +1759,13 @@ test_persistent_cache_reads_cached_boot_offset (gboolean     *unused,
    * This call should read the offset from its in-memory cache, not the new one
    * on disk.
    */
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, &second_offset,
-                                                        &error, TRUE));
+  get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache, &second_offset, &error,
+                                                TRUE);
+  g_assert_true (get_succeeded);
   g_assert_no_error (error);
 
-  g_assert (boot_timestamp_is_valid (relative_time, absolute_time));
+  g_assert_true (boot_timestamp_is_valid (relative_time, absolute_time));
 
   g_assert_cmpint (first_offset, ==, second_offset);
 
@@ -1752,8 +1791,9 @@ test_persistent_cache_get_offset_wont_update_timestamps_if_it_isnt_supposed_to (
   GError *error = NULL;
 
   // Update metadata file to reasonable values.
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
-                                                        TRUE));
+  gboolean get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
+  g_assert_true (get_succeeded);
   g_assert_no_error (error);
   gint64 relative_time = read_relative_time ();
   gint64 absolute_time = read_absolute_time ();
@@ -1762,8 +1802,10 @@ test_persistent_cache_get_offset_wont_update_timestamps_if_it_isnt_supposed_to (
   g_usleep (75000); // 0.075 seconds
 
   // This call shouldn't update the metadata file.
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
-                                                        FALSE));
+  get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, FALSE);
+
+  g_assert_true (get_succeeded);
   g_assert_no_error (error);
 
   // These timestamps should not have changed.
@@ -1791,8 +1833,9 @@ test_persistent_cache_get_offset_updates_timestamps_when_requested (gboolean    
   GError *error = NULL;
 
   // Update metadata file to reasonable values.
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
-                                                        FALSE));
+  gboolean get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, FALSE);
+  g_assert_true (get_succeeded);
 
   g_assert_no_error (error);
   gint64 relative_time = read_relative_time ();
@@ -1802,8 +1845,9 @@ test_persistent_cache_get_offset_updates_timestamps_when_requested (gboolean    
   g_usleep (75000); // 0.075 seconds
 
   // This call should update the timestamps in the metadata file.
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
-                                                        TRUE));
+  get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
+  g_assert_true (get_succeeded);
 
   g_assert_no_error (error);
 
@@ -1826,8 +1870,10 @@ test_persistent_cache_updates_timestamps_on_finalize (gboolean     *unused,
   GError *error = NULL;
 
   // Update metadata file to reasonable values.
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
-                                                        TRUE));
+  gboolean get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
+
+  g_assert_true (get_succeeded);
   g_assert_no_error (error);
   gint64 relative_time = read_relative_time ();
   gint64 absolute_time = read_absolute_time ();
@@ -1864,12 +1910,14 @@ test_persistent_cache_get_offset_can_build_boot_metadata_file (gboolean     *unu
    * This call should create the metadata file even though the
    * always_update_timestamps parameter is FALSE.
    */
-  g_assert (emer_persistent_cache_get_boot_time_offset (cache, NULL, &error,
-                                                        FALSE));
+  gboolean get_succeeded =
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, FALSE);
+
+  g_assert_true (get_succeeded);
   g_assert_no_error (error);
 
   // The previous request should have reset the metadata file.
-  g_assert (boot_offset_was_reset ());
+  g_assert_true (boot_offset_was_reset ());
 
   g_object_unref (cache);
 }
@@ -1895,9 +1943,10 @@ test_g_file_measure_disk_usage_returns_zero_on_empty_file (gboolean     *unused,
   g_assert_no_error (error);
 
   guint64 disk_usage = 555; // Arbitrary non-zero value
-  g_assert (g_file_measure_disk_usage (file, G_FILE_MEASURE_REPORT_ANY_ERROR,
-                                       NULL, NULL, NULL, &disk_usage, NULL,
-                                       NULL, &error));
+  gboolean measure_succeeded =
+    g_file_measure_disk_usage (file, G_FILE_MEASURE_REPORT_ANY_ERROR, NULL,
+                               NULL, NULL, &disk_usage, NULL, NULL, &error);
+  g_assert_true (measure_succeeded);
   g_assert_no_error (error);
   g_assert_cmpint (disk_usage, ==, 0);
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -1875,6 +1875,7 @@ test_persistent_cache_updates_timestamps_on_finalize (gboolean     *unused,
 
   g_assert_true (get_succeeded);
   g_assert_no_error (error);
+
   gint64 relative_time = read_relative_time ();
   gint64 absolute_time = read_absolute_time ();
 

--- a/tests/test-opt-out-integration.py
+++ b/tests/test-opt-out-integration.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2014, 2015 Endless Mobile, Inc.
 
 # This file is part of eos-event-recorder-daemon.

--- a/tools/Makefile.am.inc
+++ b/tools/Makefile.am.inc
@@ -47,6 +47,7 @@ tools_print_persistent_cache_LDADD = $(PERSISTENT_CACHE_TOOL_LIBS)
 dist_bin_SCRIPTS = \
 	tools/eos-enable-metrics-uploading \
 	tools/eos-select-metrics-env \
+	tools/eos-upload-metrics \
 	$(NULL)
 EXTRA_DIST += \
 	tools/eos-enable-metrics-uploading.in \

--- a/tools/eos-upload-metrics
+++ b/tools/eos-upload-metrics
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+UPLOAD_EVENTS_OUTPUT=$(gdbus call --system \
+    --dest com.endlessm.Metrics --object-path /com/endlessm/Metrics \
+    --method com.endlessm.Metrics.EventRecorderServer.UploadEvents)
+
+if [ "$UPLOAD_EVENTS_OUTPUT" != '()' ]; then
+  echo "$UPLOAD_EVENTS_OUTPUT" >&2
+  exit 1
+fi
+
+echo "Successfully uploaded all events to servers."


### PR DESCRIPTION
The new method allows consumers of the API to trigger a network upload
of all events currently stored on the client. Also, add a convenience
script that calls this new method. Finally, add a local server for
testing purposes and greatly improve test coverage of the daemon.

[endlessm/eos-sdk#3168]