### PR TITLE
Fix crash in upload retry path.

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -337,8 +337,8 @@ get_updated_request_body (EmerDaemon *self,
 
   return g_variant_new ("(ixx@ay@a(uayxmv)@a(uayxxmv)@a(uaya(xmv)))",
                         send_number, little_endian_relative_timestamp,
-                        little_endian_absolute_timestamp, &machine_id,
-                        &singulars, &aggregates, &sequences);
+                        little_endian_absolute_timestamp, machine_id,
+                        singulars, aggregates, sequences);
 }
 
 // Handles HTTP or HTTPS responses.

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -727,16 +727,14 @@ handle_network_monitor_can_reach (GNetworkMonitor *network_monitor,
     {
       flush_to_persistent_cache (self);
       g_task_return_error (upload_task, error);
-      g_object_unref (upload_task);
-      return;
+      goto handle_upload_failed;
     }
 
   GVariant *request_body = create_request_body (self, &error);
   if (request_body == NULL)
     {
       g_task_return_error (upload_task, error);
-      g_object_unref (upload_task);
-      return;
+      goto handle_upload_failed;
     }
 
   gconstpointer serialized_request_body = g_variant_get_data (request_body);
@@ -744,8 +742,7 @@ handle_network_monitor_can_reach (GNetworkMonitor *network_monitor,
     {
       g_task_return_new_error (upload_task, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
                                "Could not serialize network request body.");
-      g_object_unref (upload_task);
-      return;
+      goto handle_upload_failed;
     }
 
   priv->uploading = TRUE;
@@ -770,6 +767,11 @@ handle_network_monitor_can_reach (GNetworkMonitor *network_monitor,
   soup_session_queue_message (priv->http_session, http_message,
                               (SoupSessionCallback) handle_http_response,
                               callback_data);
+  return;
+
+handle_upload_failed:
+  g_object_unref (upload_task);
+  g_signal_emit (self, emer_daemon_signals[SIGNAL_UPLOAD_FINISHED], 0u);
 }
 
 static GSocketConnectable *
@@ -853,6 +855,7 @@ dequeue_and_do_upload (EmerDaemon  *self,
       GTask *upload_task = g_queue_pop_head (priv->upload_queue);
       g_task_return_error (upload_task, error);
       g_object_unref (upload_task);
+      g_signal_emit (self, emer_daemon_signals[SIGNAL_UPLOAD_FINISHED], 0u);
       return;
     }
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -1612,13 +1612,12 @@ emer_persistent_cache_may_fail_init (GInitable    *self,
                                      GCancellable *cancellable,
                                      GError      **error)
 {
-  gboolean versioning_success = apply_cache_versioning (EMER_PERSISTENT_CACHE (self),
-                                                        cancellable,
-                                                        error);
-  if (!versioning_success)
+  EmerPersistentCache *persistent_cache = EMER_PERSISTENT_CACHE (self);
+
+  if (!apply_cache_versioning (persistent_cache, cancellable, error))
     return FALSE;
 
-  return load_cache_size (EMER_PERSISTENT_CACHE (self), cancellable, error);
+  return load_cache_size (persistent_cache, cancellable, error);
 }
 
 static void

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -113,8 +113,7 @@ G_DEFINE_TYPE_WITH_CODE (EmerPersistentCache, emer_persistent_cache, G_TYPE_OBJE
 
 /*
  * The amount of time (in seconds) between every periodic update to the boot
- * offset file is made. This will primarily keep our relative timestamps more
- * accurate.
+ * offset file. This will primarily keep our relative timestamps more accurate.
  */
 #define DEFAULT_BOOT_TIMESTAMPS_UPDATE (60u * 60u)
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -1252,6 +1252,9 @@ emer_persistent_cache_store_metrics (EmerPersistentCache  *self,
     }
   G_UNLOCK (update_boot_offset);
 
+  if (*capacity == CAPACITY_MAX)
+    return TRUE;
+
   gboolean singulars_stored = store_singulars (self,
                                                singular_buffer,
                                                num_singulars_buffered,

--- a/shared/metrics-util.c
+++ b/shared/metrics-util.c
@@ -22,11 +22,6 @@
 
 #include "metrics-util.h"
 
-/* For clock_gettime() */
-#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 199309L
-#error "This code requires _POSIX_C_SOURCE to be 199309L or later."
-#endif
-
 #include <errno.h>
 #include <time.h>
 #include <inttypes.h>

--- a/tests/daemon/mock-server.py
+++ b/tests/daemon/mock-server.py
@@ -18,7 +18,6 @@
 # along with eos-event-recorder-daemon.  If not, see
 # <http://www.gnu.org/licenses/>.
 
-import http.client
 import http.server
 import sys
 
@@ -30,8 +29,9 @@ class PrintingHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         request_body = self.rfile.read(content_length)
         sys.stdout.buffer.write(request_body)
         sys.stdout.buffer.flush()
-        sys.stdin.readline()  # Block until test says to proceed.
-        self.send_response(http.client.OK)
+        status_code_str = sys.stdin.readline()
+        status_code = int(status_code_str)
+        self.send_response(status_code)
         self.end_headers()
 
 # A metrics server that simply prints the requests it receives to stdout

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -36,9 +36,9 @@
 #include <glib/gstdio.h>
 #include <libsoup/soup.h>
 #include <uuid/uuid.h>
+#include <signal.h>
 #include <stdio.h>
 #include <string.h>
-#include <signal.h>
 
 #define MOCK_SERVER_PATH TEST_DIR "daemon/mock-server.py"
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -1645,7 +1645,6 @@ test_persistent_cache_wipes_metrics_when_boot_offset_corrupted (gboolean     *un
 
   capacity_t capacity;
 
-  // Insert a metric.
   store_single_singular_event (cache, &capacity);
 
   // Clear in-memory boot offset cache.


### PR DESCRIPTION
`g_variant_new` expects a `GVariant *` for an `@` conversion, not a
`GVariant **`.

[endlessm/eos-sdk#3243]