### PR TITLE
Remove write_default_boot_offset_key_file.

### DIFF
--- a/daemon/Makefile.am.inc
+++ b/daemon/Makefile.am.inc
@@ -50,7 +50,6 @@ eos_metrics_event_recorder_SOURCES = \
 
 eos_metrics_event_recorder_CPPFLAGS = \
 	$(EOS_EVENT_RECORDER_DAEMON_CFLAGS) \
-	-D_POSIX_C_SOURCE=200112L \
 	-DCONFIG_DIR="\"$(configdir)\"" \
 	-DPERMISSIONS_FILE="\"$(permissions_file)\"" \
 	-DPERSISTENT_CACHE_DIR="\"$(persistentcachedir)\"" \

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -20,11 +20,6 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-/* For CLOCK_BOOTTIME */
-#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 200112L
-#error "This code requires _POSIX_C_SOURCE to be 200112L or later."
-#endif
-
 #include <byteswap.h>
 #include <string.h>
 #include <time.h>

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -178,17 +178,6 @@ finish_network_callback (NetworkCallbackData *callback_data)
   g_signal_emit (self, emer_daemon_signals[SIGNAL_UPLOAD_FINISHED], 0u);
 }
 
-static gint64
-swap_bytes_64_if_big_endian (gint64 value)
-{
-  if (G_BYTE_ORDER == G_BIG_ENDIAN)
-    return bswap_64 (value);
-  if (G_BYTE_ORDER != G_LITTLE_ENDIAN)
-    g_error ("This machine is neither big endian nor little endian. Mixed-"
-             "endian machines are not supported by the metrics system.");
-  return value;
-}
-
 static void
 release_shutdown_inhibitor (EmerDaemon *self)
 {

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -26,6 +26,7 @@
 
 #include <string.h>
 #include <uuid/uuid.h>
+
 #include <glib/gprintf.h>
 #include <glib/gstdio.h>
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -776,6 +776,7 @@ drain_metrics_file (EmerPersistentCache *self,
                              NULL, &error);
       if (error != NULL)
         {
+          g_free (variant_data);
           g_critical ("Failed to read event in persistent cache. Error: %s.",
                       error->message);
           g_error_free (error);
@@ -784,6 +785,7 @@ drain_metrics_file (EmerPersistentCache *self,
 
       if (data_bytes_read != variant_length)
         {
+          g_free (variant_data);
           g_critical ("Cache file ended earlier than expected. Read %"
                       G_GSIZE_FORMAT " bytes, but expected %" G_GSIZE_FORMAT
                       " bytes of event data.", data_bytes_read, variant_length);

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -160,7 +160,7 @@ get_saved_boot_id (EmerPersistentCache *self,
                                                error);
   if (id_as_string == NULL)
     {
-      g_prefix_error (error, "Failed to read boot_id from %s.",
+      g_prefix_error (error, "Failed to read boot_id from %s. ",
                       priv->boot_metadata_file_path);
       return FALSE;
     }
@@ -172,7 +172,7 @@ get_saved_boot_id (EmerPersistentCache *self,
   g_strchomp (id_as_string);
   if (uuid_parse (id_as_string, priv->saved_boot_id) != 0)
     {
-      g_prefix_error (error, "Failed to parse the saved boot id: %s.",
+      g_prefix_error (error, "Failed to parse the saved boot id: %s. ",
                       id_as_string);
       g_free (id_as_string);
       return FALSE;
@@ -330,7 +330,7 @@ save_timing_metadata (EmerPersistentCache *self,
   if (!g_key_file_save_to_file (priv->boot_offset_key_file,
                                 priv->boot_metadata_file_path, out_error))
     {
-      g_prefix_error (out_error, "Failed to write to metadata file: %s.",
+      g_prefix_error (out_error, "Failed to write to metadata file: %s. ",
                       priv->boot_metadata_file_path);
       return FALSE;
     }

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -418,10 +418,9 @@ compute_boot_offset (EmerPersistentCache *self,
    * This is the amount of time elapsed between the origin boot and the boot
    * with the stored ID.
    */
-  gint64 stored_offset = g_key_file_get_int64 (priv->boot_offset_key_file,
-                                               CACHE_TIMING_GROUP_NAME,
-                                               CACHE_BOOT_OFFSET_KEY,
-                                               &error);
+  gint64 stored_offset =
+    g_key_file_get_int64 (priv->boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
+                          CACHE_BOOT_OFFSET_KEY, &error);
   if (error != NULL)
     {
       g_critical ("Failed to read relative offset from metadata file %s. "
@@ -1005,10 +1004,8 @@ write_byte_array (EmerPersistentCache *self,
     emer_persistent_cache_get_instance_private (self);
 
   GError *error = NULL;
-  GFileOutputStream *stream = g_file_append_to (file,
-                                                G_FILE_CREATE_NONE,
-                                                NULL,
-                                                &error);
+  GFileOutputStream *stream =
+    g_file_append_to (file, G_FILE_CREATE_NONE, NULL, &error);
   if (stream == NULL)
     {
       g_critical ("Failed to open stream to cache file. Error: %s.",
@@ -1283,19 +1280,15 @@ emer_persistent_cache_store_metrics (EmerPersistentCache  *self,
   *num_aggregates_stored = 0;
   *num_sequences_stored = 0;
 
-  gboolean singulars_stored = store_singulars (self,
-                                               singular_buffer,
-                                               num_singulars_buffered,
-                                               num_singulars_stored,
-                                               capacity);
+  gboolean singulars_stored =
+    store_singulars (self, singular_buffer, num_singulars_buffered,
+                     num_singulars_stored, capacity);
   if (!singulars_stored || *capacity == CAPACITY_MAX)
     return singulars_stored;
 
-  gboolean aggregates_stored = store_aggregates (self,
-                                                 aggregate_buffer,
-                                                 num_aggregates_buffered,
-                                                 num_aggregates_stored,
-                                                 capacity);
+  gboolean aggregates_stored =
+    store_aggregates (self, aggregate_buffer, num_aggregates_buffered,
+                      num_aggregates_stored, capacity);
   if (!aggregates_stored || *capacity == CAPACITY_MAX)
     return aggregates_stored;
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -776,8 +776,8 @@ drain_metrics_file (EmerPersistentCache *self,
 
       if (error != NULL)
         {
-          g_critical ("Failed to read length of metric from input stream to "
-                      "drain metrics. Error: %s.", error->message);
+          g_critical ("Failed to read length of event in persistent cache. "
+                      "Error: %s.", error->message);
           g_error_free (error);
           g_object_unref (stream);
           g_object_unref (file);
@@ -786,9 +786,9 @@ drain_metrics_file (EmerPersistentCache *self,
         }
       if (length_bytes_read != sizeof (gsize))
         {
-          g_critical ("We read %" G_GSSIZE_FORMAT " bytes but expected %"
-                      G_GSIZE_FORMAT " bytes!", length_bytes_read,
-                      sizeof (gsize));
+          g_critical ("Read %" G_GSSIZE_FORMAT " bytes, but expected length of "
+                      "event to be %" G_GSIZE_FORMAT " bytes.",
+                      length_bytes_read, sizeof (gsize));
           g_object_unref (stream);
           g_object_unref (file);
           g_array_unref (dynamic_array);
@@ -801,15 +801,15 @@ drain_metrics_file (EmerPersistentCache *self,
                              NULL, &error);
       if (data_bytes_read != variant_length)
         {
-          g_critical ("We read %" G_GSSIZE_FORMAT " bytes of metric data when "
-                      "looking for %" G_GSIZE_FORMAT "!", data_bytes_read,
-                      variant_length);
+          g_critical ("Cache file ended earlier than expected. Read %"
+                      G_GSIZE_FORMAT " bytes, but expected %" G_GSIZE_FORMAT
+                      " bytes of event data.", data_bytes_read, variant_length);
           return FALSE;
         }
       if (error != NULL)
         {
-          g_critical ("Failed to read metric from input stream to drain metrics."
-                      " Error: %s.", error->message);
+          g_critical ("Failed to read event in persistent cache. Error: %s.",
+                      error->message);
           g_error_free (error);
           g_object_unref (stream);
           g_object_unref (file);
@@ -1350,8 +1350,8 @@ apply_cache_versioning (EmerPersistentCache *self,
       if (!success)
         {
           if (error != NULL)
-            g_critical ("Failed to update cache version number to %i. "
-                        "Error: %s.", CURRENT_CACHE_VERSION, (*error)->message);
+            g_critical ("Failed to update cache version number to %i. Error: "
+                        "%s.", CURRENT_CACHE_VERSION, (*error)->message);
           else
             g_critical ("Failed to update cache version number to %i.",
                         CURRENT_CACHE_VERSION);

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -751,9 +751,6 @@ drain_metrics_file (EmerPersistentCache *self,
       gssize length_bytes_read =
         g_input_stream_read (stream, &variant_length, sizeof (gsize),
                              NULL, &error);
-      if (length_bytes_read == 0) // EOF
-        break;
-
       if (error != NULL)
         {
           g_critical ("Failed to read length of event in persistent cache. "
@@ -761,6 +758,10 @@ drain_metrics_file (EmerPersistentCache *self,
           g_error_free (error);
           goto handle_failed_read;
         }
+
+      if (length_bytes_read == 0) // EOF
+        break;
+
       if (length_bytes_read != sizeof (gsize))
         {
           g_critical ("Read %" G_GSSIZE_FORMAT " bytes, but expected length of "
@@ -773,18 +774,19 @@ drain_metrics_file (EmerPersistentCache *self,
       gssize data_bytes_read =
         g_input_stream_read (stream, variant_data, variant_length,
                              NULL, &error);
-      if (data_bytes_read != variant_length)
-        {
-          g_critical ("Cache file ended earlier than expected. Read %"
-                      G_GSIZE_FORMAT " bytes, but expected %" G_GSIZE_FORMAT
-                      " bytes of event data.", data_bytes_read, variant_length);
-          goto handle_failed_read;
-        }
       if (error != NULL)
         {
           g_critical ("Failed to read event in persistent cache. Error: %s.",
                       error->message);
           g_error_free (error);
+          goto handle_failed_read;
+        }
+
+      if (data_bytes_read != variant_length)
+        {
+          g_critical ("Cache file ended earlier than expected. Read %"
+                      G_GSIZE_FORMAT " bytes, but expected %" G_GSIZE_FORMAT
+                      " bytes of event data.", data_bytes_read, variant_length);
           goto handle_failed_read;
         }
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -239,6 +239,7 @@ purge_cache_files (EmerPersistentCache *self,
     g_file_replace_contents (ind_file, "", 0, NULL, FALSE,
                              G_FILE_CREATE_REPLACE_DESTINATION,
                              NULL, cancellable, error);
+  g_object_unref (ind_file);
   if (!success)
     {
       if (error != NULL)
@@ -246,16 +247,15 @@ purge_cache_files (EmerPersistentCache *self,
                     (*error)->message);
       else
         g_critical ("Failed to purge cache files.");
-      g_object_unref (ind_file);
       return FALSE;
     }
-  g_object_unref (ind_file);
 
   GFile *agg_file = get_cache_file (self, AGGREGATE_SUFFIX);
   success =
     g_file_replace_contents (agg_file, "", 0, NULL, FALSE,
                              G_FILE_CREATE_REPLACE_DESTINATION,
                              NULL, cancellable, error);
+  g_object_unref (agg_file);
   if (!success)
     {
       if (error != NULL)
@@ -263,16 +263,15 @@ purge_cache_files (EmerPersistentCache *self,
                     (*error)->message);
       else
         g_critical ("Failed to purge cache files.");
-      g_object_unref (agg_file);
       return FALSE;
     }
-  g_object_unref (agg_file);
 
   GFile *seq_file = get_cache_file (self, SEQUENCE_SUFFIX);
   success =
     g_file_replace_contents (seq_file, "", 0, NULL, FALSE,
                              G_FILE_CREATE_REPLACE_DESTINATION,
                              NULL, cancellable, error);
+  g_object_unref (seq_file);
   if (!success)
     {
       if (error != NULL)
@@ -280,10 +279,8 @@ purge_cache_files (EmerPersistentCache *self,
                     (*error)->message);
       else
         g_critical ("Failed to purge cache files.");
-      g_object_unref (seq_file);
       return FALSE;
     }
-  g_object_unref (seq_file);
 
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
@@ -1034,10 +1031,11 @@ write_variant_string_to_file (EmerPersistentCache *self,
                                                 NULL,
                                                 NULL,
                                                 &error);
+  g_object_unref (stream);
+
   if (!success)
     {
       g_critical ("Failed to write to cache file. Error: %s.", error->message);
-      g_object_unref (stream);
       g_error_free (error);
       return FALSE;
     }
@@ -1045,8 +1043,6 @@ write_variant_string_to_file (EmerPersistentCache *self,
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
   priv->cache_size += variant_string->len;
-
-  g_object_unref (stream);
   return TRUE;
 }
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -382,25 +382,7 @@ reset_boot_offset_metadata_file (EmerPersistentCache *self,
   priv->boot_offset_initialized = FALSE;
   priv->boot_id_initialized = FALSE;
 
-  GFile *metadata_file = g_file_new_for_path (priv->boot_metadata_file_path);
-
-  // We only want to 'touch' the file; we don't need the stream.
   GError *error = NULL;
-  GFileOutputStream *unused_stream =
-    g_file_replace (metadata_file, NULL, FALSE,
-                    G_FILE_CREATE_REPLACE_DESTINATION,
-                    NULL, &error);
-  g_object_unref (metadata_file);
-  if (unused_stream == NULL)
-    {
-      g_critical ("Failed to create new metadata file at %s. Error: %s.",
-                  priv->boot_metadata_file_path, error->message);
-      g_error_free (error);
-      return FALSE;
-    }
-  g_object_unref (unused_stream);
-
-  // Wipe persistent cache if we had to reset the timing metadata.
   if (!purge_cache_files (self, NULL, &error))
     {
       g_error_free (error); // Error already reported.

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -778,7 +778,7 @@ drain_metrics_file (EmerPersistentCache *self,
           g_critical ("Cache file ended earlier than expected. Read %"
                       G_GSIZE_FORMAT " bytes, but expected %" G_GSIZE_FORMAT
                       " bytes of event data.", data_bytes_read, variant_length);
-          return FALSE;
+          goto handle_failed_read;
         }
       if (error != NULL)
         {

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -776,11 +776,8 @@ drain_metrics_file (EmerPersistentCache *self,
 
       if (error != NULL)
         {
-          gchar *fpath = g_file_get_path (file);
           g_critical ("Failed to read length of metric from input stream to "
-                      "drain metrics. File: %s. Error: %s.", fpath,
-                      error->message);
-          g_free (fpath);
+                      "drain metrics. Error: %s.", error->message);
           g_error_free (error);
           g_object_unref (stream);
           g_object_unref (file);
@@ -811,10 +808,8 @@ drain_metrics_file (EmerPersistentCache *self,
         }
       if (error != NULL)
         {
-          gchar *fpath = g_file_get_path (file);
           g_critical ("Failed to read metric from input stream to drain metrics."
-                      " File: %s. Error: %s.", fpath, error->message);
-          g_free (fpath);
+                      " Error: %s.", error->message);
           g_error_free (error);
           g_object_unref (stream);
           g_object_unref (file);
@@ -1027,10 +1022,8 @@ write_variant_string_to_file (EmerPersistentCache *self,
                                                 &error);
   if (stream == NULL)
     {
-      gchar *path = g_file_get_path (file);
-      g_critical ("Failed to open stream to cache file: %s. Error: %s.",
-                  path, error->message);
-      g_free (path);
+      g_critical ("Failed to open stream to cache file. Error: %s.",
+                  error->message);
       g_error_free (error);
       return FALSE;
     }
@@ -1043,11 +1036,8 @@ write_variant_string_to_file (EmerPersistentCache *self,
                                                 &error);
   if (!success)
     {
-      gchar *path = g_file_get_path (file);
-      g_critical ("Failed to write to cache file: %s. Error: %s.",
-                  path, error->message);
+      g_critical ("Failed to write to cache file. Error: %s.", error->message);
       g_object_unref (stream);
-      g_free (path);
       g_error_free (error);
       return FALSE;
     }

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -235,6 +235,9 @@ purge_cache_files (EmerPersistentCache *self,
                    GCancellable        *cancellable,
                    GError             **error)
 {
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
   GFile *ind_file = get_cache_file (self, INDIVIDUAL_SUFFIX);
   GError *local_error = NULL;
   gboolean success =
@@ -263,8 +266,6 @@ purge_cache_files (EmerPersistentCache *self,
   if (!success)
     goto handle_failed_write;
 
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
   priv->cache_size = 0L;
   priv->capacity = CAPACITY_LOW;
 
@@ -408,9 +409,10 @@ compute_boot_offset (EmerPersistentCache *self,
                      gint64               absolute_time,
                      gint64              *boot_offset)
 {
-  GError *error = NULL;
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
+
+  GError *error = NULL;
 
   /*
    * This is the amount of time elapsed between the origin boot and the boot
@@ -999,6 +1001,9 @@ write_byte_array (EmerPersistentCache *self,
                   GFile               *file,
                   GByteArray          *byte_array)
 {
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
   GError *error = NULL;
   GFileOutputStream *stream = g_file_append_to (file,
                                                 G_FILE_CREATE_NONE,
@@ -1024,8 +1029,6 @@ write_byte_array (EmerPersistentCache *self,
       return FALSE;
     }
 
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
   priv->cache_size += byte_array->len;
   return TRUE;
 }
@@ -1314,6 +1317,9 @@ load_cache_size (EmerPersistentCache *self,
                  GCancellable        *cancellable,
                  GError             **error)
 {
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
   GFile *singular_file = get_cache_file (self, INDIVIDUAL_SUFFIX);
   guint64 singular_disk_used;
   GError *local_error = NULL;
@@ -1360,8 +1366,6 @@ load_cache_size (EmerPersistentCache *self,
   if (!success)
     goto handle_failed_read;
 
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
   priv->cache_size =
     singular_disk_used + aggregate_disk_used + sequence_disk_used;
   update_capacity (self, FALSE);

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -1033,6 +1033,9 @@ store_singulars (EmerPersistentCache *self,
                  gint                *num_singulars_stored,
                  capacity_t          *capacity)
 {
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
   GByteArray *serialized_variants = g_byte_array_new ();
   gboolean will_fit = TRUE;
   gint i;
@@ -1057,8 +1060,8 @@ store_singulars (EmerPersistentCache *self,
 
   g_byte_array_unref (serialized_variants);
 
-  gboolean set_to_max = !will_fit && write_successful;
-  *capacity = update_capacity (self, set_to_max);
+  *capacity =
+    write_successful ? update_capacity (self, !will_fit) : priv->capacity;
 
   *num_singulars_stored = i;
   return write_successful;
@@ -1071,6 +1074,9 @@ store_aggregates (EmerPersistentCache *self,
                   gint                *num_aggregates_stored,
                   capacity_t          *capacity)
 {
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
   GByteArray *serialized_variants = g_byte_array_new ();
   gboolean will_fit = TRUE;
   gint i;
@@ -1095,8 +1101,8 @@ store_aggregates (EmerPersistentCache *self,
 
   g_byte_array_unref (serialized_variants);
 
-  gboolean set_to_max = !will_fit && write_successful;
-  *capacity = update_capacity (self, set_to_max);
+  *capacity =
+    write_successful ? update_capacity (self, !will_fit) : priv->capacity;
 
   *num_aggregates_stored = i;
   return write_successful;
@@ -1109,6 +1115,9 @@ store_sequences (EmerPersistentCache *self,
                  gint                *num_sequences_stored,
                  capacity_t          *capacity)
 {
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
   GByteArray *serialized_variants = g_byte_array_new ();
   gboolean will_fit = TRUE;
   gint i;
@@ -1133,8 +1142,8 @@ store_sequences (EmerPersistentCache *self,
 
   g_byte_array_unref (serialized_variants);
 
-  gboolean set_to_max = !will_fit && write_successful;
-  *capacity = update_capacity (self, set_to_max);
+  *capacity =
+    write_successful ? update_capacity (self, !will_fit) : priv->capacity;
 
   *num_sequences_stored = i;
   return write_successful;

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -216,6 +216,7 @@ get_cache_file (EmerPersistentCache *self,
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
+
   gchar *path =
     g_strconcat (priv->cache_directory, CACHE_PREFIX, path_ending, NULL);
   GFile *file = g_file_new_for_path (path);
@@ -355,6 +356,7 @@ reset_boot_offset_metadata_file (EmerPersistentCache *self,
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
+
   priv->boot_offset_initialized = FALSE;
   priv->boot_id_initialized = FALSE;
 
@@ -848,6 +850,7 @@ emer_persistent_cache_drain_metrics (EmerPersistentCache  *self,
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
+
   if (priv->cache_size == 0)
     {
       set_to_empty_list (list_of_individual_metrics);
@@ -905,6 +908,7 @@ cache_has_room (EmerPersistentCache *self,
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
+
   if (priv->capacity == CAPACITY_MAX)
     return FALSE;
 
@@ -942,7 +946,6 @@ update_capacity (EmerPersistentCache *self,
 
   return priv->capacity;
 }
-
 
 /*
  * Serializes the given variant little-endian with its length in bytes as a
@@ -1436,6 +1439,7 @@ set_cache_directory (EmerPersistentCache *self,
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
+
   priv->cache_directory = g_strdup (directory);
 }
 
@@ -1618,6 +1622,7 @@ emer_persistent_cache_init (EmerPersistentCache *self)
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
+
   priv->cache_size = 0L;
   priv->capacity = CAPACITY_LOW;
   priv->boot_offset_key_file = g_key_file_new ();

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -1213,9 +1213,6 @@ emer_persistent_cache_store_metrics (EmerPersistentCache  *self,
   *num_aggregates_stored = 0;
   *num_sequences_stored = 0;
 
-  if (*capacity == CAPACITY_MAX)
-    return TRUE;
-
   gboolean singulars_stored = store_singulars (self,
                                                singular_buffer,
                                                num_singulars_buffered,

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -749,7 +749,7 @@ drain_metrics_file (EmerPersistentCache *self,
     {
       gsize variant_length;
       gssize length_bytes_read =
-        g_input_stream_read (stream, &variant_length, sizeof (gsize),
+        g_input_stream_read (stream, &variant_length, sizeof (variant_length),
                              NULL, &error);
       if (error != NULL)
         {
@@ -762,11 +762,11 @@ drain_metrics_file (EmerPersistentCache *self,
       if (length_bytes_read == 0) // EOF
         break;
 
-      if (length_bytes_read != sizeof (gsize))
+      if (length_bytes_read != sizeof (variant_length))
         {
           g_critical ("Read %" G_GSSIZE_FORMAT " bytes, but expected length of "
                       "event to be %" G_GSIZE_FORMAT " bytes.",
-                      length_bytes_read, sizeof (gsize));
+                      length_bytes_read, sizeof (variant_length));
           goto handle_failed_read;
         }
 
@@ -957,7 +957,7 @@ append_variant_to_string (EmerPersistentCache *self,
                           GVariant            *variant)
 {
   gsize variant_length = g_variant_get_size (variant);
-  gsize event_size_on_disk = sizeof (gsize) + variant_length;
+  gsize event_size_on_disk = sizeof (variant_length) + variant_length;
   if (cache_has_room (self, event_size_on_disk))
     {
       g_variant_ref_sink (variant);

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -837,7 +837,7 @@ drain_metrics_file (EmerPersistentCache *self,
                                  writable.data,
                                  writable.length,
                                  FALSE,
-                                 (GDestroyNotify) g_free,
+                                 g_free,
                                  writable.data);
 
       GVariant *regularized_event = regularize_variant (current_event);

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -38,12 +38,12 @@
  * @title: Persistent Cache
  * @short_description: Stores metrics locally (on the user's machine).
  *
- * The Persistent Cache is the sink to which an event recorder flushes
+ * The persistent cache is the sink to which an event recorder flushes
  * metrics. It will store these metrics until a drain operation is
- * requested or the Persistent Cache is purged due to versioning.
+ * requested or the persistent cache is purged due to versioning.
  *
  * Should the cached metrics occupy more than the maximum allowed cache size,
- * the Persistent Cache will begin ignoring new metrics until the old ones have
+ * the persistent cache will begin ignoring new metrics until the old ones have
  * been removed.
  *
  * If the CURRENT_CACHE_VERSION is incremented to indicate
@@ -172,8 +172,7 @@ get_saved_boot_id (EmerPersistentCache *self,
     }
 
   /*
-   * With both the keyfile and the system file, a newline is appended
-   * when a uuid is changed to a string and stored on disk.
+   * A newline is appended when a string is stored in a keyfile.
    * We chomp it off here because uuid_parse will fail otherwise.
    */
   g_strchomp (id_as_string);
@@ -192,8 +191,8 @@ get_saved_boot_id (EmerPersistentCache *self,
 }
 
 /*
- * Reads the Operating System's boot id from disk or cached value, returning it
- * via the out parameter boot_id.  Returns FALSE on failure and sets the GError.
+ * Reads the operating system's boot id from disk or cached value, returning it
+ * via the out parameter boot_id. Returns FALSE on failure and sets the GError.
  * Returns TRUE on success.
  */
 static gboolean
@@ -370,7 +369,7 @@ save_timing_metadata (EmerPersistentCache *self,
  *
  * Completely wipes the persistent cache's stored metrics.
  *
- * Returns FALSE and writes nothing to disk on failure. Returns TRUE on success.
+ * Returns TRUE if successful and FALSE on failure.
  */
 static gboolean
 reset_boot_offset_metadata_file (EmerPersistentCache *self,
@@ -745,9 +744,9 @@ regularize_variant (GVariant *variant)
 
 /*
  * Will transfer all metrics in the corresponding file into the out parameter
- * 'return_list'. The list will be NULL-terminated.  Returns TRUE on success,
- * and FALSE if any I/O error occured. Contents of return_list are undefined if
- * the return value is FALSE.
+ * 'return_list'. The list will be NULL-terminated. Returns TRUE on success, and
+ * FALSE if any I/O error occured. Contents of return_list are undefined if the
+ * return value is FALSE.
  */
 static gboolean
 drain_metrics_file (EmerPersistentCache *self,
@@ -838,7 +837,7 @@ drain_metrics_file (EmerPersistentCache *self,
         g_variant_new_from_data (G_VARIANT_TYPE (variant_type),
                                  writable.data,
                                  writable.length,
-                                 FALSE,
+                                 FALSE /* trusted */,
                                  g_free,
                                  writable.data);
 
@@ -1192,7 +1191,7 @@ store_sequences (EmerPersistentCache *self,
  * the persistent cache's space quota.
  * Will return the capacity of the cache via the out parameter 'capacity'.
  * Returns %TRUE on success, even if the metrics are intentionally dropped due
- * to space limitations.  Returns %FALSE only on I/O error.
+ * to space limitations. Returns %FALSE only on I/O error.
  *
  * Regardless of success or failure, num_singulars_stored,
  * num_aggregates_stored, num_sequences_stored, and capacity will be correctly
@@ -1612,7 +1611,7 @@ emer_persistent_cache_initable_init (GInitableIface *iface)
 }
 
 /*
- * Constructor for creating a new Persistent Cache.
+ * Constructor for creating a new persistent cache.
  * Please use this in production instead of the testing constructor!
  */
 EmerPersistentCache *

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -383,12 +383,6 @@ reset_boot_offset_metadata_file (EmerPersistentCache *self,
   priv->boot_id_initialized = FALSE;
 
   GError *error = NULL;
-  if (!purge_cache_files (self, NULL, &error))
-    {
-      g_error_free (error); // Error already reported.
-      return FALSE;
-    }
-
   uuid_t system_boot_id;
   if (!get_system_boot_id (self, system_boot_id, &error))
     {
@@ -398,6 +392,12 @@ reset_boot_offset_metadata_file (EmerPersistentCache *self,
     }
   gchar system_boot_id_string[BOOT_ID_FILE_LENGTH];
   uuid_unparse_lower (system_boot_id, system_boot_id_string);
+
+  if (!purge_cache_files (self, NULL, &error))
+    {
+      g_error_free (error); // Error already reported.
+      return FALSE;
+    }
 
   gint64 reset_offset = 0;
   gboolean was_reset = TRUE;

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -798,8 +798,9 @@ drain_metrics_file (EmerPersistentCache *self,
         }
       if (length_bytes_read != sizeof (gsize))
         {
-          g_critical ("We read %i bytes but expected %u bytes!",
-                      length_bytes_read, sizeof (gsize));
+          g_critical ("We read %" G_GSSIZE_FORMAT " bytes but expected %"
+                      G_GSIZE_FORMAT " bytes!", length_bytes_read,
+                      sizeof (gsize));
           g_object_unref (stream);
           g_object_unref (file);
           g_array_unref (dynamic_array);
@@ -814,8 +815,9 @@ drain_metrics_file (EmerPersistentCache *self,
                                                     &error);
       if (data_bytes_read != writable.length)
         {
-          g_critical ("We read %i bytes of metric data when looking for %u!",
-                      data_bytes_read, writable.length);
+          g_critical ("We read %" G_GSSIZE_FORMAT " bytes of metric data when "
+                      "looking for %" G_GSIZE_FORMAT "!", data_bytes_read,
+                      writable.length);
           return FALSE;
         }
       if (error != NULL)

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -961,7 +961,8 @@ append_variant (EmerPersistentCache *self,
 {
   gsize variant_length = g_variant_get_size (variant);
   gsize event_size_on_disk = sizeof (variant_length) + variant_length;
-  if (cache_has_room (self, event_size_on_disk))
+  gsize byte_array_size_on_disk = serialized_variants->len + event_size_on_disk;
+  if (cache_has_room (self, byte_array_size_on_disk))
     {
       g_variant_ref_sink (variant);
       GVariant *native_endian_variant = swap_bytes_if_big_endian (variant);

--- a/shared/metrics-util.c
+++ b/shared/metrics-util.c
@@ -22,6 +22,7 @@
 
 #include "metrics-util.h"
 
+#include <byteswap.h>
 #include <errno.h>
 #include <uuid/uuid.h>
 
@@ -140,6 +141,17 @@ sequence_to_variant (SequenceEvent *sequence)
   return g_variant_new ("(uaya(xmv))", sequence->user_id, &event_id_builder,
                         &event_values_builder);
 
+}
+
+guint64
+swap_bytes_64_if_big_endian (guint64 value)
+{
+  if (G_BYTE_ORDER == G_BIG_ENDIAN)
+    return bswap_64 (value);
+  if (G_BYTE_ORDER != G_LITTLE_ENDIAN)
+    g_error ("This machine is neither big endian nor little endian. Mixed-"
+             "endian machines are not supported by the metrics system.");
+  return value;
 }
 
 /*

--- a/shared/metrics-util.c
+++ b/shared/metrics-util.c
@@ -23,8 +23,6 @@
 #include "metrics-util.h"
 
 #include <errno.h>
-#include <time.h>
-#include <inttypes.h>
 
 #include <glib.h>
 #include <gio/gio.h>

--- a/shared/metrics-util.c
+++ b/shared/metrics-util.c
@@ -23,10 +23,10 @@
 #include "metrics-util.h"
 
 #include <errno.h>
+#include <uuid/uuid.h>
 
 #include <glib.h>
 #include <gio/gio.h>
-#include <uuid/uuid.h>
 
 static void
 trash_event_value (EventValue *event_value)

--- a/shared/metrics-util.h
+++ b/shared/metrics-util.h
@@ -23,12 +23,6 @@
 #ifndef METRICS_UTIL_H
 #define METRICS_UTIL_H
 
-/* For clockid_t */
-#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 199309L
-#error "This code requires _POSIX_C_SOURCE to be 199309L or later."
-#endif
-
-
 #include <glib.h>
 #include <gio/gio.h>
 #include <uuid/uuid.h>

--- a/shared/metrics-util.h
+++ b/shared/metrics-util.h
@@ -71,33 +71,35 @@ typedef struct SequenceEvent
   gsize num_event_values;
 } SequenceEvent;
 
-void      trash_singular_event     (SingularEvent   *singular);
+void      trash_singular_event         (SingularEvent   *singular);
 
-void      trash_aggregate_event    (AggregateEvent  *aggregate);
+void      trash_aggregate_event        (AggregateEvent  *aggregate);
 
-void      trash_sequence_event     (SequenceEvent   *sequence);
+void      trash_sequence_event         (SequenceEvent   *sequence);
 
-void      free_singular_buffer     (SingularEvent   *singular_buffer,
-                                    gint             num_singulars_buffered);
+void      free_singular_buffer         (SingularEvent   *singular_buffer,
+                                        gint             num_singulars_buffered);
 
-void      free_aggregate_buffer    (AggregateEvent  *aggregate_buffer,
-                                    gint             num_aggregates_buffered);
+void      free_aggregate_buffer        (AggregateEvent  *aggregate_buffer,
+                                        gint             num_aggregates_buffered);
 
-void      free_sequence_buffer     (SequenceEvent   *sequence_buffer,
-                                    gint             num_sequences_buffered);
+void      free_sequence_buffer         (SequenceEvent   *sequence_buffer,
+                                        gint             num_sequences_buffered);
 
-void      free_variant_array       (GVariant       **variant_array);
+void      free_variant_array           (GVariant       **variant_array);
 
-GVariant *singular_to_variant      (SingularEvent   *singular);
+GVariant *singular_to_variant          (SingularEvent   *singular);
 
-GVariant *aggregate_to_variant     (AggregateEvent  *aggregate);
+GVariant *aggregate_to_variant         (AggregateEvent  *aggregate);
 
-GVariant *sequence_to_variant      (SequenceEvent   *sequence);
+GVariant *sequence_to_variant          (SequenceEvent   *sequence);
 
-GVariant *swap_bytes_if_big_endian (GVariant        *variant);
+guint64    swap_bytes_64_if_big_endian (guint64          value);
 
-void      get_uuid_builder         (uuid_t           uuid,
-                                    GVariantBuilder *uuid_builder);
+GVariant *swap_bytes_if_big_endian     (GVariant        *variant);
+
+void      get_uuid_builder             (uuid_t           uuid,
+                                        GVariantBuilder *uuid_builder);
 
 G_END_DECLS
 

--- a/shared/metrics-util.h
+++ b/shared/metrics-util.h
@@ -28,7 +28,6 @@
 #error "This code requires _POSIX_C_SOURCE to be 199309L or later."
 #endif
 
-#include <sys/types.h>
 
 #include <glib.h>
 #include <gio/gio.h>

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -34,6 +34,7 @@ DAEMON_TEST_FLAGS = \
 	-DCONFIG_DIR="\"$(configdir)\"" \
 	-DPERMISSIONS_FILE="\"$(permissions_file)\"" \
 	-DPERSISTENT_CACHE_DIR="\"$(persistentcachedir)\"" \
+	-DTEST_DIR="\"$(srcdir)/tests/\"" \
 	$(NULL)
 DAEMON_TEST_LIBS = @EOS_EVENT_RECORDER_DAEMON_LIBS@
 
@@ -73,10 +74,7 @@ tests_daemon_test_daemon_dbusdaemon_SOURCES = \
 	tests/daemon/mock-persistent-cache.c tests/daemon/mock-persistent-cache.h \
 	shared/metrics-util.c shared/metrics-util.h \
 	$(NULL)
-tests_daemon_test_daemon_dbusdaemon_CPPFLAGS = \
-	$(DAEMON_TEST_FLAGS) \
-	-DTEST_DIR="\"$(srcdir)/tests/\"" \
-	$(NULL)
+tests_daemon_test_daemon_dbusdaemon_CPPFLAGS = $(DAEMON_TEST_FLAGS)
 tests_daemon_test_daemon_dbusdaemon_LDADD = $(DAEMON_TEST_LIBS)
 
 tests_daemon_test_machine_id_provider_SOURCES = \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -75,7 +75,6 @@ tests_daemon_test_daemon_dbusdaemon_SOURCES = \
 	$(NULL)
 tests_daemon_test_daemon_dbusdaemon_CPPFLAGS = \
 	$(DAEMON_TEST_FLAGS) \
-	-D_POSIX_C_SOURCE=200112L \
 	-DTEST_DIR="\"$(srcdir)/tests/\"" \
 	$(NULL)
 tests_daemon_test_daemon_dbusdaemon_LDADD = $(DAEMON_TEST_LIBS)
@@ -109,10 +108,7 @@ tests_daemon_test_persistent_cache_SOURCES = \
 	daemon/emer-cache-version-provider.c daemon/emer-cache-version-provider.h \
 	shared/metrics-util.c shared/metrics-util.h \
 	$(NULL)
-tests_daemon_test_persistent_cache_CPPFLAGS = \
-	$(DAEMON_TEST_FLAGS) \
-	-D_POSIX_C_SOURCE=200112L \
-	$(NULL)
+tests_daemon_test_persistent_cache_CPPFLAGS = $(DAEMON_TEST_FLAGS)
 tests_daemon_test_persistent_cache_LDADD = $(DAEMON_TEST_LIBS)
 
 dist_noinst_SCRIPTS = \

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -186,15 +186,16 @@ make_testing_cache (void)
  * Keyfile should be unref'd via g_key_file_unref().
  */
 static GKeyFile *
-load_testing_key_file (void)
+load_boot_offset_key_file (void)
 {
-  GKeyFile *key_file = g_key_file_new ();
+  GKeyFile *boot_offset_key_file = g_key_file_new ();
   gchar *full_path =
     g_strconcat (TEST_DIRECTORY, BOOT_OFFSET_METADATA_FILE, NULL);
   gboolean load_succeeded =
-    g_key_file_load_from_file (key_file, full_path, G_KEY_FILE_NONE, NULL);
+    g_key_file_load_from_file (boot_offset_key_file, full_path, G_KEY_FILE_NONE,
+                               NULL);
   g_assert_true (load_succeeded);
-  return key_file;
+  return boot_offset_key_file;
 }
 
 /*
@@ -204,16 +205,16 @@ load_testing_key_file (void)
 static void
 set_boot_offset_in_metadata_file (gint64 new_offset)
 {
-  GKeyFile *key_file = load_testing_key_file ();
+  GKeyFile *boot_offset_key_file = load_boot_offset_key_file ();
 
-  g_key_file_set_int64 (key_file, CACHE_TIMING_GROUP_NAME,
+  g_key_file_set_int64 (boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
                         CACHE_BOOT_OFFSET_KEY, new_offset);
 
   gboolean save_succeeded =
-    g_key_file_save_to_file (key_file, TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
-                             NULL);
+    g_key_file_save_to_file (boot_offset_key_file,
+                             TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE, NULL);
   g_assert_true (save_succeeded);
-  g_key_file_unref (key_file);
+  g_key_file_unref (boot_offset_key_file);
 }
 
 /*
@@ -222,16 +223,16 @@ set_boot_offset_in_metadata_file (gint64 new_offset)
 static void
 set_boot_id_in_metadata_file (gchar *boot_id)
 {
-  GKeyFile *key_file = load_testing_key_file ();
+  GKeyFile *boot_offset_key_file = load_boot_offset_key_file ();
 
-  g_key_file_set_string (key_file, CACHE_TIMING_GROUP_NAME,
+  g_key_file_set_string (boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
                          CACHE_LAST_BOOT_ID_KEY, boot_id);
 
   gboolean save_succeeded =
-    g_key_file_save_to_file (key_file, TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
-                             NULL);
+    g_key_file_save_to_file (boot_offset_key_file,
+                             TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE, NULL);
   g_assert_true (save_succeeded);
-  g_key_file_unref (key_file);
+  g_key_file_unref (boot_offset_key_file);
 }
 
 /*
@@ -241,17 +242,17 @@ set_boot_id_in_metadata_file (gchar *boot_id)
 static void
 remove_offset (void)
 {
-  GKeyFile *key_file = load_testing_key_file ();
+  GKeyFile *boot_offset_key_file = load_boot_offset_key_file ();
   gboolean remove_succeeded =
-    g_key_file_remove_key (key_file, CACHE_TIMING_GROUP_NAME,
+    g_key_file_remove_key (boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
                            CACHE_BOOT_OFFSET_KEY, NULL);
   g_assert_true (remove_succeeded);
 
   gboolean save_succeeded =
-    g_key_file_save_to_file (key_file, TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
-                             NULL);
+    g_key_file_save_to_file (boot_offset_key_file,
+                             TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE, NULL);
   g_assert_true (save_succeeded);
-  g_key_file_unref (key_file);
+  g_key_file_unref (boot_offset_key_file);
 }
 
 /*
@@ -260,12 +261,12 @@ remove_offset (void)
 static gint64
 read_offset (void)
 {
-  GKeyFile *key_file = load_testing_key_file ();
+  GKeyFile *boot_offset_key_file = load_boot_offset_key_file ();
   GError *error = NULL;
   gint64 stored_offset =
-    g_key_file_get_int64 (key_file, CACHE_TIMING_GROUP_NAME,
+    g_key_file_get_int64 (boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
                           CACHE_BOOT_OFFSET_KEY, &error);
-  g_key_file_unref (key_file);
+  g_key_file_unref (boot_offset_key_file);
   g_assert_no_error (error);
   return stored_offset;
 }
@@ -277,12 +278,12 @@ read_offset (void)
 static gboolean
 boot_offset_was_reset (void)
 {
-  GKeyFile *key_file = load_testing_key_file ();
+  GKeyFile *boot_offset_key_file = load_boot_offset_key_file ();
   GError *error = NULL;
   gboolean was_reset =
-    g_key_file_get_boolean (key_file, CACHE_TIMING_GROUP_NAME,
+    g_key_file_get_boolean (boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
                             CACHE_WAS_RESET_KEY, &error);
-  g_key_file_unref (key_file);
+  g_key_file_unref (boot_offset_key_file);
   g_assert_no_error (error);
   return was_reset && (read_offset() == 0);
 }
@@ -293,12 +294,12 @@ boot_offset_was_reset (void)
 static gint64
 read_relative_time (void)
 {
-  GKeyFile *key_file = load_testing_key_file ();
+  GKeyFile *boot_offset_key_file = load_boot_offset_key_file ();
   GError *error = NULL;
   gint64 stored_offset =
-    g_key_file_get_int64 (key_file, CACHE_TIMING_GROUP_NAME,
+    g_key_file_get_int64 (boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
                           CACHE_RELATIVE_TIME_KEY, &error);
-  g_key_file_unref (key_file);
+  g_key_file_unref (boot_offset_key_file);
   g_assert_no_error (error);
   return stored_offset;
 }
@@ -309,12 +310,12 @@ read_relative_time (void)
 static gint64
 read_absolute_time (void)
 {
-  GKeyFile *key_file = load_testing_key_file ();
+  GKeyFile *boot_offset_key_file = load_boot_offset_key_file ();
   GError *error = NULL;
   gint64 stored_offset =
-    g_key_file_get_int64 (key_file, CACHE_TIMING_GROUP_NAME,
+    g_key_file_get_int64 (boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
                           CACHE_ABSOLUTE_TIME_KEY, &error);
-  g_key_file_unref (key_file);
+  g_key_file_unref (boot_offset_key_file);
   g_assert_no_error (error);
   return stored_offset;
 }

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -190,7 +190,7 @@ make_testing_cache (void)
 }
 
 /*
- * Returns a new GKeyFile associated with the boot timing metadata file.
+ * Returns a new key file associated with the boot timing metadata file.
  * Keyfile should be unref'd via g_key_file_unref().
  */
 static GKeyFile *

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -214,10 +214,8 @@ set_boot_offset_in_metadata_file (gint64 new_offset)
 {
   GKeyFile *key_file = load_testing_key_file ();
 
-  g_key_file_set_int64 (key_file,
-                        CACHE_TIMING_GROUP_NAME,
-                        CACHE_BOOT_OFFSET_KEY,
-                        new_offset);
+  g_key_file_set_int64 (key_file, CACHE_TIMING_GROUP_NAME,
+                        CACHE_BOOT_OFFSET_KEY, new_offset);
 
   gboolean save_succeeded =
     g_key_file_save_to_file (key_file, TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
@@ -255,10 +253,8 @@ set_boot_id_in_metadata_file (gchar *boot_id)
 {
   GKeyFile *key_file = load_testing_key_file ();
 
-  g_key_file_set_string (key_file,
-                         CACHE_TIMING_GROUP_NAME,
-                         CACHE_LAST_BOOT_ID_KEY,
-                         boot_id);
+  g_key_file_set_string (key_file, CACHE_TIMING_GROUP_NAME,
+                         CACHE_LAST_BOOT_ID_KEY, boot_id);
 
   gboolean save_succeeded =
     g_key_file_save_to_file (key_file, TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
@@ -295,10 +291,9 @@ read_offset (void)
 {
   GKeyFile *key_file = load_testing_key_file ();
   GError *error = NULL;
-  gint64 stored_offset = g_key_file_get_int64 (key_file,
-                                               CACHE_TIMING_GROUP_NAME,
-                                               CACHE_BOOT_OFFSET_KEY,
-                                               &error);
+  gint64 stored_offset =
+    g_key_file_get_int64 (key_file, CACHE_TIMING_GROUP_NAME,
+                          CACHE_BOOT_OFFSET_KEY, &error);
   g_key_file_unref (key_file);
   g_assert_no_error (error);
   return stored_offset;
@@ -313,10 +308,9 @@ boot_offset_was_reset (void)
 {
   GKeyFile *key_file = load_testing_key_file ();
   GError *error = NULL;
-  gboolean was_reset = g_key_file_get_boolean (key_file,
-                                               CACHE_TIMING_GROUP_NAME,
-                                               CACHE_WAS_RESET_KEY,
-                                               &error);
+  gboolean was_reset =
+    g_key_file_get_boolean (key_file, CACHE_TIMING_GROUP_NAME,
+                            CACHE_WAS_RESET_KEY, &error);
   g_key_file_unref (key_file);
   g_assert_no_error (error);
   return was_reset && (read_offset() == 0);
@@ -330,10 +324,9 @@ read_relative_time (void)
 {
   GKeyFile *key_file = load_testing_key_file ();
   GError *error = NULL;
-  gint64 stored_offset = g_key_file_get_int64 (key_file,
-                                               CACHE_TIMING_GROUP_NAME,
-                                               CACHE_RELATIVE_TIME_KEY,
-                                               &error);
+  gint64 stored_offset =
+    g_key_file_get_int64 (key_file, CACHE_TIMING_GROUP_NAME,
+                          CACHE_RELATIVE_TIME_KEY, &error);
   g_key_file_unref (key_file);
   g_assert_no_error (error);
   return stored_offset;
@@ -347,10 +340,9 @@ read_absolute_time (void)
 {
   GKeyFile *key_file = load_testing_key_file ();
   GError *error = NULL;
-  gint64 stored_offset = g_key_file_get_int64 (key_file,
-                                               CACHE_TIMING_GROUP_NAME,
-                                               CACHE_ABSOLUTE_TIME_KEY,
-                                               &error);
+  gint64 stored_offset =
+    g_key_file_get_int64 (key_file, CACHE_TIMING_GROUP_NAME,
+                          CACHE_ABSOLUTE_TIME_KEY, &error);
   g_key_file_unref (key_file);
   g_assert_no_error (error);
   return stored_offset;

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -1640,7 +1640,6 @@ test_persistent_cache_wipes_metrics_when_boot_offset_corrupted (gboolean     *un
   write_default_boot_offset_key_file ();
 
   capacity_t capacity;
-
   store_single_singular_event (cache, &capacity);
 
   // Clear in-memory boot offset cache.
@@ -1795,6 +1794,7 @@ test_persistent_cache_get_offset_wont_update_timestamps_if_it_isnt_supposed_to (
   // These timestamps should not have changed.
   g_assert_cmpint (relative_time, ==, read_relative_time ());
   g_assert_cmpint (absolute_time, ==, read_absolute_time ());
+
   g_object_unref (cache);
 }
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -1682,7 +1682,6 @@ test_persistent_cache_resets_boot_metadata_file_when_boot_offset_corrupted (gboo
   // Corrupt metadata file.
   remove_offset ();
 
-  GError *error = NULL;
   g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, "Could not find a "
                          "valid boot offset in the metadata file. Error: *.");
 
@@ -1690,7 +1689,6 @@ test_persistent_cache_resets_boot_metadata_file_when_boot_offset_corrupted (gboo
   EmerPersistentCache *cache = make_testing_cache ();
 
   g_test_assert_expected_messages ();
-  g_assert_no_error (error);
 
   g_assert_true (boot_offset_was_reset ());
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -233,7 +233,7 @@ set_boot_offset_in_metadata_file (gint64 new_offset)
  * instance has been constructed).
  */
 static void
-write_default_boot_offset_key_file_to_disk (void)
+write_default_boot_offset_key_file (void)
 {
   GKeyFile *key_file = g_key_file_new ();
   gboolean load_succeeded =
@@ -1637,7 +1637,7 @@ test_persistent_cache_wipes_metrics_when_boot_offset_corrupted (gboolean     *un
 {
   EmerPersistentCache *cache = make_testing_cache ();
 
-  write_default_boot_offset_key_file_to_disk ();
+  write_default_boot_offset_key_file ();
 
   capacity_t capacity;
 
@@ -1686,7 +1686,7 @@ static void
 test_persistent_cache_resets_boot_metadata_file_when_boot_offset_corrupted (gboolean     *unused,
                                                                             gconstpointer dontuseme)
 {
-  write_default_boot_offset_key_file_to_disk ();
+  write_default_boot_offset_key_file ();
 
   // Corrupt metadata file.
   remove_offset ();
@@ -1715,7 +1715,7 @@ test_persistent_cache_reads_cached_boot_offset (gboolean     *unused,
                                                 gconstpointer dontuseme)
 {
   EmerPersistentCache *cache = make_testing_cache ();
-  write_default_boot_offset_key_file_to_disk ();
+  write_default_boot_offset_key_file ();
 
   gint64 first_offset;
   GError *error = NULL;
@@ -1770,7 +1770,7 @@ test_persistent_cache_get_offset_wont_update_timestamps_if_it_isnt_supposed_to (
                                                                                 gconstpointer dontuseme)
 {
   EmerPersistentCache *cache = make_testing_cache ();
-  write_default_boot_offset_key_file_to_disk ();
+  write_default_boot_offset_key_file ();
 
   GError *error = NULL;
 
@@ -1812,7 +1812,7 @@ test_persistent_cache_get_offset_updates_timestamps_when_requested (gboolean    
                                                                     gconstpointer dontuseme)
 {
   EmerPersistentCache *cache = make_testing_cache ();
-  write_default_boot_offset_key_file_to_disk ();
+  write_default_boot_offset_key_file ();
 
   GError *error = NULL;
 
@@ -1849,7 +1849,7 @@ test_persistent_cache_updates_timestamps_on_finalize (gboolean     *unused,
                                                       gconstpointer dontuseme)
 {
   EmerPersistentCache *cache = make_testing_cache ();
-  write_default_boot_offset_key_file_to_disk ();
+  write_default_boot_offset_key_file ();
 
   GError *error = NULL;
 

--- a/tools/Makefile.am.inc
+++ b/tools/Makefile.am.inc
@@ -26,7 +26,6 @@ PERSISTENT_CACHE_TOOL_FLAGS = \
 	-I$(top_srcdir)/daemon \
 	-I$(top_srcdir)/shared \
 	-I$(top_srcdir)/tools \
-	-D_POSIX_C_SOURCE=200112L \
 	-DCONFIG_DIR="\"$(configdir)\"" \
 	-DPERMISSIONS_FILE="\"$(permissions_file)\"" \
 	-DPERSISTENT_CACHE_DIR="\"$(persistentcachedir)\"" \


### PR DESCRIPTION
This change fixes at least one very nasty bug where
test_persistent_cache_get_offset_updates_timestamps_when_requested would
fail consistently but only within 42 minutes of startup.
write_default_boot_offset_key_file is hazardous and unnecessary now that
the persistent cache creates a boot offset file when initialized.
Refactor all tests that were using this function to account for the fact
that the persistent cache now reads the boot offset metadata file
immediately upon initialization.

[endlessm/eos-sdk#3254]