### PR TITLE
Overhaul persistent cache API.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /tests/daemon/test-boot-id-provider
 /tests/daemon/test-cache-size-provider
 /tests/daemon/test-cache-version-provider
+/tests/daemon/test-circular-file
 /tests/daemon/test-daemon.dbusdaemon
 /tests/daemon/test-machine-id-provider
 /tests/daemon/test-network-send-provider

--- a/daemon/Makefile.am.inc
+++ b/daemon/Makefile.am.inc
@@ -39,6 +39,7 @@ eos_metrics_event_recorder_SOURCES = \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
 	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
 	daemon/emer-cache-version-provider.c daemon/emer-cache-version-provider.h \
+	daemon/emer-circular-file.c daemon/emer-circular-file.h \
 	daemon/emer-daemon.c daemon/emer-daemon.h \
 	daemon/emer-machine-id-provider.c daemon/emer-machine-id-provider.h \
 	daemon/emer-network-send-provider.c daemon/emer-network-send-provider.h \

--- a/daemon/emer-circular-file.c
+++ b/daemon/emer-circular-file.c
@@ -1,0 +1,820 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2015 Endless Mobile, Inc. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "emer-circular-file.h"
+
+#include <gio/gio.h>
+#include <glib.h>
+
+#include "shared/metrics-util.h"
+
+#define METADATA_GROUP_NAME "metadata"
+#define MAX_SIZE_KEY "max_size"
+#define SIZE_KEY "size"
+#define HEAD_KEY "head"
+
+typedef struct _EmerCircularFilePrivate
+{
+  GFile *data_file;
+  GKeyFile *metadata_key_file;
+
+  GByteArray *write_buffer;
+
+  guint64 max_size;
+  guint64 size;
+  goffset head;
+} EmerCircularFilePrivate;
+
+static void emer_circular_file_initable_iface_init (GInitableIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (EmerCircularFile, emer_circular_file, G_TYPE_OBJECT,
+                         G_ADD_PRIVATE (EmerCircularFile)
+                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, emer_circular_file_initable_iface_init))
+
+enum
+{
+  PROP_0,
+  PROP_PATH,
+  PROP_MAX_SIZE,
+  NPROPS
+};
+
+static GParamSpec *emer_circular_file_props[NPROPS] = { NULL, };
+
+static gchar *
+get_metadata_filepath (EmerCircularFile *self)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  gchar *data_filepath = g_file_get_path (priv->data_file);
+  gchar *metadata_filepath =
+    g_strconcat (data_filepath, METADATA_EXTENSION, NULL);
+  g_free (data_filepath);
+
+  return metadata_filepath;
+}
+
+static gboolean
+save_metadata_file (EmerCircularFile *self,
+                    GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  gchar *metadata_filepath = get_metadata_filepath (self);
+  gboolean save_succeeded =
+    g_key_file_save_to_file (priv->metadata_key_file, metadata_filepath, error);
+  g_free (metadata_filepath);
+
+  return save_succeeded;
+}
+
+static gboolean
+add_to_size (EmerCircularFile *self,
+             guint64           delta,
+             GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  guint64 new_size = priv->size + delta;
+  g_key_file_set_uint64 (priv->metadata_key_file, METADATA_GROUP_NAME, SIZE_KEY,
+                         new_size);
+  if (!save_metadata_file (self, error))
+    return FALSE;
+
+  priv->size = new_size;
+  return TRUE;
+}
+
+static gboolean
+set_metadata (EmerCircularFile *self,
+              guint64           size,
+              goffset           head,
+              GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  g_key_file_set_uint64 (priv->metadata_key_file, METADATA_GROUP_NAME, SIZE_KEY,
+                         size);
+  g_key_file_set_int64 (priv->metadata_key_file, METADATA_GROUP_NAME, HEAD_KEY,
+                        head);
+
+  if (!save_metadata_file (self, error))
+    return FALSE;
+
+  priv->size = size;
+  priv->head = head;
+  return TRUE;
+}
+
+static gboolean
+read_disk_bytes (EmerCircularFile *self,
+                 guint8           *buffer,
+                 gsize             num_bytes,
+                 gsize             max_size,
+                 GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  if (num_bytes == 0)
+    return TRUE;
+
+  GFileInputStream *file_input_stream =
+    g_file_read (priv->data_file, NULL /* GCancellable */, error);
+  if (file_input_stream == NULL)
+    return FALSE;
+
+  GInputStream *input_stream = G_INPUT_STREAM (file_input_stream);
+  gsize head_to_end = max_size - priv->head;
+  gsize bytes_head = MIN(num_bytes, head_to_end);
+  gsize bytes_start = num_bytes - bytes_head;
+  if (bytes_start > 0)
+    {
+      gpointer copy_to = buffer + bytes_head;
+      gboolean read_succeeded =
+        g_input_stream_read_all (input_stream, copy_to, bytes_start,
+                                 NULL /* bytes read */, NULL /* GCancellable */,
+                                 error);
+      if (!read_succeeded)
+        goto handle_failed_read;
+    }
+
+  GSeekable *seekable = G_SEEKABLE (file_input_stream);
+  gboolean seek_succeeded =
+    g_seekable_seek (seekable, priv->head, G_SEEK_SET, NULL /* GCancellable */,
+                     error);
+  if (!seek_succeeded)
+    goto handle_failed_read;
+
+  gboolean read_succeeded =
+    g_input_stream_read_all (input_stream, buffer, bytes_head,
+                             NULL /* bytes read */, NULL /* GCancellable */,
+                             error);
+  g_object_unref (file_input_stream);
+  return read_succeeded;
+
+handle_failed_read:
+  g_object_unref (file_input_stream);
+  return FALSE;
+}
+
+/* Returns the size of a length-encoded buffer excluding any truncated trailing
+ * element. Assumes each element in the buffer is preceded by its length in
+ * bytes encoded as a little-endian guint64. Also assumes that each length,
+ * element pair is concatenated to the next.
+ */
+static guint64
+get_trimmed_size (const guint8 *buffer,
+                  gsize         num_bytes)
+{
+  guint64 curr_pos = 0;
+  while ((curr_pos + sizeof (curr_pos)) < num_bytes)
+    {
+      guint64 little_endian_elem_size = *(const guint64 *) (buffer + curr_pos);
+      guint64 elem_size =
+        swap_bytes_64_if_big_endian (little_endian_elem_size);
+      guint64 next_pos = curr_pos + sizeof (curr_pos) + elem_size;
+      if (next_pos > num_bytes)
+        break;
+      curr_pos = next_pos;
+    }
+
+  return curr_pos;
+}
+
+/* Replace the data file with the contents of the given buffer, and update the
+ * metadata file accordingly. In the event of an error, the circular file may
+ * instead be left logically empty, but the data and metadata files will never
+ * be left in an inconsistent state.
+ */
+static gboolean
+overwrite (EmerCircularFile *self,
+           gconstpointer     buffer,
+           gsize             num_bytes,
+           guint64           prev_max_size,
+           GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  /* The size of the data file may not exceed the maximum size stored in the
+   * metadata file.
+   */
+  if (priv->max_size > prev_max_size)
+    g_key_file_set_uint64 (priv->metadata_key_file, METADATA_GROUP_NAME,
+                           MAX_SIZE_KEY, priv->max_size);
+  if (!set_metadata (self, 0, 0, error))
+    return FALSE;
+
+  gboolean write_succeeded =
+    g_file_replace_contents (priv->data_file, buffer, num_bytes, NULL, FALSE,
+                             G_FILE_CREATE_NONE, NULL, NULL, error);
+  if (!write_succeeded)
+    return FALSE;
+
+  /* We only need to update the maximum size if we didn't already. */
+  if (priv->max_size < prev_max_size)
+    g_key_file_set_uint64 (priv->metadata_key_file, METADATA_GROUP_NAME,
+                           MAX_SIZE_KEY, priv->max_size);
+
+  return add_to_size (self, num_bytes, error);
+}
+
+/* Change the maximum size of the circular file from prev_max_size to
+ * priv->max_size. If the new maximum is less than the amount of data currently
+ * in the buffer, then any data that doesn't fit will be removed. Also
+ * reorganizes the circular file so that its head is at the start of the file.
+ */
+static gboolean
+resize (EmerCircularFile *self,
+        guint64           prev_max_size,
+        GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  if (prev_max_size == priv->max_size)
+    return TRUE;
+
+  gsize bytes_to_read = MIN (priv->size, priv->max_size);
+  guint8 buffer[bytes_to_read];
+  gboolean read_succeeded =
+    read_disk_bytes (self, buffer, bytes_to_read, prev_max_size, error);
+  if (!read_succeeded)
+    return FALSE;
+
+  guint64 new_size = get_trimmed_size (buffer, bytes_to_read);
+  return overwrite (self, buffer, new_size, prev_max_size, error);
+}
+
+static gboolean
+continue_reading_from_start (EmerCircularFile *self,
+                             GInputStream     *input_stream,
+                             guint8           *partially_filled_buffer,
+                             gsize             total_bytes_to_read,
+                             gsize             bytes_read_end,
+                             GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  if (bytes_read_end == total_bytes_to_read)
+    return TRUE;
+
+  GSeekable *seekable = G_SEEKABLE (input_stream);
+  goffset curr_position = g_seekable_tell (seekable);
+  if (curr_position != priv->max_size)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+                   "Circular file has a physical size of %" G_GOFFSET_FORMAT
+                   "bytes, but expected physical size to be %" G_GUINT64_FORMAT
+                   " bytes.", curr_position, priv->max_size);
+      return FALSE;
+    }
+
+  gboolean seek_succeeded =
+    g_seekable_seek (seekable, 0, G_SEEK_SET, NULL /* GCancellable */, error);
+  if (!seek_succeeded)
+    return FALSE;
+
+  guint8 *copy_to = partially_filled_buffer + bytes_read_end;
+  gsize bytes_remaining = total_bytes_to_read - bytes_read_end;
+  gsize bytes_read_start;
+  gboolean read_succeeded =
+    g_input_stream_read_all (input_stream, copy_to, bytes_remaining,
+                             &bytes_read_start, NULL /* GCancellable */, error);
+  if (!read_succeeded)
+    return FALSE;
+
+  if (bytes_remaining != bytes_read_start)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+                   "Circular file is shorter than expected. Reached end of "
+                   "file at byte %" G_GSIZE_FORMAT ".", bytes_read_start);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+read_elem_size (EmerCircularFile *self,
+                GInputStream     *input_stream,
+                guint64          *elem_size,
+                GError          **error)
+{
+  guint64 little_endian_elem_size;
+  gsize bytes_read;
+  gboolean read_succeeded =
+    g_input_stream_read_all (input_stream,
+                             &little_endian_elem_size,
+                             sizeof (little_endian_elem_size),
+                             &bytes_read,
+                             NULL /* GCancellable */,
+                             error);
+  if (!read_succeeded)
+    return FALSE;
+
+  read_succeeded =
+    continue_reading_from_start (self,
+                                 input_stream,
+                                 (guint8 *) &little_endian_elem_size,
+                                 sizeof (little_endian_elem_size),
+                                 bytes_read,
+                                 error);
+  if (!read_succeeded)
+    return FALSE;
+
+  *elem_size = swap_bytes_64_if_big_endian (little_endian_elem_size);
+  return TRUE;
+}
+
+static gboolean
+append_elem_to_array (EmerCircularFile *self,
+                      GInputStream     *input_stream,
+                      GPtrArray        *elem_array,
+                      guint64           elem_size,
+                      GError          **error)
+{
+  guint8 elem_data[elem_size];
+  gsize bytes_read;
+  gboolean read_succeeded =
+    g_input_stream_read_all (input_stream, elem_data, elem_size, &bytes_read,
+                             NULL /* GCancellable */, error);
+  if (!read_succeeded)
+    return FALSE;
+
+  read_succeeded =
+    continue_reading_from_start (self, input_stream, elem_data, elem_size,
+                                 bytes_read, error);
+  if (!read_succeeded)
+    return FALSE;
+
+  GBytes *elem = g_bytes_new (elem_data, elem_size);
+  g_ptr_array_add (elem_array, elem);
+  return TRUE;
+}
+
+static void
+set_path (EmerCircularFile *self,
+          const gchar      *data_filepath)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  priv->data_file = g_file_new_for_path (data_filepath);
+}
+
+static void
+set_max_size (EmerCircularFile *self,
+              guint64           max_size)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  priv->max_size = max_size;
+}
+
+static void
+emer_circular_file_set_property (GObject      *object,
+                                 guint         property_id,
+                                 const GValue *value,
+                                 GParamSpec   *pspec)
+{
+  EmerCircularFile *self = EMER_CIRCULAR_FILE (object);
+
+  switch (property_id)
+    {
+    case PROP_PATH:
+      set_path (self, g_value_get_string (value));
+      break;
+
+    case PROP_MAX_SIZE:
+      set_max_size (self, g_value_get_uint64 (value));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    }
+}
+
+static void
+emer_circular_file_finalize (GObject *object)
+{
+  EmerCircularFile *self = EMER_CIRCULAR_FILE (object);
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  g_clear_object (&priv->data_file);
+  g_clear_pointer (&priv->metadata_key_file, g_key_file_unref);
+  g_clear_pointer (&priv->write_buffer, g_byte_array_unref);
+
+  G_OBJECT_CLASS (emer_circular_file_parent_class)->finalize (object);
+}
+
+static void
+emer_circular_file_class_init (EmerCircularFileClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = emer_circular_file_set_property;
+  object_class->finalize = emer_circular_file_finalize;
+
+  emer_circular_file_props[PROP_PATH] =
+    g_param_spec_string ("path", "Path",
+                         "Path at which circular file is stored",
+                         NULL,
+                         G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE |
+                         G_PARAM_STATIC_STRINGS);
+
+  emer_circular_file_props[PROP_MAX_SIZE] =
+    g_param_spec_uint64 ("max-size", "Max size",
+                         "The maximum permitted physical size of the "
+                         "underlying data file. Does not include the overhead "
+                         "of the metadata file.",
+                         0, G_MAXUINT64, 0,
+                         G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE |
+                         G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class, NPROPS,
+                                     emer_circular_file_props);
+}
+
+static void
+emer_circular_file_init (EmerCircularFile *self)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  priv->write_buffer = g_byte_array_new ();
+}
+
+static gboolean
+emer_circular_file_initable_init (GInitable    *initable,
+                                  GCancellable *cancellable,
+                                  GError      **error)
+{
+  EmerCircularFile *self = EMER_CIRCULAR_FILE (initable);
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  /* Create data file if it doesn't already exist. */
+  GFileOutputStream *data_file_output_stream =
+    g_file_append_to (priv->data_file, G_FILE_CREATE_NONE,
+                      NULL /* GCancellable */, error);
+  if (data_file_output_stream == NULL)
+    return FALSE;
+
+  g_object_unref (data_file_output_stream);
+
+  gchar *metadata_filepath = get_metadata_filepath (self);
+  priv->metadata_key_file = g_key_file_new ();
+  GError *local_error = NULL;
+  gboolean load_succeeded =
+    g_key_file_load_from_file (priv->metadata_key_file, metadata_filepath,
+                               G_KEY_FILE_NONE, &local_error);
+  g_free (metadata_filepath);
+  if (!load_succeeded)
+    {
+      if (!g_error_matches (local_error, G_KEY_FILE_ERROR,
+                            G_KEY_FILE_ERROR_NOT_FOUND) &&
+          !g_error_matches (local_error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+        goto handle_failed_read;
+
+      g_key_file_set_uint64 (priv->metadata_key_file, METADATA_GROUP_NAME,
+                             MAX_SIZE_KEY, priv->max_size);
+      return set_metadata (self, 0, 0, error);
+    }
+
+  guint64 prev_max_size =
+    g_key_file_get_uint64 (priv->metadata_key_file, METADATA_GROUP_NAME,
+                           MAX_SIZE_KEY, &local_error);
+  if (local_error != NULL)
+    goto handle_failed_read;
+
+  priv->size =
+    g_key_file_get_uint64 (priv->metadata_key_file, METADATA_GROUP_NAME,
+                           SIZE_KEY, &local_error);
+  if (local_error != NULL)
+    goto handle_failed_read;
+
+  if (priv->size > prev_max_size)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "Logical size "
+                   "of circular file must be at most %" G_GUINT64_FORMAT ", "
+                   "but was %" G_GUINT64_FORMAT ".", prev_max_size, priv->size);
+      return FALSE;
+    }
+
+  priv->head =
+    g_key_file_get_int64 (priv->metadata_key_file, METADATA_GROUP_NAME,
+                          HEAD_KEY, &local_error);
+  if (local_error != NULL)
+    goto handle_failed_read;
+
+  if (priv->head < 0 || priv->head >= prev_max_size)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "Pointer to "
+                   "head of circular file must lie in range [0, %"
+                   G_GUINT64_FORMAT "), but was %" G_GOFFSET_FORMAT ".",
+                   prev_max_size, priv->head);
+      return FALSE;
+    }
+
+  return resize (self, prev_max_size, error);
+
+handle_failed_read:
+  g_propagate_error (error, local_error);
+  return FALSE;
+}
+
+static void
+emer_circular_file_initable_iface_init (GInitableIface *iface)
+{
+  iface->init = emer_circular_file_initable_init;
+}
+
+/* Returns a new circular file or NULL on error. If a circular file does not
+ * already exist at the given path, a new one is created. Limits the physical
+ * size of the underlying data file to max_size bytes. If a circular file with a
+ * different maximum size already exists at the given path, its maximum size is
+ * changed to the given value, which may result in data loss.
+ */
+EmerCircularFile *
+emer_circular_file_new (const gchar *path,
+                        guint64      max_size,
+                        GError     **error)
+{
+  return g_initable_new (EMER_TYPE_CIRCULAR_FILE,
+                         NULL /* GCancellable */,
+                         error,
+                         "path", path,
+                         "max-size", max_size,
+                         NULL);
+}
+
+/* Appends the given element in-memory only. Use emer_circular_file_save to
+ * flush all appended elements. This allows for batching of writes. Note that
+ * elements can not be read with emer_circular_file_read until they have been
+ * saved. Returns TRUE if the given element was successfully appended and will
+ * fit in the space allotted to the circular file. Returns FALSE otherwise.
+ */
+gboolean
+emer_circular_file_append (EmerCircularFile *self,
+                           gconstpointer     elem,
+                           guint64           elem_size)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  guint64 elem_size_on_disk = sizeof (elem_size) + elem_size;
+  guint64 total_size = priv->size + priv->write_buffer->len + elem_size_on_disk;
+  if (total_size > priv->max_size)
+    return FALSE;
+
+  guint64 little_endian_elem_size = swap_bytes_64_if_big_endian (elem_size);
+  g_byte_array_append (priv->write_buffer,
+                       (const guint8 *) &little_endian_elem_size,
+                       sizeof (little_endian_elem_size));
+  g_byte_array_append (priv->write_buffer, elem, elem_size);
+
+  return TRUE;
+}
+
+/* Flushes all elements successfully appended via emer_circular_file_append
+ * through to the underlying data file. Elements are saved in the same order in
+ * which they were appended. Returns TRUE on success and FALSE on error.
+ */
+gboolean
+emer_circular_file_save (EmerCircularFile *self,
+                         GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  if (priv->write_buffer->len == 0)
+    return TRUE;
+
+  GFileIOStream *file_io_stream =
+    g_file_open_readwrite (priv->data_file, NULL /* GCancellable */, error);
+  if (file_io_stream == NULL)
+    return FALSE;
+
+  GIOStream *io_stream = G_IO_STREAM (file_io_stream);
+  GOutputStream *output_stream = g_io_stream_get_output_stream (io_stream);
+  GSeekable *seekable = G_SEEKABLE (output_stream);
+
+  goffset tail = (priv->head + priv->size) % priv->max_size;
+  gsize space_available_at_tail = priv->max_size - tail;
+  gsize bytes_tail = MIN(priv->write_buffer->len, space_available_at_tail);
+  gsize bytes_start = priv->write_buffer->len - bytes_tail;
+  if (bytes_start > 0)
+    {
+      gboolean seek_succeeded =
+        g_seekable_seek (seekable, 0, G_SEEK_SET, NULL /* GCancellable */,
+                         error);
+      if (!seek_succeeded)
+        goto handle_failed_write;
+
+      const guint8 *copy_from = priv->write_buffer->data + bytes_tail;
+      gboolean write_succeeded =
+        g_output_stream_write_all (output_stream,
+                                   copy_from,
+                                   bytes_start,
+                                   NULL /* bytes written */,
+                                   NULL /* GCancellable */,
+                                   error);
+      if (!write_succeeded)
+        goto handle_failed_write;
+    }
+
+  gboolean seek_succeeded =
+    g_seekable_seek (seekable, tail, G_SEEK_SET, NULL /* GCancellable */,
+                     error);
+
+  if (!seek_succeeded)
+    goto handle_failed_write;
+
+  gboolean write_succeeded =
+    g_output_stream_write_all (output_stream,
+                               priv->write_buffer->data,
+                               bytes_tail,
+                               NULL /* bytes written */,
+                               NULL /* GCancellable */,
+                               error);
+  g_object_unref (file_io_stream);
+  if (!write_succeeded)
+    return FALSE;
+
+  if (!add_to_size (self, priv->write_buffer->len, error))
+    return FALSE;
+
+  g_byte_array_unref (priv->write_buffer);
+  priv->write_buffer = g_byte_array_new ();
+  return TRUE;
+
+handle_failed_write:
+  g_object_unref (file_io_stream);
+  return FALSE;
+}
+
+/* Populates elems with a C array of elements that consume no more than the
+ * given number of bytes in total. Note that only the size of the underlying
+ * data is taken into consideration, not overhead. Elements are read in the same
+ * order in which they were stored; in other words, the circular file is FIFO.
+ * Only data that has been successfully saved with emer_circular_file_save will
+ * be read. Sets token to an opaque value that may be passed to
+ * emer_circular_file_remove to remove the elements that were read in a
+ * particular call to emer_circular_file_read. Tokens may not be reused, and any
+ * successful call to emer_circular_file_remove invalidates any outstanding
+ * tokens. If no elements were read but the read succeeded, then elems is set to
+ * NULL. Returns TRUE on success and FALSE on error.
+ */
+gboolean
+emer_circular_file_read (EmerCircularFile *self,
+                         GBytes         ***elems,
+                         gsize             data_bytes_to_read,
+                         gsize            *num_elems,
+                         guint64          *token,
+                         GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  if (priv->size == 0)
+    {
+      *elems = NULL;
+      *num_elems = 0;
+      *token = 0;
+      return TRUE;
+    }
+
+  GFileInputStream *file_input_stream =
+    g_file_read (priv->data_file, NULL /* GCancellable */, error);
+  if (file_input_stream == NULL)
+    return FALSE;
+
+  GPtrArray *elem_array =
+    g_ptr_array_new_with_free_func ((GDestroyNotify) g_bytes_unref);
+
+  gboolean seek_succeeded =
+    g_seekable_seek (G_SEEKABLE (file_input_stream), priv->head, G_SEEK_SET,
+                     NULL /* GCancellable */, error);
+  if (!seek_succeeded)
+    goto handle_failed_read;
+
+  guint64 curr_data_bytes = 0;
+  guint64 curr_disk_bytes = 0;
+  GInputStream *input_stream = G_INPUT_STREAM (file_input_stream);
+  while (curr_disk_bytes < priv->size)
+    {
+      guint64 elem_size;
+      if (!read_elem_size (self, input_stream, &elem_size, error))
+        goto handle_failed_read;
+
+      guint64 next_data_bytes = curr_data_bytes + elem_size;
+      if (next_data_bytes > data_bytes_to_read)
+        break;
+
+      gboolean append_succeeded =
+        append_elem_to_array (self, input_stream, elem_array, elem_size, error);
+      if (!append_succeeded)
+        goto handle_failed_read;
+
+      curr_data_bytes = next_data_bytes;
+
+      /* sizeof (elem_size) gives the number of bytes used to record the
+       * element's length on disk.
+       */
+      curr_disk_bytes += sizeof (elem_size) + elem_size;
+    }
+
+  g_object_unref (file_input_stream);
+
+  *num_elems = elem_array->len;
+  *elems = (GBytes **) g_ptr_array_free (elem_array, FALSE);
+  *token = curr_disk_bytes;
+  return TRUE;
+
+handle_failed_read:
+  g_object_unref (file_input_stream);
+  g_ptr_array_unref (elem_array);
+  return FALSE;
+}
+
+/* Returns TRUE if there would still be at least one element remaining after a
+ * successful call to emer_circular_file_remove with this token. Returns FALSE
+ * if a successful call to emer_circular_file_remove with this token would
+ * result in all of the elements that are currently in the circular file being
+ * removed. Calling emer_circular_file_has_more does not invalidate this or any
+ * other token, but passing invalid tokens to emer_circular_file_has_more
+ * results in undefined behavior. A token value of 0 may be passed to ascertain
+ * whether the circular file is currently empty.
+ */
+gboolean
+emer_circular_file_has_more (EmerCircularFile *self,
+                             guint64           token)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  return token < priv->size;
+}
+
+/* Removes the elements that were read in the call to emer_circular_file_read
+ * that produced the given token. Tokens may not be reused, and any successful
+ * call to emer_circular_file_remove invalidates any outstanding tokens. A token
+ * value of 0 indicates that no elements should be removed. Returns TRUE on
+ * success and FALSE on error.
+ */
+gboolean
+emer_circular_file_remove (EmerCircularFile *self,
+                           guint64           token,
+                           GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  if (token == 0)
+    return TRUE;
+
+  guint64 new_size = priv->size - token;
+  goffset new_head = (priv->head + token) % priv->max_size;
+  return set_metadata (self, new_size, new_head, error);
+}
+
+/* Removes all data stored in the circular file. Does not remove any data that
+ * has been appended but not saved. Returns TRUE on success and FALSE on error.
+ */
+gboolean
+emer_circular_file_purge (EmerCircularFile *self,
+                          GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  return priv->size == 0 ? TRUE : set_metadata (self, 0, 0, error);
+}

--- a/daemon/emer-circular-file.h
+++ b/daemon/emer-circular-file.h
@@ -1,0 +1,100 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2015 Endless Mobile, Inc. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EMER_CIRCULAR_FILE_H
+#define EMER_CIRCULAR_FILE_H
+
+#include <gio/gio.h>
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define EMER_TYPE_CIRCULAR_FILE emer_circular_file_get_type()
+
+#define EMER_CIRCULAR_FILE(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST ((obj), \
+  EMER_TYPE_CIRCULAR_FILE, EmerCircularFile))
+
+#define EMER_CIRCULAR_FILE_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST ((klass), \
+  EMER_TYPE_CIRCULAR_FILE, EmerCircularFileClass))
+
+#define EMER_IS_CIRCULAR_FILE(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), \
+  EMER_TYPE_CIRCULAR_FILE))
+
+#define EMER_IS_CIRCULAR_FILE_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE ((klass), \
+  EMER_TYPE_CIRCULAR_FILE))
+
+#define EMER_CIRCULAR_FILE_GET_CLASS(obj) \
+  (G_TYPE_INSTANCE_GET_CLASS ((obj), \
+  EMER_TYPE_CIRCULAR_FILE, EmerCircularFileClass))
+
+#define METADATA_EXTENSION ".metadata"
+
+typedef struct _EmerCircularFile EmerCircularFile;
+typedef struct _EmerCircularFileClass EmerCircularFileClass;
+
+struct _EmerCircularFile
+{
+  GObject parent;
+};
+
+struct _EmerCircularFileClass
+{
+  GObjectClass parent_class;
+};
+
+GType             emer_circular_file_get_type (void) G_GNUC_CONST;
+
+EmerCircularFile *emer_circular_file_new      (const gchar      *path,
+                                               guint64           max_size,
+                                               GError          **error);
+
+gboolean          emer_circular_file_append   (EmerCircularFile *self,
+                                               gconstpointer     elem,
+                                               guint64           elem_size);
+
+gboolean          emer_circular_file_save     (EmerCircularFile *self,
+                                               GError          **error);
+
+gboolean          emer_circular_file_read     (EmerCircularFile *self,
+                                               GBytes         ***elems,
+                                               gsize             num_bytes,
+                                               gsize            *num_elems,
+                                               guint64          *token,
+                                               GError          **error);
+
+gboolean          emer_circular_file_has_more (EmerCircularFile *self,
+                                               guint64           token);
+
+gboolean          emer_circular_file_remove   (EmerCircularFile *self,
+                                               guint64           token,
+                                               GError          **error);
+
+gboolean          emer_circular_file_purge    (EmerCircularFile *self,
+                                               GError          **error);
+
+G_END_DECLS
+
+#endif /* EMER_CIRCULAR_FILE_H */

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -260,7 +260,7 @@ get_http_request_uri (EmerDaemon   *self,
   gchar *checksum =
     g_compute_checksum_for_data (G_CHECKSUM_SHA512, data, length);
   gchar *http_request_uri_string =
-    g_strconcat (priv->server_uri, checksum, NULL);
+    g_build_filename (priv->server_uri, checksum, NULL);
   g_free (checksum);
 
   SoupURI *http_request_uri = soup_uri_new (http_request_uri_string);
@@ -1117,7 +1117,7 @@ set_server_uri (EmerDaemon  *self,
     {
       g_free (priv->server_uri);
       priv->server_uri =
-        g_strconcat (server_uri, CLIENT_VERSION_NUMBER "/", NULL);
+        g_build_filename (server_uri, CLIENT_VERSION_NUMBER "/", NULL);
     }
 }
 

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -20,7 +20,6 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#include <string.h>
 #include <time.h>
 #include <uuid/uuid.h>
 
@@ -988,7 +987,7 @@ handle_login_manager_signal (GDBusProxy *dbus_proxy,
                              GVariant   *parameters,
                              EmerDaemon *self)
 {
-  if (strcmp ("PrepareForShutdown", signal_name) == 0)
+  if (g_strcmp0 ("PrepareForShutdown", signal_name) == 0)
     {
       gboolean shutting_down;
       g_variant_get_child (parameters, 0, "b", &shutting_down);

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -95,9 +95,11 @@ typedef struct _EmerDaemonPrivate
 {
   gint shutdown_inhibitor;
   GDBusProxy *login_manager_proxy;
+
   guint network_send_interval;
   GQueue *upload_queue;
   gboolean uploading;
+
   SoupSession *http_session;
 
   /* Private storage for public properties */
@@ -1214,7 +1216,6 @@ set_sequence_buffer_length (EmerDaemon *self,
   priv->sequence_buffer_length = length;
   priv->sequence_buffer = g_new (SequenceEvent, length);
   priv->num_sequences_buffered = 0;
-
 }
 
 static void
@@ -1303,7 +1304,6 @@ emer_daemon_finalize (GObject *object)
   g_queue_free_full (priv->upload_queue, g_object_unref);
 
   soup_session_abort (priv->http_session);
-
   g_clear_object (&priv->http_session);
 
   g_rand_free (priv->rand);

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -20,7 +20,6 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#include <byteswap.h>
 #include <string.h>
 #include <time.h>
 #include <uuid/uuid.h>

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1384,7 +1384,6 @@ emer_daemon_class_init (EmerDaemonClass *klass)
    * An #EmerMachineIdProvider for retrieving the UUID of this machine.
    * If this property is not specified, the default machine ID provider (from
    * emer_machine_id_provider_new()) will be used.
-   * You should only set this property to something else for testing purposes.
    */
   emer_daemon_props[PROP_MACHINE_ID_PROVIDER] =
     g_param_spec_object ("machine-id-provider", "Machine ID provider",
@@ -1399,7 +1398,6 @@ emer_daemon_class_init (EmerDaemonClass *klass)
    * An #EmerNetworkSendProvider for getting and setting the network send
    * metadata. If this property is not specified, the default network send
    * provider will be used (from emer_network_send_provider_new()).
-   * You should only set this property to something else for testing purposes.
    */
   emer_daemon_props[PROP_NETWORK_SEND_PROVIDER] =
     g_param_spec_object ("network-send-provider", "Network send provider",
@@ -1411,6 +1409,9 @@ emer_daemon_class_init (EmerDaemonClass *klass)
   /*
    * EmerDaemon:permissions-provider:
    *
+   * An #EmerPermissionsProvider for getting the user's preferences regarding
+   * the metrics system. If this property is not specified, the default
+   * permissions provider will be used (from emer_permissions_provider_new()).
    */
   emer_daemon_props[PROP_PERMISSIONS_PROVIDER] =
     g_param_spec_object ("permissions-provider", "Permissions provider",
@@ -1426,7 +1427,6 @@ emer_daemon_class_init (EmerDaemonClass *klass)
    * proxy server.
    * If this property is not specified, a default persistent cache (created by
    * emer_persistent_cache_new ()) will be used.
-   * You should only set this property to something else for testing purposes.
    */
   emer_daemon_props[PROP_PERSISTENT_CACHE] =
     g_param_spec_object ("persistent-cache", "Persistent cache",
@@ -1503,9 +1503,7 @@ emer_daemon_init (EmerDaemon *self)
 /*
  * emer_daemon_new:
  *
- * Creates a new EOS Metrics Daemon.
- *
- * Returns: (transfer full): a new #EmerDaemon.
+ * Returns: (transfer full): a new #EmerDaemon with the default configuration.
  */
 EmerDaemon *
 emer_daemon_new (void)
@@ -1537,10 +1535,8 @@ emer_daemon_new (void)
  *   in-memory buffers. There are three in-memory buffers, one for singulars,
  *   for aggregates, and one for sequences.
  *
- * Testing function for creating a new EOS Metrics daemon.
- * You should only need to use this for unit testing.
- *
- * Returns: (transfer full): a new #EmerDaemon.
+ * Returns: (transfer full): a new customized #EmerDaemon. Use emer_daemon_new
+ * to use the default configuration.
  */
 EmerDaemon *
 emer_daemon_new_full (GRand                   *rand,

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -391,7 +391,7 @@ get_offset_timestamps (EmerDaemon *self,
 
   gint64 boot_offset;
   if (!emer_persistent_cache_get_boot_time_offset (priv->persistent_cache,
-                                                   &boot_offset, error, FALSE))
+                                                   &boot_offset, FALSE, error))
     return FALSE;
 
   *rel_timestamp_ptr += boot_offset;
@@ -972,7 +972,7 @@ update_timestamps (EmerDaemon *self)
 
   GError *error = NULL;
   if (!emer_persistent_cache_get_boot_time_offset (priv->persistent_cache,
-                                                   NULL, &error, TRUE))
+                                                   NULL, TRUE, &error))
     {
       g_warning ("Persistent cache could not update timestamps: %s.",
                  error->message);
@@ -1525,7 +1525,7 @@ emer_daemon_record_singular_event (EmerDaemon *self,
   gint64 boot_offset;
   GError *error = NULL;
   if (!emer_persistent_cache_get_boot_time_offset (priv->persistent_cache,
-                                                   &boot_offset, &error, FALSE))
+                                                   &boot_offset, FALSE, &error))
     {
       g_warning ("Unable to correct event's relative timestamp. Dropping "
                  "event. Error: %s.", error->message);
@@ -1565,7 +1565,7 @@ emer_daemon_record_aggregate_event (EmerDaemon *self,
   gint64 boot_offset;
   GError *error = NULL;
   if (!emer_persistent_cache_get_boot_time_offset (priv->persistent_cache,
-                                                   &boot_offset, &error, FALSE))
+                                                   &boot_offset, FALSE, &error))
     {
       g_warning ("Unable to correct event's relative timestamp. Dropping "
                  "event. Error: %s.", error->message);
@@ -1602,7 +1602,7 @@ emer_daemon_record_event_sequence (EmerDaemon *self,
   gint64 boot_offset;
   GError *error = NULL;
   if (!emer_persistent_cache_get_boot_time_offset (priv->persistent_cache,
-                                                   &boot_offset, &error, FALSE))
+                                                   &boot_offset, FALSE, &error))
     {
       g_warning ("Unable to correct event's relative timestamp. Dropping "
                  "event. Error: %s.", error->message);

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1199,7 +1199,6 @@ set_singular_buffer_length (EmerDaemon *self,
   EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
   priv->singular_buffer_length = length;
   priv->singular_buffer = g_new (SingularEvent, length);
-  priv->num_singulars_buffered = 0;
 }
 
 static void
@@ -1209,7 +1208,6 @@ set_aggregate_buffer_length (EmerDaemon *self,
   EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
   priv->aggregate_buffer_length = length;
   priv->aggregate_buffer = g_new (AggregateEvent, length);
-  priv->num_aggregates_buffered = 0;
 }
 
 static void
@@ -1219,7 +1217,6 @@ set_sequence_buffer_length (EmerDaemon *self,
   EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
   priv->sequence_buffer_length = length;
   priv->sequence_buffer = g_new (SequenceEvent, length);
-  priv->num_sequences_buffered = 0;
 }
 
 static void
@@ -1483,7 +1480,6 @@ emer_daemon_init (EmerDaemon *self)
   connect_to_login_manager (self);
 
   priv->upload_queue = g_queue_new ();
-  priv->uploading = FALSE;
 
   gchar *user_agent = get_user_agent ();
 

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -808,8 +808,7 @@ upload_permitted (EmerDaemon *self,
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED,
                    "Could not upload events because the metrics system is "
                    "disabled. You may enable the metrics system via "
-                   "Settings/Configuración > Privacy/Privacidad > "
-                   "Metrics/Métricas.");
+                   "Settings > Privacy > Metrics.");
       return FALSE;
     }
 

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1184,8 +1184,6 @@ set_persistent_cache (EmerDaemon          *self,
       if (priv->persistent_cache == NULL)
         {
           g_error_free (error);
-          priv->persistent_cache = NULL;
-          return;
         }
     }
   else

--- a/daemon/emer-daemon.h
+++ b/daemon/emer-daemon.h
@@ -81,7 +81,7 @@ EmerDaemon *             emer_daemon_new_full                 (GRand            
                                                                EmerNetworkSendProvider *network_send_provider,
                                                                EmerPermissionsProvider *permissions_provider,
                                                                EmerPersistentCache     *persistent_cache,
-                                                               gint                     buffer_length);
+                                                               gulong                   max_bytes_buffered);
 
 void                     emer_daemon_record_singular_event    (EmerDaemon              *self,
                                                                guint32                  user_id,

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -956,8 +956,8 @@ emer_persistent_cache_cost (GVariant *variant)
 gboolean
 emer_persistent_cache_get_boot_time_offset (EmerPersistentCache *self,
                                             gint64              *offset,
-                                            GError             **error,
-                                            gboolean             always_update_timestamps)
+                                            gboolean             always_update_timestamps,
+                                            GError             **error)
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -160,7 +160,7 @@ get_saved_boot_id (EmerPersistentCache *self,
                                                error);
   if (id_as_string == NULL)
     {
-      g_prefix_error (error, "Failed to read boot_id from %s. ",
+      g_prefix_error (error, "Failed to read boot ID from %s. ",
                       priv->boot_metadata_file_path);
       return FALSE;
     }
@@ -172,7 +172,7 @@ get_saved_boot_id (EmerPersistentCache *self,
   g_strchomp (id_as_string);
   if (uuid_parse (id_as_string, priv->saved_boot_id) != 0)
     {
-      g_prefix_error (error, "Failed to parse the saved boot id: %s. ",
+      g_prefix_error (error, "Failed to parse saved boot ID: %s. ",
                       id_as_string);
       g_free (id_as_string);
       return FALSE;
@@ -200,7 +200,7 @@ get_system_boot_id (EmerPersistentCache *self,
   if (!emer_boot_id_provider_get_id (priv->boot_id_provider, boot_id))
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
-                   "Failed to get the boot ID from the EmerBootIdProvider.");
+                   "Failed to get boot ID from EmerBootIdProvider.");
       return FALSE;
     }
   return TRUE;
@@ -423,7 +423,7 @@ compute_boot_offset (EmerPersistentCache *self,
                           CACHE_BOOT_OFFSET_KEY, &error);
   if (error != NULL)
     {
-      g_critical ("Failed to read relative offset from metadata file %s. "
+      g_critical ("Failed to read boot offset from metadata file %s. "
                   "Error: %s.", priv->boot_metadata_file_path, error->message);
       g_error_free (error);
       return FALSE;
@@ -562,8 +562,8 @@ update_boot_offset (EmerPersistentCache *self,
                                              CACHE_BOOT_OFFSET_KEY, &error);
   if (error != NULL)
     {
-      g_warning ("Could not find a valid boot offset in the metadata file. "
-                 "Error: %s.", error->message);
+      g_warning ("Failed to read boot offset from metadata file %s. "
+                 "Error: %s.", priv->boot_metadata_file_path, error->message);
       g_error_free (error);
       return FALSE;
     }
@@ -1414,8 +1414,7 @@ apply_cache_versioning (EmerPersistentCache *self,
       gboolean success = purge_cache_files (self, cancellable, &local_error);
       if (!success)
         {
-          g_prefix_error (&local_error, "Failed to purge cache files! Will not "
-                          "update version number. ");
+          g_prefix_error (&local_error, "Will not update version number. ");
           g_critical ("%s.", local_error->message);
           g_propagate_error (error, local_error);
           return FALSE;

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -23,43 +23,35 @@
 #include "emer-persistent-cache.h"
 
 #include <errno.h>
+#include <string.h>
 
 #include <gio/gio.h>
 #include <glib.h>
 #include <glib/gprintf.h>
+#include <glib/gstdio.h>
 #include <glib-object.h>
 
 #include <eosmetrics/eosmetrics.h>
 
+#include "emer-circular-file.h"
 #include "shared/metrics-util.h"
+
+#define VARIANT_FILENAME "variants.dat"
 
 /* SECTION:emer-persistent-cache.c
  * @title: Persistent Cache
- * @short_description: Stores metrics locally (on the user's machine).
+ * @short_description: A general-purpose persistent FIFO store for variants
  *
- * The persistent cache is the sink to which an event recorder flushes
- * metrics. It will store these metrics until a drain operation is
- * requested or the persistent cache is purged due to versioning.
- *
- * Should the cached metrics occupy more than the maximum allowed cache size,
- * the persistent cache will begin ignoring new metrics until the old ones have
- * been removed.
- *
- * If the CURRENT_CACHE_VERSION is incremented to indicate
- * backwards-incompatible versioning, any cached metrics will be deleted, and
- * the file indicating the local cache version will be updated to the reflect
- * the new version number.
+ * Uses a machine-independent storage format that may only be modified in a
+ * backwards-incompatible manner when CURRENT_CACHE_VERSION is incremented.
  */
 
 typedef struct _EmerPersistentCachePrivate
 {
   EmerCacheSizeProvider *cache_size_provider;
-  guint64 cache_size;
-  capacity_t capacity;
-
   EmerBootIdProvider *boot_id_provider;
-
   EmerCacheVersionProvider *cache_version_provider;
+  EmerCircularFile *variant_file;
 
   guint boot_offset_update_timeout_source_id;
 
@@ -81,17 +73,11 @@ G_DEFINE_TYPE_WITH_CODE (EmerPersistentCache, emer_persistent_cache, G_TYPE_OBJE
                          G_ADD_PRIVATE (EmerPersistentCache)
                          G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, emer_persistent_cache_initable_iface_init))
 
-/*
- * If this version is greater than the version of the persisted metrics,
- * they will be purged from the system, and the file indicating which
- * version the persisted metrics currently have will be updated.
+/* If this version is greater than the version of the persisted variants,
+ * they will be removed, and the file in which the version number is stored
+ * will be updated.
  */
-#define CURRENT_CACHE_VERSION 3
-
-/*
- * The point at which the capacity switches fron LOW to HIGH.
- */
-#define HIGH_CAPACITY_THRESHOLD 0.75 // 75%
+#define CURRENT_CACHE_VERSION 4
 
 /*
  * The expected size in bytes of the file located at SYSTEM_BOOT_ID_FILE.
@@ -112,7 +98,7 @@ G_DEFINE_TYPE_WITH_CODE (EmerPersistentCache, emer_persistent_cache, G_TYPE_OBJE
 
 /*
  * The path to the file containing the boot ID used to determine if this is the
- * same boot as previous metrics were recorded in or not.
+ * same boot the persistent cache was last initialized in.
  */
 #define SYSTEM_BOOT_ID_FILE "/proc/sys/kernel/random/boot_id"
 
@@ -168,8 +154,8 @@ get_saved_boot_id (EmerPersistentCache *self,
   g_strchomp (id_as_string);
   if (uuid_parse (id_as_string, priv->saved_boot_id) != 0)
     {
-      g_prefix_error (error, "Failed to parse saved boot ID: %s. ",
-                      id_as_string);
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Failed to parse saved boot ID: %s", id_as_string);
       g_free (id_as_string);
       return FALSE;
     }
@@ -196,83 +182,36 @@ get_system_boot_id (EmerPersistentCache *self,
   if (!emer_boot_id_provider_get_id (priv->boot_id_provider, boot_id))
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
-                   "Failed to get boot ID from EmerBootIdProvider.");
+                   "Failed to get boot ID from EmerBootIdProvider");
       return FALSE;
     }
+
   return TRUE;
 }
 
-/*
- * Creates and returns a newly allocated GFile * corresponding to the cache
- * file ending or metadata file ending given to it as path_ending.
- */
-static GFile *
-get_cache_file (EmerPersistentCache *self,
-                gchar               *path_ending)
+static void
+unlink_old_file (EmerPersistentCache *self,
+                 const gchar         *filename)
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  gchar *filename = g_strconcat (CACHE_PREFIX, path_ending, NULL);
   gchar *path = g_build_filename (priv->cache_directory, filename, NULL);
-  g_free (filename);
-  GFile *file = g_file_new_for_path (path);
+  if (g_unlink (path) != 0)
+    {
+      const gchar *error_string = g_strerror (errno);
+      g_warning ("Failed to unlink old cache file %s. Error: %s.",
+                 path, error_string);
+    }
   g_free (path);
-  return file;
 }
 
-/*
- * Should only be called if the version is out of date, corrupted, or the cache
- * file does not exist. Replaces the content of all cache files with the empty
- * string. Will create these empty files if they do not already exist.
- * Returns TRUE on success and FALSE on I/O failure.
- */
-static gboolean
-purge_cache_files (EmerPersistentCache *self,
-                   GCancellable        *cancellable,
-                   GError             **error)
+static void
+unlink_old_files (EmerPersistentCache *self)
 {
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
-
-  GFile *ind_file = get_cache_file (self, INDIVIDUAL_SUFFIX);
-  GError *local_error = NULL;
-  gboolean success =
-    g_file_replace_contents (ind_file, "", 0, NULL, FALSE,
-                             G_FILE_CREATE_REPLACE_DESTINATION,
-                             NULL, cancellable, &local_error);
-  g_object_unref (ind_file);
-  if (!success)
-    goto handle_failed_write;
-
-  GFile *agg_file = get_cache_file (self, AGGREGATE_SUFFIX);
-  success =
-    g_file_replace_contents (agg_file, "", 0, NULL, FALSE,
-                             G_FILE_CREATE_REPLACE_DESTINATION,
-                             NULL, cancellable, &local_error);
-  g_object_unref (agg_file);
-  if (!success)
-    goto handle_failed_write;
-
-  GFile *seq_file = get_cache_file (self, SEQUENCE_SUFFIX);
-  success =
-    g_file_replace_contents (seq_file, "", 0, NULL, FALSE,
-                             G_FILE_CREATE_REPLACE_DESTINATION,
-                             NULL, cancellable, &local_error);
-  g_object_unref (seq_file);
-  if (!success)
-    goto handle_failed_write;
-
-  priv->cache_size = 0L;
-  priv->capacity = CAPACITY_LOW;
-
-  return TRUE;
-
-handle_failed_write:
-  g_prefix_error (&local_error, "Failed to purge cache files. ");
-  g_critical ("%s.", local_error->message);
-  g_propagate_error (error, local_error);
-  return FALSE;
+  unlink_old_file (self, "cache_individual.metrics");
+  unlink_old_file (self, "cache_aggregate.metrics");
+  unlink_old_file (self, "cache_sequence.metrics");
 }
 
 /*
@@ -343,14 +282,15 @@ save_timing_metadata (EmerPersistentCache *self,
  *
  * Initializes the cache's boot offset and boot id.
  *
- * Completely wipes the persistent cache's stored metrics.
+ * Completely wipes the persistent cache.
  *
  * Returns TRUE if successful and FALSE on failure.
  */
 static gboolean
 reset_boot_offset_metadata_file (EmerPersistentCache *self,
                                  gint64              *relative_time_ptr,
-                                 gint64              *absolute_time_ptr)
+                                 gint64              *absolute_time_ptr,
+                                 GError             **error)
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
@@ -358,18 +298,14 @@ reset_boot_offset_metadata_file (EmerPersistentCache *self,
   priv->boot_offset_initialized = FALSE;
   priv->boot_id_initialized = FALSE;
 
-  GError *error = NULL;
   uuid_t system_boot_id;
-  if (!get_system_boot_id (self, system_boot_id, &error))
-    {
-      g_critical ("Failed to reset boot metadata. Error: %s.", error->message);
-      g_error_free (error);
-      return FALSE;
-    }
+  if (!get_system_boot_id (self, system_boot_id, error))
+    return FALSE;
+
   gchar system_boot_id_string[BOOT_ID_FILE_LENGTH];
   uuid_unparse_lower (system_boot_id, system_boot_id_string);
 
-  if (!purge_cache_files (self, NULL, NULL))
+  if (!emer_circular_file_purge (priv->variant_file, error))
     return FALSE;
 
   gint64 reset_offset = 0;
@@ -377,14 +313,10 @@ reset_boot_offset_metadata_file (EmerPersistentCache *self,
   gboolean write_success =
     save_timing_metadata (self, relative_time_ptr, absolute_time_ptr,
                           &reset_offset, system_boot_id_string, &was_reset,
-                          &error);
+                          error);
 
   if (!write_success)
-    {
-      g_critical ("Failed to reset boot timing metadata. Error: %s.",
-                   error->message);
-      return FALSE;
-    }
+    return FALSE;
 
   priv->boot_offset = reset_offset;
   priv->boot_offset_initialized = TRUE;
@@ -404,12 +336,13 @@ static gboolean
 compute_boot_offset (EmerPersistentCache *self,
                      gint64               relative_time,
                      gint64               absolute_time,
-                     gint64              *boot_offset)
+                     gint64              *boot_offset,
+                     GError             **error)
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  GError *error = NULL;
+  GError *local_error = NULL;
 
   /*
    * This is the amount of time elapsed between the origin boot and the boot
@@ -417,34 +350,37 @@ compute_boot_offset (EmerPersistentCache *self,
    */
   gint64 stored_offset =
     g_key_file_get_int64 (priv->boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
-                          CACHE_BOOT_OFFSET_KEY, &error);
-  if (error != NULL)
+                          CACHE_BOOT_OFFSET_KEY, &local_error);
+  if (local_error != NULL)
     {
-      g_critical ("Failed to read boot offset from metadata file %s. "
-                  "Error: %s.", priv->boot_metadata_file_path, error->message);
-      g_error_free (error);
+      g_propagate_prefixed_error (error, local_error,
+                                  "Failed to read boot offset from metadata "
+                                  "file %s. ",
+                                  priv->boot_metadata_file_path);
       return FALSE;
     }
 
   gint64 stored_relative_time =
     g_key_file_get_int64 (priv->boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
-                          CACHE_RELATIVE_TIME_KEY, &error);
-  if (error != NULL)
+                          CACHE_RELATIVE_TIME_KEY, &local_error);
+  if (local_error != NULL)
     {
-      g_critical ("Failed to read relative time from metadata file %s. "
-                  "Error: %s.", priv->boot_metadata_file_path, error->message);
-      g_error_free (error);
+      g_propagate_prefixed_error (error, local_error,
+                                  "Failed to read relative time from metadata "
+                                  "file %s. ",
+                                  priv->boot_metadata_file_path);
       return FALSE;
     }
 
   gint64 stored_absolute_time =
     g_key_file_get_int64 (priv->boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
-                          CACHE_ABSOLUTE_TIME_KEY, &error);
-  if (error != NULL)
+                          CACHE_ABSOLUTE_TIME_KEY, &local_error);
+  if (local_error != NULL)
     {
-      g_critical ("Failed to read absolute time from metadata file %s. "
-                  "Error: %s.", priv->boot_metadata_file_path, error->message);
-      g_error_free (error);
+      g_propagate_prefixed_error (error, local_error,
+                                  "Failed to read absolute time from metadata "
+                                  "file %s. ",
+                                  priv->boot_metadata_file_path);
       return FALSE;
     }
 
@@ -497,102 +433,83 @@ compute_boot_offset (EmerPersistentCache *self,
  *
  * The net effect of the entire system is that the most plausible way to trick
  * it is to adjust the system clock and yank the power cord before the next
- * network send occurs (an hourly event).
+ * timestamp update.
  */
 static gboolean
 update_boot_offset (EmerPersistentCache *self,
-                    gboolean             always_update_timestamps)
+                    gboolean             always_update_timestamps,
+                    GError             **error)
 {
   gint64 relative_time, absolute_time;
   if (!emtr_util_get_current_time (CLOCK_BOOTTIME, &relative_time) ||
       !emtr_util_get_current_time (CLOCK_REALTIME, &absolute_time))
     {
-      g_critical ("Could not get the boot offset because getting the current "
-                  "time failed.");
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Could not get the "
+                   "boot offset because getting the current time failed");
       return FALSE;
     }
 
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  GError *error = NULL;
-
   if (priv->boot_offset_initialized)
     {
       if (always_update_timestamps)
-        {
-          gboolean write_success =
-            save_timing_metadata (self, &relative_time, &absolute_time,
-                                  NULL, NULL, NULL, &error);
-          if (!write_success)
-            {
-              g_warning ("Failed to update relative and absolute time in "
-                         "metadata file. Error: %s.", error->message);
-              g_error_free (error);
-            }
-        }
+        return save_timing_metadata (self, &relative_time, &absolute_time, NULL,
+                                     NULL, NULL, error);
 
       return TRUE;
     }
 
+  GError *local_error = NULL;
   gboolean load_succeeded =
     g_key_file_load_from_file (priv->boot_offset_key_file,
                                priv->boot_metadata_file_path, G_KEY_FILE_NONE,
-                               &error);
+                               &local_error);
   if (!load_succeeded)
     {
-      if (!g_error_matches (error, G_KEY_FILE_ERROR,
+      if (!g_error_matches (local_error, G_KEY_FILE_ERROR,
                             G_KEY_FILE_ERROR_NOT_FOUND) &&
-          !g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
-        g_warning ("Got an unexpected error trying to load %s. Error: %s.",
-                   priv->boot_metadata_file_path, error->message);
+          !g_error_matches (local_error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+        {
+          g_propagate_error (error, local_error);
+          return FALSE;
+        }
 
-      g_error_free (error);
       return reset_boot_offset_metadata_file (self, &relative_time,
-                                              &absolute_time);
+                                              &absolute_time, error);
     }
 
   gint64 boot_offset =
     g_key_file_get_int64 (priv->boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
-                          CACHE_BOOT_OFFSET_KEY, &error);
-  if (error != NULL)
+                          CACHE_BOOT_OFFSET_KEY, &local_error);
+  if (local_error != NULL)
     {
-      g_warning ("Failed to read boot offset from metadata file %s. "
-                 "Error: %s.", priv->boot_metadata_file_path, error->message);
-      g_error_free (error);
+      g_propagate_prefixed_error (error, local_error,
+                                  "Failed to read boot offset from metadata "
+                                  "file %s. ",
+                                  priv->boot_metadata_file_path);
       return FALSE;
     }
 
   uuid_t saved_boot_id, system_boot_id;
-  if (!get_saved_boot_id (self, saved_boot_id, &error) ||
-      !get_system_boot_id (self, system_boot_id, &error))
-    {
-      g_critical ("Failed to access boot ids for comparison. Error: %s.",
-                  error->message);
-      g_error_free (error);
-      return FALSE;
-    }
+  if (!get_saved_boot_id (self, saved_boot_id, error) ||
+      !get_system_boot_id (self, system_boot_id, error))
+    return FALSE;
 
   if (uuid_compare (saved_boot_id, system_boot_id) == 0)
     {
       if (always_update_timestamps)
-        {
-          gboolean write_success =
-            save_timing_metadata (self, &relative_time, &absolute_time,
-                                  NULL, NULL, NULL, &error);
-
-          if (!write_success)
-            {
-              g_warning ("Failed to update relative and absolute time in "
-                         "metadata file. Error: %s.", error->message);
-              g_error_free (error);
-            }
-        }
+        return save_timing_metadata (self, &relative_time, &absolute_time, NULL,
+                                     NULL, NULL, error);
 
       return TRUE;
     }
 
-  if (!compute_boot_offset (self, relative_time, absolute_time, &boot_offset))
+  gboolean compute_succeeded =
+    compute_boot_offset (self, relative_time, absolute_time, &boot_offset,
+                         error);
+  if (!compute_succeeded)
     return FALSE;
 
   gchar system_boot_id_string[BOOT_ID_FILE_LENGTH];
@@ -601,15 +518,10 @@ update_boot_offset (EmerPersistentCache *self,
   gboolean was_reset = FALSE;
   gboolean write_success =
     save_timing_metadata (self, &relative_time, &absolute_time, &boot_offset,
-                          system_boot_id_string, &was_reset, &error);
+                          system_boot_id_string, &was_reset, error);
 
   if (!write_success)
-    {
-      g_warning ("Failed to write computed boot offset. Resetting cache. "
-                 "Error: %s.", error->message);
-      g_error_free (error);
-      return FALSE;
-    }
+    return FALSE;
 
   priv->boot_offset = boot_offset;
   priv->boot_offset_initialized = TRUE;
@@ -622,758 +534,76 @@ update_boot_offset (EmerPersistentCache *self,
 static gboolean
 update_boot_offset_source_func (EmerPersistentCache *self)
 {
-  update_boot_offset (self, TRUE);
+  GError *error = NULL;
+  if (!update_boot_offset (self, TRUE, &error))
+    {
+      g_warning ("Failed to update metadata timestamps. Error: %s",
+                 error->message);
+      g_error_free (error);
+    }
 
   return G_SOURCE_CONTINUE;
 }
 
-/* Gets the boot time offset and stores it in the out parameter offset.
- * If the always_update_timestamps parameter is FALSE, does not write to disk
- * solely to update the timestamps during this operation unless the boot id is
- * out of date or some corruption is detected that prompts a total rewrite of
- * the boot timing metadata file. Pass an offset of NULL if you don't care about
- * its value.
- *
- * Returns TRUE on success. Returns FALSE on failure and sets the error unless
- * it's NULL. Does not alter the offset out parameter on failure.
+/* Returns a new variant or a new reference to the given variant that is
+ * little-endian, in normal form, and marked trusted. Free the return value with
+ * g_variant_unref.
  */
-gboolean
-emer_persistent_cache_get_boot_time_offset (EmerPersistentCache *self,
-                                            gint64              *offset,
-                                            GError             **error,
-                                            gboolean             always_update_timestamps)
-{
-  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
-
-
-  /* When always_update_timestamps is FALSE, the timestamps won't be written
-   * unless the boot offset in the metadata file is being overwritten.
-   */
-  if (!update_boot_offset (self, always_update_timestamps))
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
-                   "Couldn't read boot offset.");
-      return FALSE;
-    }
-
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
-
-  if (offset != NULL)
-    *offset = priv->boot_offset;
-
-  return TRUE;
-}
-
 static GVariant *
-deep_copy_variant (GVariant *variant)
+regularize_pre_storage (GVariant *variant)
 {
-  GBytes *bytes = g_variant_get_data_as_bytes (variant);
-  const GVariantType *variant_type = g_variant_get_type (variant);
-  GVariant *copy = g_variant_new_from_bytes (variant_type, bytes, TRUE);
-  g_bytes_unref (bytes);
-  return copy;
+  if (G_BYTE_ORDER == G_LITTLE_ENDIAN)
+    return g_variant_get_normal_form (variant);
+
+  if (G_BYTE_ORDER != G_BIG_ENDIAN)
+    g_error ("This machine is neither big endian nor little endian. Mixed-"
+             "endian machines are not supported.");
+
+  /* Avoid sinking floating reference of variant. */
+  GVariant *copy = deep_copy_variant (variant);
+  g_variant_ref_sink (copy);
+  GVariant *little_endian_variant = g_variant_byteswap (copy);
+  g_variant_unref (copy);
+
+  return little_endian_variant;
 }
 
-/* Return a new floating GVariant with the machine's native endianness that is
+/* Returns a new floating variant with the machine's native endianness that is
  * in normal form and marked trusted.
  */
 static GVariant *
-regularize_variant (GVariant *variant)
+regularize_post_storage (GVariant *variant)
 {
+  if (!g_variant_is_normal_form (variant))
+    g_error ("A variant was stored in normal form but read in non-normal "
+             "form.");
+
+  if (G_BYTE_ORDER == G_LITTLE_ENDIAN)
+    return variant;
+
+  if (G_BYTE_ORDER != G_BIG_ENDIAN)
+    g_error ("This machine is neither big endian nor little endian. Mixed-"
+             "endian machines are not supported.");
+
   g_variant_ref_sink (variant);
-  GVariant *normalized_variant = g_variant_get_normal_form (variant);
+  GVariant *native_endian_variant = g_variant_byteswap (variant);
   g_variant_unref (variant);
 
-  if (G_BYTE_ORDER == G_BIG_ENDIAN)
-    {
-      GVariant *byteswapped_variant = g_variant_byteswap (normalized_variant);
-      g_variant_unref (normalized_variant);
-      normalized_variant = byteswapped_variant;
-    }
-  else if (G_BYTE_ORDER != G_LITTLE_ENDIAN)
-    {
-      g_error ("This machine is neither big endian nor little endian. Mixed-"
-               "endian machines are not supported by the metrics system.");
-    }
+  /* Restore floating bit. */
+  GVariant *floating_variant = deep_copy_variant (native_endian_variant);
 
-  // Restore floating bit.
-  GVariant *native_endian_variant = deep_copy_variant (normalized_variant);
-
-  g_variant_unref (normalized_variant);
-  return native_endian_variant;
+  g_variant_unref (native_endian_variant);
+  return floating_variant;
 }
 
 /*
- * Will transfer all metrics in the corresponding file into the out parameter
- * 'return_list'. The list will be NULL-terminated. Returns TRUE on success, and
- * FALSE if any I/O error occured. Contents of return_list are undefined if the
- * return value is FALSE.
- */
-static gboolean
-drain_metrics_file (EmerPersistentCache *self,
-                    GVariant          ***return_list,
-                    gchar               *path_ending,
-                    gchar               *variant_type)
-{
-  GError *error = NULL;
-  GFile *file = get_cache_file (self, path_ending);
-  GFileInputStream *file_stream = g_file_read (file, NULL, &error);
-
-  if (file_stream == NULL)
-    {
-      g_critical ("Failed to open input stream to drain metrics. Error: %s.",
-                   error->message);
-      g_error_free (error);
-      g_object_unref (file);
-      return FALSE;
-    }
-  GInputStream *stream = G_INPUT_STREAM (file_stream);
-
-  GArray *dynamic_array = g_array_new (TRUE, FALSE, sizeof (GVariant *));
-  g_array_set_clear_func (dynamic_array, (GDestroyNotify) g_variant_unref);
-
-  while (TRUE)
-    {
-      guint64 little_endian_length;
-      gsize length_bytes_read;
-      gboolean read_succeeded =
-        g_input_stream_read_all (stream,
-                                 &little_endian_length,
-                                 sizeof (little_endian_length),
-                                 &length_bytes_read,
-                                 NULL /* GCancellable */,
-                                 &error);
-      if (!read_succeeded)
-        {
-          g_critical ("Failed to read length of event in persistent cache. "
-                      "Error: %s.", error->message);
-          g_error_free (error);
-          goto handle_failed_read;
-        }
-
-      if (length_bytes_read == 0) // EOF
-        break;
-
-      if (length_bytes_read != sizeof (little_endian_length))
-        {
-          g_critical ("Read %" G_GSIZE_FORMAT " bytes, but expected length of "
-                      "event to be %" G_GSIZE_FORMAT " bytes.",
-                      length_bytes_read, sizeof (little_endian_length));
-          goto handle_failed_read;
-        }
-
-      guint64 variant_length =
-        swap_bytes_64_if_big_endian (little_endian_length);
-      gpointer variant_data = g_new (guchar, variant_length);
-      gsize data_bytes_read;
-      read_succeeded =
-        g_input_stream_read_all (stream, variant_data, variant_length,
-                                 &data_bytes_read, NULL /* GCancellable */,
-                                 &error);
-      if (!read_succeeded)
-        {
-          g_free (variant_data);
-          g_critical ("Failed to read event in persistent cache. Error: %s.",
-                      error->message);
-          g_error_free (error);
-          goto handle_failed_read;
-        }
-
-      if (data_bytes_read != variant_length)
-        {
-          g_free (variant_data);
-          g_critical ("Cache file ended earlier than expected. Read %"
-                      G_GSIZE_FORMAT " bytes, but expected %" G_GUINT64_FORMAT
-                      " bytes of event data.", data_bytes_read, variant_length);
-          goto handle_failed_read;
-        }
-
-      // Deserialize
-      GVariant *current_event =
-        g_variant_new_from_data (G_VARIANT_TYPE (variant_type), variant_data,
-                                 variant_length, FALSE /* trusted */, g_free,
-                                 variant_data);
-
-      GVariant *regularized_event = regularize_variant (current_event);
-      g_array_append_val (dynamic_array, regularized_event);
-    }
-
-  g_object_unref (stream);
-  g_object_unref (file);
-
-  *return_list = (GVariant **) g_array_free (dynamic_array, FALSE);
-
-  return TRUE;
-
-handle_failed_read:
-  g_object_unref (stream);
-  g_object_unref (file);
-  g_array_unref (dynamic_array);
-  return FALSE;
-}
-
-/*
- * Mutates the given out parameter GVariant pointer list to become a list of
- * GVariant pointers with the only element set to NULL. This is an empty,
- * NULL-terminated list.
- */
-static void
-set_to_empty_list (GVariant ***list)
-{
-  *list = g_new (GVariant *, 1);
-  (*list)[0] = NULL;
-}
-
-/*
- * Will transfer all metrics on disk into the three out parameters.
- * Each list is NULL-terminated. Will delete all metrics from disk immediately
- * afterward. Returns %TRUE on success. If any I/O operation fails, will return
- * %FALSE and the out parameters' contents will be undefined. max_num_bytes is
- * currently ignored. TODO: Actually use max_num_bytes to limit the amount of
- * metrics drained.
- */
-gboolean
-emer_persistent_cache_drain_metrics (EmerPersistentCache  *self,
-                                     GVariant           ***list_of_individual_metrics,
-                                     GVariant           ***list_of_aggregate_metrics,
-                                     GVariant           ***list_of_sequence_metrics,
-                                     gint                  max_num_bytes)
-{
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
-
-  if (priv->cache_size == 0)
-    {
-      set_to_empty_list (list_of_individual_metrics);
-      set_to_empty_list (list_of_aggregate_metrics);
-      set_to_empty_list (list_of_sequence_metrics);
-      return TRUE;
-    }
-
-  gboolean ind_success = drain_metrics_file (self,
-                                             list_of_individual_metrics,
-                                             INDIVIDUAL_SUFFIX,
-                                             INDIVIDUAL_TYPE);
-  if (!ind_success)
-    return FALSE;
-
-  gboolean agg_success = drain_metrics_file (self,
-                                             list_of_aggregate_metrics,
-                                             AGGREGATE_SUFFIX,
-                                             AGGREGATE_TYPE);
-  if (!agg_success)
-    {
-      free_variant_array (*list_of_individual_metrics);
-      return FALSE;
-    }
-
-  gboolean seq_success = drain_metrics_file (self,
-                                             list_of_sequence_metrics,
-                                             SEQUENCE_SUFFIX,
-                                             SEQUENCE_TYPE);
-  if (!seq_success)
-    {
-      free_variant_array (*list_of_individual_metrics);
-      free_variant_array (*list_of_aggregate_metrics);
-      return FALSE;
-    }
-
-  if (!purge_cache_files (self, NULL, NULL))
-    {
-      free_variant_array (*list_of_individual_metrics);
-      free_variant_array (*list_of_aggregate_metrics);
-      free_variant_array (*list_of_sequence_metrics);
-      return FALSE;
-    }
-
-  return TRUE;
-}
-
-/*
- * Will check if the cache can store 'size' additional bytes. Returns
- * %TRUE if it can, %FALSE otherwise.
- */
-static gboolean
-cache_has_room (EmerPersistentCache *self,
-                gsize                size)
-{
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
-
-  if (priv->capacity == CAPACITY_MAX)
-    return FALSE;
-
-  guint64 max_cache_size =
-    emer_cache_size_provider_get_max_cache_size (priv->cache_size_provider);
-  return priv->cache_size + size <= max_cache_size;
-}
-
-/*
- * Returns a hint (capacity_t) as to how filled up the cache is and
- * updates the internal value of capacity. If 'set_to_max' is TRUE, will update
- * to (and return) CAPACITY_MAX.
- */
-static capacity_t
-update_capacity (EmerPersistentCache *self,
-                 gboolean             set_to_max)
-{
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
-
-  if (set_to_max)
-    {
-      priv->capacity = CAPACITY_MAX;
-    }
-  else
-    {
-      guint64 max_cache_size =
-        emer_cache_size_provider_get_max_cache_size (priv->cache_size_provider);
-
-      if (priv->cache_size >= HIGH_CAPACITY_THRESHOLD * max_cache_size)
-        priv->capacity = CAPACITY_HIGH;
-      else
-        priv->capacity = CAPACITY_LOW;
-    }
-
-  return priv->capacity;
-}
-
-/*
- * Serializes the given variant little-endian with its length in bytes as a
- * little-endian guint64 prepended to it. Appends the entire serialized blob to
- * the end of the given byte array.
- *
- * If there is not enough room in the persistent cache to store the given byte
- * array with the given variant appended, the given byte array is not mutated,
- * and the function returns FALSE. Otherwise, it will mutate it as described and
- * return TRUE.
- */
-static gboolean
-append_variant (EmerPersistentCache *self,
-                GByteArray          *serialized_variants,
-                GVariant            *variant)
-{
-  guint64 variant_length = g_variant_get_size (variant);
-  gsize event_size_on_disk = sizeof (variant_length) + variant_length;
-  gsize byte_array_size_on_disk = serialized_variants->len + event_size_on_disk;
-  g_variant_ref_sink (variant);
-  if (cache_has_room (self, byte_array_size_on_disk))
-    {
-      guint64 little_endian_length =
-        swap_bytes_64_if_big_endian (variant_length);
-
-      GVariant *native_endian_variant = swap_bytes_if_big_endian (variant);
-      g_variant_unref (variant);
-
-      gconstpointer serialized_variant =
-        g_variant_get_data (native_endian_variant);
-
-      g_byte_array_append (serialized_variants,
-                           (const guint8 *) &little_endian_length,
-                           sizeof (little_endian_length));
-      g_byte_array_append (serialized_variants, serialized_variant,
-                           variant_length);
-
-      g_variant_unref (native_endian_variant);
-      return TRUE;
-    }
-
-  g_variant_unref (variant);
-  return FALSE;
-}
-
-/*
- * Appends the given byte array to the end of the given file. Updates the size
- * of the cache if the store was successful.
- *
- * Returns TRUE on success and FALSE on failure.
- */
-static gboolean
-write_byte_array (EmerPersistentCache *self,
-                  GFile               *file,
-                  GByteArray          *byte_array)
-{
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
-
-  GError *error = NULL;
-  GFileOutputStream *stream =
-    g_file_append_to (file, G_FILE_CREATE_NONE, NULL, &error);
-  if (stream == NULL)
-    {
-      g_critical ("Failed to open stream to cache file. Error: %s.",
-                  error->message);
-      g_error_free (error);
-      return FALSE;
-    }
-
-  gboolean success =
-    g_output_stream_write_all (G_OUTPUT_STREAM (stream), byte_array->data,
-                               byte_array->len, NULL, NULL, &error);
-  g_object_unref (stream);
-
-  if (!success)
-    {
-      g_critical ("Failed to write to cache file. Error: %s.", error->message);
-      g_error_free (error);
-      return FALSE;
-    }
-
-  priv->cache_size += byte_array->len;
-  return TRUE;
-}
-
-static GVariant *
-replace_payload_with_copy (EventValue *event_value)
-{
-  GVariant *auxiliary_payload = event_value->auxiliary_payload;
-  if (auxiliary_payload == NULL)
-    return NULL;
-
-  event_value->auxiliary_payload = deep_copy_variant (auxiliary_payload);
-  return auxiliary_payload;
-}
-
-static void
-consume_floating_ref (EventValue *event_value)
-{
-  GVariant *auxiliary_payload = event_value->auxiliary_payload;
-  if (auxiliary_payload == NULL)
-    return;
-
-  g_variant_ref_sink (auxiliary_payload);
-  g_variant_unref (auxiliary_payload);
-}
-
-static gboolean
-store_singulars (EmerPersistentCache *self,
-                 SingularEvent       *singular_buffer,
-                 gint                 num_singulars_buffered,
-                 gint                *num_singulars_stored,
-                 capacity_t          *capacity)
-{
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
-
-  GByteArray *serialized_variants = g_byte_array_new ();
-  gboolean will_fit = TRUE;
-  gint i;
-  for (i = 0; i < num_singulars_buffered; i++)
-    {
-      SingularEvent *curr_singular = singular_buffer + i;
-      EventValue *curr_event_value = &curr_singular->event_value;
-      GVariant *curr_payload = replace_payload_with_copy (curr_event_value);
-      GVariant *curr_singular_variant = singular_to_variant (curr_singular);
-      curr_event_value->auxiliary_payload = curr_payload;
-      will_fit =
-        append_variant (self, serialized_variants, curr_singular_variant);
-      if (!will_fit)
-        break;
-    }
-
-  gboolean write_successful = TRUE;
-  if (i > 0)
-    {
-      GFile *singulars_file = get_cache_file (self, INDIVIDUAL_SUFFIX);
-      write_successful =
-        write_byte_array (self, singulars_file, serialized_variants);
-      g_object_unref (singulars_file);
-    }
-
-  g_byte_array_unref (serialized_variants);
-
-  if (write_successful)
-    {
-      for (gint j = 0; j < i; j++)
-        {
-          SingularEvent *curr_singular = singular_buffer + j;
-          EventValue *curr_event_value = &curr_singular->event_value;
-          consume_floating_ref (curr_event_value);
-        }
-
-      *num_singulars_stored = i;
-      *capacity = update_capacity (self, !will_fit);
-    }
-  else
-    {
-      *num_singulars_stored = 0;
-      *capacity = priv->capacity;
-    }
-
-  return write_successful;
-}
-
-static gboolean
-store_aggregates (EmerPersistentCache *self,
-                  AggregateEvent      *aggregate_buffer,
-                  gint                 num_aggregates_buffered,
-                  gint                *num_aggregates_stored,
-                  capacity_t          *capacity)
-{
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
-
-  GByteArray *serialized_variants = g_byte_array_new ();
-  gboolean will_fit = TRUE;
-  gint i;
-  for (i = 0; i < num_aggregates_buffered; i++)
-    {
-      AggregateEvent *curr_aggregate = aggregate_buffer + i;
-      EventValue *curr_event_value = &curr_aggregate->event.event_value;
-      GVariant *curr_payload = replace_payload_with_copy (curr_event_value);
-      GVariant *curr_aggregate_variant = aggregate_to_variant (curr_aggregate);
-      curr_event_value->auxiliary_payload = curr_payload;
-      will_fit =
-        append_variant (self, serialized_variants, curr_aggregate_variant);
-      if (!will_fit)
-        break;
-    }
-
-  gboolean write_successful = TRUE;
-  if (i > 0)
-    {
-      GFile *aggregate_file = get_cache_file (self, AGGREGATE_SUFFIX);
-      write_successful =
-        write_byte_array (self, aggregate_file, serialized_variants);
-      g_object_unref (aggregate_file);
-    }
-
-  g_byte_array_unref (serialized_variants);
-
-  if (write_successful)
-    {
-      for (gint j = 0; j < i; j++)
-        {
-          AggregateEvent *curr_aggregate = aggregate_buffer + j;
-          EventValue *curr_event_value = &curr_aggregate->event.event_value;
-          consume_floating_ref (curr_event_value);
-        }
-
-      *num_aggregates_stored = i;
-      *capacity = update_capacity (self, !will_fit);
-    }
-  else
-    {
-      *num_aggregates_stored = 0;
-      *capacity = priv->capacity;
-    }
-
-  return write_successful;
-}
-
-static gboolean
-store_sequences (EmerPersistentCache *self,
-                 SequenceEvent       *sequence_buffer,
-                 gint                 num_sequences_buffered,
-                 gint                *num_sequences_stored,
-                 capacity_t          *capacity)
-{
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
-
-  GByteArray *serialized_variants = g_byte_array_new ();
-  gboolean will_fit = TRUE;
-  gint i;
-  for (i = 0; i < num_sequences_buffered; i++)
-    {
-      SequenceEvent *curr_sequence = sequence_buffer + i;
-
-      GVariant *curr_payloads[curr_sequence->num_event_values];
-      for (gint j = 0; j < curr_sequence->num_event_values; j++)
-        {
-          EventValue *curr_event_value = curr_sequence->event_values + j;
-          curr_payloads[j] = replace_payload_with_copy (curr_event_value);
-        }
-
-      GVariant *curr_sequence_variant = sequence_to_variant (curr_sequence);
-
-      for (gint j = 0; j < curr_sequence->num_event_values; j++)
-        {
-          EventValue *curr_event_value = curr_sequence->event_values + j;
-          curr_event_value->auxiliary_payload = curr_payloads[j];
-        }
-
-      will_fit =
-        append_variant (self, serialized_variants, curr_sequence_variant);
-      if (!will_fit)
-        break;
-    }
-
-  gboolean write_successful = TRUE;
-  if (i > 0)
-    {
-      GFile *sequences_file = get_cache_file (self, SEQUENCE_SUFFIX);
-      write_successful =
-        write_byte_array (self, sequences_file, serialized_variants);
-      g_object_unref (sequences_file);
-    }
-
-  g_byte_array_unref (serialized_variants);
-
-  if (write_successful)
-    {
-      for (gint j = 0; j < i; j++)
-        {
-          SequenceEvent *curr_sequence = sequence_buffer + j;
-          for (gint k = 0; k < curr_sequence->num_event_values; k++)
-            {
-              EventValue *curr_event_value = curr_sequence->event_values + k;
-              consume_floating_ref (curr_event_value);
-            }
-        }
-
-      *num_sequences_stored = i;
-      *capacity = update_capacity (self, !will_fit);
-    }
-  else
-    {
-      *num_sequences_stored = 0;
-      *capacity = priv->capacity;
-    }
-
-  return write_successful;
-}
-
-/*
- * Will persistently store all metrics passed to it if doing so would not exceed
- * the persistent cache's space quota.
- * Will return the capacity of the cache via the out parameter 'capacity'.
- * Returns %TRUE on success, even if the metrics are intentionally dropped due
- * to space limitations. Returns %FALSE only on I/O error.
- *
- * Regardless of success or failure, num_singulars_stored,
- * num_aggregates_stored, num_sequences_stored, and capacity will be correctly
- * set.
- *
- * This function assumes all events given to it have already had their
- * relative timestamps corrected.
- */
-gboolean
-emer_persistent_cache_store_metrics (EmerPersistentCache  *self,
-                                     SingularEvent        *singular_buffer,
-                                     AggregateEvent       *aggregate_buffer,
-                                     SequenceEvent        *sequence_buffer,
-                                     gint                  num_singulars_buffered,
-                                     gint                  num_aggregates_buffered,
-                                     gint                  num_sequences_buffered,
-                                     gint                 *num_singulars_stored,
-                                     gint                 *num_aggregates_stored,
-                                     gint                 *num_sequences_stored,
-                                     capacity_t           *capacity)
-{
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
-
-  /*
-   * Initialize the out parameters in case we return early. They may be updated
-   * by store_singulars, store_aggregates, and store_sequences below.
-   */
-  *capacity = priv->capacity;
-  *num_singulars_stored = 0;
-  *num_aggregates_stored = 0;
-  *num_sequences_stored = 0;
-
-  gboolean singulars_stored =
-    store_singulars (self, singular_buffer, num_singulars_buffered,
-                     num_singulars_stored, capacity);
-  if (!singulars_stored || *capacity == CAPACITY_MAX)
-    return singulars_stored;
-
-  gboolean aggregates_stored =
-    store_aggregates (self, aggregate_buffer, num_aggregates_buffered,
-                      num_aggregates_stored, capacity);
-  if (!aggregates_stored || *capacity == CAPACITY_MAX)
-    return aggregates_stored;
-
-  /*
-   * num_singulars_stored, num_aggregates_stored, num_sequences_stored, and
-   * capacity may be updated within store_singulars, store_aggregates, and
-   * store_sequences.
-   */
-  return store_sequences (self, sequence_buffer, num_sequences_buffered,
-                          num_sequences_stored, capacity);
-}
-
-/*
- * Sets the cache_size variable of self to the total size in bytes of the cache
- * files. Returns %TRUE on success.
- */
-static gboolean
-load_cache_size (EmerPersistentCache *self,
-                 GCancellable        *cancellable,
-                 GError             **error)
-{
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
-
-  GFile *singular_file = get_cache_file (self, INDIVIDUAL_SUFFIX);
-  guint64 singular_disk_used;
-  GError *local_error = NULL;
-  gboolean success = g_file_measure_disk_usage (singular_file,
-                                                G_FILE_MEASURE_REPORT_ANY_ERROR,
-                                                NULL,
-                                                NULL,
-                                                NULL,
-                                                &singular_disk_used,
-                                                NULL,
-                                                NULL,
-                                                &local_error);
-  g_object_unref (singular_file);
-  if (!success)
-    goto handle_failed_read;
-
-  guint64 aggregate_disk_used;
-  GFile *aggregate_file = get_cache_file (self, AGGREGATE_SUFFIX);
-  success = g_file_measure_disk_usage (aggregate_file,
-                                       G_FILE_MEASURE_REPORT_ANY_ERROR,
-                                       NULL,
-                                       NULL,
-                                       NULL,
-                                       &aggregate_disk_used,
-                                       NULL,
-                                       NULL,
-                                       &local_error);
-  g_object_unref (aggregate_file);
-  if (!success)
-    goto handle_failed_read;
-
-  guint64 sequence_disk_used;
-  GFile *sequence_file = get_cache_file (self, SEQUENCE_SUFFIX);
-  success = g_file_measure_disk_usage (sequence_file,
-                                       G_FILE_MEASURE_REPORT_ANY_ERROR,
-                                       NULL,
-                                       NULL,
-                                       NULL,
-                                       &sequence_disk_used,
-                                       NULL,
-                                       NULL,
-                                       &local_error);
-  g_object_unref (sequence_file);
-  if (!success)
-    goto handle_failed_read;
-
-  priv->cache_size =
-    singular_disk_used + aggregate_disk_used + sequence_disk_used;
-  update_capacity (self, FALSE);
-  return TRUE;
-
-handle_failed_read:
-  g_prefix_error (&local_error, "Failed to measure disk usage. ");
-  g_critical ("%s.", local_error->message);
-  g_propagate_error (error, local_error);
-  return FALSE;
-}
-
-/*
- * Attempts to remove all cached metrics if the cache version file is out of date
- * or not found. Updates the cache version file as specified by the cache
+ * Attempts to wipe the persistent cache if the cache version file is out of
+ * date or not found. Updates the cache version file as specified by the cache
  * provider if successful. Creates the cache directory if it doesn't exist.
  * Returns %TRUE on success and %FALSE on failure.
  */
 static gboolean
 apply_cache_versioning (EmerPersistentCache *self,
-                        GCancellable        *cancellable,
                         GError             **error)
 {
   EmerPersistentCachePrivate *priv =
@@ -1382,10 +612,8 @@ apply_cache_versioning (EmerPersistentCache *self,
   if (g_mkdir_with_parents (priv->cache_directory, 02774) != 0)
     {
       const gchar *err_str = g_strerror (errno);
-      g_critical ("Failed to create directory: %s. Error: %s.",
-                  priv->cache_directory, err_str);
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Failed to create directory: %s. Error: %s.",
+                   "Failed to create directory: %s. Error: %s",
                    priv->cache_directory, err_str);
       return FALSE;
     }
@@ -1397,25 +625,23 @@ apply_cache_versioning (EmerPersistentCache *self,
 
   if (!read_success || CURRENT_CACHE_VERSION != old_version)
     {
-      GError *local_error = NULL;
-      gboolean success = purge_cache_files (self, cancellable, &local_error);
-      if (!success)
+      if (old_version < 4)
+        unlink_old_files (self);
+
+      if (!emer_circular_file_purge (priv->variant_file, error))
         {
-          g_prefix_error (&local_error, "Will not update version number. ");
-          g_critical ("%s.", local_error->message);
-          g_propagate_error (error, local_error);
+          g_prefix_error (error, "Will not update version number. ");
           return FALSE;
         }
 
-      success =
+      gboolean set_succeeded =
         emer_cache_version_provider_set_version (priv->cache_version_provider,
                                                  CURRENT_CACHE_VERSION, error);
-      if (!success)
+      if (!set_succeeded)
         {
-          g_prefix_error (&local_error, "Failed to update cache version number "
-                          "to %i. ", CURRENT_CACHE_VERSION);
-          g_critical ("%s.", local_error->message);
-          g_propagate_error (error, local_error);
+          g_prefix_error (error,
+                          "Failed to update cache version number to %i. ",
+                          CURRENT_CACHE_VERSION);
           return FALSE;
         }
     }
@@ -1536,19 +762,27 @@ static void
 emer_persistent_cache_finalize (GObject *object)
 {
   EmerPersistentCache *self = EMER_PERSISTENT_CACHE (object);
-  update_boot_offset (self, TRUE);
-
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  g_source_remove (priv->boot_offset_update_timeout_source_id);
+  GError *error = NULL;
+  if (priv->variant_file != NULL && !update_boot_offset (self, TRUE, &error))
+    {
+      g_warning ("Failed to update boot offset when persistent cache was "
+                 "finalized. Error: %s", error->message);
+      g_error_free (error);
+    }
 
-  g_object_unref (priv->cache_size_provider);
-  g_object_unref (priv->boot_id_provider);
-  g_object_unref (priv->cache_version_provider);
-  g_free (priv->boot_metadata_file_path);
-  g_key_file_unref (priv->boot_offset_key_file);
-  g_free (priv->cache_directory);
+  g_clear_pointer (&priv->boot_offset_update_timeout_source_id,
+                   g_source_remove);
+
+  g_clear_object (&priv->cache_size_provider);
+  g_clear_object (&priv->boot_id_provider);
+  g_clear_object (&priv->cache_version_provider);
+  g_clear_object (&priv->variant_file);
+  g_clear_pointer (&priv->boot_metadata_file_path, g_free);
+  g_clear_pointer (&priv->boot_offset_key_file, g_key_file_unref);
+  g_clear_pointer (&priv->cache_directory, g_free);
 
   G_OBJECT_CLASS (emer_persistent_cache_parent_class)->finalize (object);
 }
@@ -1565,8 +799,8 @@ emer_persistent_cache_class_init (EmerPersistentCacheClass *klass)
   /* Blurb string is good enough default documentation for this. */
   emer_persistent_cache_props[PROP_CACHE_DIRECTORY] =
     g_param_spec_string ("cache-directory", "Cache directory",
-                         "The directory to save metrics and metadata in.",
-                         PERSISTENT_CACHE_DIR,
+                         "The directory to save data in.",
+                         NULL,
                          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   /* Blurb string is good enough default documentation for this. */
@@ -1613,8 +847,6 @@ emer_persistent_cache_init (EmerPersistentCache *self)
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  priv->cache_size = 0L;
-  priv->capacity = CAPACITY_LOW;
   priv->boot_offset_key_file = g_key_file_new ();
 }
 
@@ -1624,19 +856,30 @@ emer_persistent_cache_initable_init (GInitable    *self,
                                      GError      **error)
 {
   EmerPersistentCache *persistent_cache = EMER_PERSISTENT_CACHE (self);
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (persistent_cache);
 
-  if (!apply_cache_versioning (persistent_cache, cancellable, error))
+  gchar *variant_file_path =
+    g_build_filename (priv->cache_directory, VARIANT_FILENAME, NULL);
+  guint64 max_cache_size =
+    emer_cache_size_provider_get_max_cache_size (priv->cache_size_provider);
+  priv->variant_file =
+    emer_circular_file_new (variant_file_path, max_cache_size, error);
+  g_free (variant_file_path);
+  if (priv->variant_file == NULL)
     return FALSE;
 
-  if (!update_boot_offset (persistent_cache, FALSE))
-    {
-      g_critical ("Couldn't update the boot offset upon initialization.");
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Couldn't update the boot offset upon initialization.");
-      return FALSE;
-    }
+  if (!apply_cache_versioning (persistent_cache, error))
+    goto handle_failed_init;
 
-  return load_cache_size (persistent_cache, cancellable, error);
+  if (!update_boot_offset (persistent_cache, FALSE, error))
+    goto handle_failed_init;
+
+  return TRUE;
+
+handle_failed_init:
+  g_clear_object (&priv->variant_file);
+  return FALSE;
 }
 
 static void
@@ -1648,31 +891,230 @@ emer_persistent_cache_initable_iface_init (GInitableIface *iface)
 /* Returns a new persistent cache with the default configuration.
  */
 EmerPersistentCache *
-emer_persistent_cache_new (GCancellable *cancellable,
-                           GError      **error)
+emer_persistent_cache_new (const gchar *directory,
+                           GError     **error)
 {
-  return g_initable_new (EMER_TYPE_PERSISTENT_CACHE, cancellable, error, NULL);
+  return g_initable_new (EMER_TYPE_PERSISTENT_CACHE,
+                         NULL /* GCancellable */,
+                         error,
+                         "cache-directory", directory,
+                         NULL);
 }
 
 /* Returns a customized persistent cache. Use emer_persistent_cache_new to use
  * the default configuration.
  */
 EmerPersistentCache *
-emer_persistent_cache_new_full (GCancellable             *cancellable,
-                                GError                  **error,
-                                const gchar              *custom_directory,
+emer_persistent_cache_new_full (const gchar              *directory,
                                 EmerCacheSizeProvider    *cache_size_provider,
                                 EmerBootIdProvider       *boot_id_provider,
                                 EmerCacheVersionProvider *cache_version_provider,
-                                guint                     boot_offset_update_interval)
+                                guint                     boot_offset_update_interval,
+                                GError                  **error)
 {
   return g_initable_new (EMER_TYPE_PERSISTENT_CACHE,
-                         cancellable,
+                         NULL /* GCancellable */,
                          error,
-                         "cache-directory", custom_directory,
+                         "cache-directory", directory,
                          "cache-size-provider", cache_size_provider,
                          "boot-id-provider", boot_id_provider,
                          "cache-version-provider", cache_version_provider,
                          "boot-offset-update-interval", boot_offset_update_interval,
                          NULL);
+}
+
+/* Returns the cost of the given variant, which is the size of its serialized
+ * representation in the persistent cache. See emer_persistent_cache_read for
+ * more details.
+ */
+gsize
+emer_persistent_cache_cost (GVariant *variant)
+{
+  const GVariantType *variant_type = g_variant_get_type (variant);
+  gsize type_string_length =
+    g_variant_type_get_string_length (variant_type) + 1;
+  gsize variant_size = g_variant_get_size (variant);
+  return type_string_length + variant_size;
+}
+
+/* Gets the boot time offset and stores it in the out parameter offset.
+ * If the always_update_timestamps parameter is FALSE, does not write to disk
+ * solely to update the timestamps during this operation unless the boot id is
+ * out of date or some corruption is detected that prompts a total rewrite of
+ * the boot timing metadata file. Pass an offset of NULL if you don't care about
+ * its value.
+ *
+ * Returns TRUE on success. Returns FALSE on failure and sets the error unless
+ * it's NULL. Does not alter the offset out parameter on failure.
+ */
+gboolean
+emer_persistent_cache_get_boot_time_offset (EmerPersistentCache *self,
+                                            gint64              *offset,
+                                            GError             **error,
+                                            gboolean             always_update_timestamps)
+{
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
+  /* When always_update_timestamps is FALSE, the timestamps won't be written
+   * unless the boot offset in the metadata file is being overwritten.
+   */
+  gboolean update_succeeded =
+    update_boot_offset (self, always_update_timestamps, error);
+  if (!update_succeeded)
+    return FALSE;
+
+  if (offset != NULL)
+    *offset = priv->boot_offset;
+
+  return TRUE;
+}
+
+/* Persistently stores the given variants. Sets num_variants_stored to the
+ * number of variants that were actually stored. Returns TRUE on success even
+ * if all of the given variants don't fit in the space allocated to the
+ * persistent cache. Returns FALSE only on error.
+ */
+gboolean
+emer_persistent_cache_store (EmerPersistentCache *self,
+                             GVariant           **variants,
+                             gsize                num_variants,
+                             gsize               *num_variants_stored,
+                             GError             **error)
+{
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
+  gsize curr_variants_stored = 0;
+  for (; curr_variants_stored < num_variants; curr_variants_stored++)
+    {
+      GVariant *curr_variant = variants[curr_variants_stored];
+      GVariant *regularized_variant = regularize_pre_storage (curr_variant);
+
+      const gchar *type_string = g_variant_get_type_string (regularized_variant);
+      gsize type_length = strlen (type_string) + 1;
+      gconstpointer variant_data = g_variant_get_data (regularized_variant);
+      gsize variant_size = g_variant_get_size (regularized_variant);
+
+      gsize elem_size = type_length + variant_size;
+      guint8 elem[elem_size];
+      memcpy (elem, type_string, type_length);
+      memcpy (elem + type_length, variant_data, variant_size);
+      g_variant_unref (regularized_variant);
+      if (!emer_circular_file_append (priv->variant_file, elem, elem_size))
+        break;
+    }
+
+  if (!emer_circular_file_save (priv->variant_file, error))
+    return FALSE;
+
+  for (gsize i = 0; i < curr_variants_stored; i++)
+    {
+      g_variant_ref_sink (variants[i]);
+      g_variant_unref (variants[i]);
+    }
+
+  *num_variants_stored = curr_variants_stored;
+  return TRUE;
+}
+
+/* Populates variants with a C array of variants that cost no more than the
+ * given amount in total (as defined by emer_persistent_cache_cost). Variants
+ * are read in the same order in which they were stored; in other words, the
+ * persistent cache is FIFO. Sets token to an opaque value that may be passed to
+ * emer_persistent_cache_remove to remove the variants that were read in a
+ * particular call to emer_persistent_cache_read. Tokens may not be reused, and
+ * any successful call to emer_persistent_cache_remove invalidates any
+ * outstanding tokens. If no variants were read but the read succeeded, then
+ * variants is set to NULL. Returns TRUE on success and FALSE on error.
+ */
+gboolean
+emer_persistent_cache_read (EmerPersistentCache *self,
+                            GVariant          ***variants,
+                            gsize                cost,
+                            gsize               *num_variants,
+                            guint64             *token,
+                            GError             **error)
+{
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
+  GBytes **elems;
+  gsize num_elems;
+  guint64 local_token;
+  gboolean read_succeeded =
+    emer_circular_file_read (priv->variant_file, &elems, cost, &num_elems,
+                             &local_token, error);
+  if (!read_succeeded)
+    return FALSE;
+
+  GVariant **local_variants = g_new (GVariant *, num_elems);
+  for (gsize i = 0; i < num_elems; i++)
+    {
+      gsize elem_size;
+      const gchar *elem_data = g_bytes_get_data (elems[i], &elem_size);
+      if (elem_data == NULL)
+        g_error ("An element had size 0.");
+
+      const gchar *end_of_type = memchr (elem_data, '\0', elem_size);
+      if (end_of_type == NULL)
+        g_error ("An element did not contain a null byte indicating the end of "
+                 "a variant type string.");
+
+      if (!g_variant_type_string_is_valid (elem_data))
+        g_error ("An element did not begin with a valid variant type string.");
+
+      const GVariantType *variant_type = G_VARIANT_TYPE (elem_data);
+      const gchar *start_of_variant = end_of_type + 1;
+      gsize variant_size = (elem_data + elem_size) - start_of_variant;
+      gpointer variant_data = g_memdup (start_of_variant, variant_size);
+      GVariant *curr_variant =
+        g_variant_new_from_data (variant_type, variant_data, variant_size,
+                                 FALSE /* trusted */, g_free, variant_data);
+      g_bytes_unref (elems[i]);
+      local_variants[i] = regularize_post_storage (curr_variant);
+    }
+
+  g_free (elems);
+  *variants = local_variants;
+  *num_variants = num_elems;
+  *token = local_token;
+  return TRUE;
+}
+
+/* Returns TRUE if there would still be at least one variant remaining after a
+ * successful call to emer_persistent_cache_remove with this token. Returns
+ * FALSE if a successful call to emer_persistent_cache_remove with this token
+ * would result in all of the variants that are currently in the persistent
+ * cache being removed. Calling emer_persistent_cache_has_more does not
+ * invalidate this or any other token, but passing invalid tokens to
+ * emer_persistent_cache_has_more results in undefined behavior. A token value
+ * of 0 may be passed to ascertain whether the persistent cache is currently
+ * empty.
+ */
+gboolean
+emer_persistent_cache_has_more (EmerPersistentCache *self,
+                                guint64              token)
+{
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
+  return emer_circular_file_has_more (priv->variant_file, token);
+}
+
+/* Removes the variants that were read in the call to emer_persistent_cache_read
+ * that produced the given token. Tokens may not be reused, and any successful
+ * call to emer_persistent_cache_remove invalidates any outstanding tokens. A
+ * token value of 0 indicates that no variants should be removed. Returns TRUE
+ * on success and FALSE on error.
+ */
+gboolean
+emer_persistent_cache_remove (EmerPersistentCache *self,
+                              guint64              token,
+                              GError             **error)
+{
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
+  return emer_circular_file_remove (priv->variant_file, token, error);
 }

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -33,8 +33,7 @@
 
 #include "shared/metrics-util.h"
 
-/*
- * SECTION:emer-persistent-cache.c
+/* SECTION:emer-persistent-cache.c
  * @title: Persistent Cache
  * @short_description: Stores metrics locally (on the user's machine).
  *
@@ -112,7 +111,7 @@ G_DEFINE_TYPE_WITH_CODE (EmerPersistentCache, emer_persistent_cache, G_TYPE_OBJE
 #define DEFAULT_BOOT_TIMESTAMPS_UPDATE (60u * 60u)
 
 /*
- * The path to the file containing the boot-id used to determine if this is the
+ * The path to the file containing the boot ID used to determine if this is the
  * same boot as previous metrics were recorded in or not.
  */
 #define SYSTEM_BOOT_ID_FILE "/proc/sys/kernel/random/boot_id"
@@ -634,8 +633,7 @@ update_boot_offset_source_func (EmerPersistentCache *self)
   return G_SOURCE_CONTINUE;
 }
 
-/*
- * Gets the boot time offset and stores it in the out parameter offset.
+/* Gets the boot time offset and stores it in the out parameter offset.
  * If the always_update_timestamps parameter is FALSE, does not write to disk
  * solely to update the timestamps during this operation unless the boot id is
  * out of date or some corruption is detected that prompts a total rewrite of
@@ -655,8 +653,7 @@ emer_persistent_cache_get_boot_time_offset (EmerPersistentCache *self,
 
   G_LOCK (update_boot_offset);
 
-  /*
-   * When always_update_timestamps is FALSE, the timestamps won't be written
+  /* When always_update_timestamps is FALSE, the timestamps won't be written
    * unless the boot offset in the metadata file is being overwritten.
    */
   if (!update_boot_offset (self, always_update_timestamps))
@@ -1394,7 +1391,7 @@ apply_cache_versioning (EmerPersistentCache *self,
 
   if (g_mkdir_with_parents (priv->cache_directory, 02774) != 0)
     {
-      const gchar *err_str = g_strerror (errno); // Don't free.
+      const gchar *err_str = g_strerror (errno);
       g_critical ("Failed to create directory: %s. Error: %s.",
                   priv->cache_directory, err_str);
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
@@ -1661,9 +1658,7 @@ emer_persistent_cache_initable_init (GInitableIface *iface)
   iface->init = emer_persistent_cache_may_fail_init;
 }
 
-/*
- * Constructor for creating a new persistent cache.
- * Please use this in production instead of the testing constructor!
+/* Returns a new persistent cache with the default configuration.
  */
 EmerPersistentCache *
 emer_persistent_cache_new (GCancellable *cancellable,
@@ -1672,10 +1667,8 @@ emer_persistent_cache_new (GCancellable *cancellable,
   return g_initable_new (EMER_TYPE_PERSISTENT_CACHE, cancellable, error, NULL);
 }
 
-/*
- * You should use emer_persistent_cache_new() instead of this function.
- * Function should only be used in testing code, NOT in production code.
- * Should always use a custom directory.
+/* Returns a customized persistent cache. Use emer_persistent_cache_new to use
+ * the default configuration.
  */
 EmerPersistentCache *
 emer_persistent_cache_new_full (GCancellable             *cancellable,

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -22,12 +22,12 @@
 
 #include "emer-persistent-cache.h"
 
+#include <errno.h>
+
 #include <gio/gio.h>
 #include <glib.h>
 #include <glib/gprintf.h>
 #include <glib-object.h>
-
-#include <errno.h>
 
 #include <eosmetrics/eosmetrics.h>
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -565,8 +565,7 @@ update_boot_offset (EmerPersistentCache *self,
       g_warning ("Could not find a valid boot offset in the metadata file. "
                  "Error: %s.", error->message);
       g_error_free (error);
-      return reset_boot_offset_metadata_file (self, &relative_time,
-                                              &absolute_time);
+      return FALSE;
     }
 
   uuid_t saved_boot_id, system_boot_id;
@@ -614,8 +613,7 @@ update_boot_offset (EmerPersistentCache *self,
       g_warning ("Failed to write computed boot offset. Resetting cache. "
                  "Error: %s.", error->message);
       g_error_free (error);
-      return reset_boot_offset_metadata_file (self, &relative_time,
-                                              &absolute_time);
+      return FALSE;
     }
 
   priv->boot_offset = boot_offset;

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -213,8 +213,9 @@ get_cache_file (EmerPersistentCache *self,
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  gchar *path =
-    g_strconcat (priv->cache_directory, CACHE_PREFIX, path_ending, NULL);
+  gchar *filename = g_strconcat (CACHE_PREFIX, path_ending, NULL);
+  gchar *path = g_build_filename (priv->cache_directory, filename, NULL);
+  g_free (filename);
   GFile *file = g_file_new_for_path (path);
   g_free (path);
   return file;
@@ -1491,7 +1492,7 @@ emer_persistent_cache_constructed (GObject *object)
     emer_persistent_cache_get_instance_private (self);
 
   priv->boot_metadata_file_path =
-    g_strconcat (priv->cache_directory, BOOT_OFFSET_METADATA_FILE, NULL);
+    g_build_filename (priv->cache_directory, BOOT_OFFSET_METADATA_FILE, NULL);
 
   G_OBJECT_CLASS (emer_persistent_cache_parent_class)->constructed (object);
 }

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -75,11 +75,11 @@ typedef struct _EmerPersistentCachePrivate
   GKeyFile *boot_offset_key_file;
 } EmerPersistentCachePrivate;
 
-static void emer_persistent_cache_initable_init (GInitableIface *iface);
+static void emer_persistent_cache_initable_iface_init (GInitableIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (EmerPersistentCache, emer_persistent_cache, G_TYPE_OBJECT,
                          G_ADD_PRIVATE (EmerPersistentCache)
-                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, emer_persistent_cache_initable_init))
+                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, emer_persistent_cache_initable_iface_init))
 
 /*
  * If this version is greater than the version of the persisted metrics,
@@ -1629,7 +1629,7 @@ emer_persistent_cache_init (EmerPersistentCache *self)
 }
 
 static gboolean
-emer_persistent_cache_may_fail_init (GInitable    *self,
+emer_persistent_cache_initable_init (GInitable    *self,
                                      GCancellable *cancellable,
                                      GError      **error)
 {
@@ -1653,9 +1653,9 @@ emer_persistent_cache_may_fail_init (GInitable    *self,
 }
 
 static void
-emer_persistent_cache_initable_init (GInitableIface *iface)
+emer_persistent_cache_initable_iface_init (GInitableIface *iface)
 {
-  iface->init = emer_persistent_cache_may_fail_init;
+  iface->init = emer_persistent_cache_initable_init;
 }
 
 /* Returns a new persistent cache with the default configuration.

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -153,10 +153,9 @@ get_saved_boot_id (EmerPersistentCache *self,
       return TRUE;
     }
 
-  gchar *id_as_string = g_key_file_get_string (priv->boot_offset_key_file,
-                                               CACHE_TIMING_GROUP_NAME,
-                                               CACHE_LAST_BOOT_ID_KEY,
-                                               error);
+  gchar *id_as_string =
+    g_key_file_get_string (priv->boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
+                           CACHE_LAST_BOOT_ID_KEY, error);
   if (id_as_string == NULL)
     {
       g_prefix_error (error, "Failed to read boot ID from %s. ",
@@ -540,10 +539,11 @@ update_boot_offset (EmerPersistentCache *self,
       return TRUE;
     }
 
-  if (!g_key_file_load_from_file (priv->boot_offset_key_file,
-                                  priv->boot_metadata_file_path,
-                                  G_KEY_FILE_NONE,
-                                  &error))
+  gboolean load_succeeded =
+    g_key_file_load_from_file (priv->boot_offset_key_file,
+                               priv->boot_metadata_file_path, G_KEY_FILE_NONE,
+                               &error);
+  if (!load_succeeded)
     {
       if (!g_error_matches (error, G_KEY_FILE_ERROR,
                             G_KEY_FILE_ERROR_NOT_FOUND) &&
@@ -556,9 +556,9 @@ update_boot_offset (EmerPersistentCache *self,
                                               &absolute_time);
     }
 
-  gint64 boot_offset = g_key_file_get_int64 (priv->boot_offset_key_file,
-                                             CACHE_TIMING_GROUP_NAME,
-                                             CACHE_BOOT_OFFSET_KEY, &error);
+  gint64 boot_offset =
+    g_key_file_get_int64 (priv->boot_offset_key_file, CACHE_TIMING_GROUP_NAME,
+                          CACHE_BOOT_OFFSET_KEY, &error);
   if (error != NULL)
     {
       g_warning ("Failed to read boot offset from metadata file %s. "

--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -144,9 +144,6 @@ gboolean             emer_persistent_cache_store_metrics       (EmerPersistentCa
                                                                 gint                     *num_sequences_stored,
                                                                 capacity_t               *capacity);
 
-/*
- * Function should only be used in testing code, NOT in production code.
- */
 EmerPersistentCache *emer_persistent_cache_new_full            (GCancellable             *cancellable,
                                                                 GError                  **error,
                                                                 const gchar              *custom_directory,

--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -62,25 +62,6 @@ G_BEGIN_DECLS
 #define BOOT_OFFSET_METADATA_FILE "boot_offset_metafile"
 
 /*
- * The prefix for all metrics cache files.
- */
-#define CACHE_PREFIX "cache_"
-
-/*
- * The suffixes for each metric type's file.
- */
-#define INDIVIDUAL_SUFFIX "individual.metrics"
-#define AGGREGATE_SUFFIX  "aggregate.metrics"
-#define SEQUENCE_SUFFIX   "sequence.metrics"
-
-/*
- * GVariant Types for deserializing metrics.
- */
-#define INDIVIDUAL_TYPE "(uayxmv)"
-#define AGGREGATE_TYPE  "(uayxxmv)"
-#define SEQUENCE_TYPE   "(uaya(xmv))"
-
-/*
  * Constants for GKeyFile metadata.
  */
 #define CACHE_TIMING_GROUP_NAME   "time"
@@ -92,19 +73,6 @@ G_BEGIN_DECLS
 
 typedef struct _EmerPersistentCache EmerPersistentCache;
 typedef struct _EmerPersistentCacheClass EmerPersistentCacheClass;
-
-/*
- * CAPAICTY_LOW = No urgent need to write to network.
- * CAPACITY_HIGH = Should write to network when possible. Occupancy is beyond a threshold.
- * CAPACITY_MAX = Should write to network when possible. Occupancy is at or
- *                near 100% and metrics are being ignored!
- */
-typedef enum
-{
-  CAPACITY_LOW,
-  CAPACITY_HIGH,
-  CAPACITY_MAX
-} capacity_t;
 
 struct _EmerPersistentCache
 {
@@ -118,39 +86,42 @@ struct _EmerPersistentCacheClass
 
 GType                emer_persistent_cache_get_type             (void) G_GNUC_CONST;
 
+EmerPersistentCache *emer_persistent_cache_new                  (const gchar              *directory,
+                                                                 GError                  **error);
+
+gsize                emer_persistent_cache_cost                 (GVariant                 *self);
+
 gboolean             emer_persistent_cache_get_boot_time_offset (EmerPersistentCache      *self,
                                                                  gint64                   *offset,
                                                                  GError                  **error,
                                                                  gboolean                  always_update_timestamps);
 
-EmerPersistentCache *emer_persistent_cache_new                  (GCancellable             *cancellable,
+gboolean             emer_persistent_cache_store                (EmerPersistentCache      *self,
+                                                                 GVariant                **variants,
+                                                                 gsize                     num_variants,
+                                                                 gsize                    *num_variants_stored,
                                                                  GError                  **error);
 
-gboolean             emer_persistent_cache_drain_metrics        (EmerPersistentCache      *self,
-                                                                 GVariant               ***list_of_individual_metrics,
-                                                                 GVariant               ***list_of_aggregate_metrics,
-                                                                 GVariant               ***list_of_sequence_metrics,
-                                                                 gint                      max_num_bytes);
+gboolean             emer_persistent_cache_read                 (EmerPersistentCache      *self,
+                                                                 GVariant               ***variants,
+                                                                 gsize                     cost,
+                                                                 gsize                    *num_variants,
+                                                                 guint64                  *token,
+                                                                 GError                  **error);
 
-gboolean             emer_persistent_cache_store_metrics        (EmerPersistentCache      *self,
-                                                                 SingularEvent            *singular_buffer,
-                                                                 AggregateEvent           *aggregate_buffer,
-                                                                 SequenceEvent            *sequence_buffer,
-                                                                 gint                      num_singulars_buffered,
-                                                                 gint                      num_aggregates_buffered,
-                                                                 gint                      num_sequences_buffered,
-                                                                 gint                     *num_singulars_stored,
-                                                                 gint                     *num_aggregates_stored,
-                                                                 gint                     *num_sequences_stored,
-                                                                 capacity_t               *capacity);
+gboolean             emer_persistent_cache_has_more             (EmerPersistentCache      *self,
+                                                                 guint64                   token);
 
-EmerPersistentCache *emer_persistent_cache_new_full             (GCancellable             *cancellable,
-                                                                 GError                  **error,
-                                                                 const gchar              *custom_directory,
+gboolean             emer_persistent_cache_remove               (EmerPersistentCache      *self,
+                                                                 guint64                   token,
+                                                                 GError                  **error);
+
+EmerPersistentCache *emer_persistent_cache_new_full             (const gchar              *directory,
                                                                  EmerCacheSizeProvider    *cache_size_provider,
                                                                  EmerBootIdProvider       *boot_id_provider,
                                                                  EmerCacheVersionProvider *version_provider,
-                                                                 guint                     boot_offset_update_interval);
+                                                                 guint                     boot_offset_update_interval,
+                                                                 GError                  **error);
 
 G_END_DECLS
 

--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -93,8 +93,8 @@ gsize                emer_persistent_cache_cost                 (GVariant       
 
 gboolean             emer_persistent_cache_get_boot_time_offset (EmerPersistentCache      *self,
                                                                  gint64                   *offset,
-                                                                 GError                  **error,
-                                                                 gboolean                  always_update_timestamps);
+                                                                 gboolean                  always_update_timestamps,
+                                                                 GError                  **error);
 
 gboolean             emer_persistent_cache_store                (EmerPersistentCache      *self,
                                                                  GVariant                **variants,

--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -143,6 +143,7 @@ gboolean             emer_persistent_cache_store_metrics       (EmerPersistentCa
                                                                 gint                     *num_aggregates_stored,
                                                                 gint                     *num_sequences_stored,
                                                                 capacity_t               *capacity);
+
 /*
  * Function should only be used in testing code, NOT in production code.
  */

--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -116,41 +116,41 @@ struct _EmerPersistentCacheClass
   GObjectClass parent_class;
 };
 
-GType               emer_persistent_cache_get_type             (void) G_GNUC_CONST;
+GType                emer_persistent_cache_get_type             (void) G_GNUC_CONST;
 
-gboolean            emer_persistent_cache_get_boot_time_offset (EmerPersistentCache      *self,
-                                                                gint64                   *offset,
-                                                                GError                  **error,
-                                                                gboolean                  always_update_timestamps);
+gboolean             emer_persistent_cache_get_boot_time_offset (EmerPersistentCache      *self,
+                                                                 gint64                   *offset,
+                                                                 GError                  **error,
+                                                                 gboolean                  always_update_timestamps);
 
-EmerPersistentCache *emer_persistent_cache_new                 (GCancellable             *cancellable,
-                                                                GError                  **error);
+EmerPersistentCache *emer_persistent_cache_new                  (GCancellable             *cancellable,
+                                                                 GError                  **error);
 
-gboolean             emer_persistent_cache_drain_metrics       (EmerPersistentCache      *self,
-                                                                GVariant               ***list_of_individual_metrics,
-                                                                GVariant               ***list_of_aggregate_metrics,
-                                                                GVariant               ***list_of_sequence_metrics,
-                                                                gint                      max_num_bytes);
+gboolean             emer_persistent_cache_drain_metrics        (EmerPersistentCache      *self,
+                                                                 GVariant               ***list_of_individual_metrics,
+                                                                 GVariant               ***list_of_aggregate_metrics,
+                                                                 GVariant               ***list_of_sequence_metrics,
+                                                                 gint                      max_num_bytes);
 
-gboolean             emer_persistent_cache_store_metrics       (EmerPersistentCache      *self,
-                                                                SingularEvent            *singular_buffer,
-                                                                AggregateEvent           *aggregate_buffer,
-                                                                SequenceEvent            *sequence_buffer,
-                                                                gint                      num_singulars_buffered,
-                                                                gint                      num_aggregates_buffered,
-                                                                gint                      num_sequences_buffered,
-                                                                gint                     *num_singulars_stored,
-                                                                gint                     *num_aggregates_stored,
-                                                                gint                     *num_sequences_stored,
-                                                                capacity_t               *capacity);
+gboolean             emer_persistent_cache_store_metrics        (EmerPersistentCache      *self,
+                                                                 SingularEvent            *singular_buffer,
+                                                                 AggregateEvent           *aggregate_buffer,
+                                                                 SequenceEvent            *sequence_buffer,
+                                                                 gint                      num_singulars_buffered,
+                                                                 gint                      num_aggregates_buffered,
+                                                                 gint                      num_sequences_buffered,
+                                                                 gint                     *num_singulars_stored,
+                                                                 gint                     *num_aggregates_stored,
+                                                                 gint                     *num_sequences_stored,
+                                                                 capacity_t               *capacity);
 
-EmerPersistentCache *emer_persistent_cache_new_full            (GCancellable             *cancellable,
-                                                                GError                  **error,
-                                                                const gchar              *custom_directory,
-                                                                EmerCacheSizeProvider    *cache_size_provider,
-                                                                EmerBootIdProvider       *boot_id_provider,
-                                                                EmerCacheVersionProvider *version_provider,
-                                                                guint                     boot_offset_update_interval);
+EmerPersistentCache *emer_persistent_cache_new_full             (GCancellable             *cancellable,
+                                                                 GError                  **error,
+                                                                 const gchar              *custom_directory,
+                                                                 EmerCacheSizeProvider    *cache_size_provider,
+                                                                 EmerBootIdProvider       *boot_id_provider,
+                                                                 EmerCacheVersionProvider *version_provider,
+                                                                 guint                     boot_offset_update_interval);
 
 G_END_DECLS
 

--- a/data/cache-size.conf
+++ b/data/cache-size.conf
@@ -1,2 +1,2 @@
 [persistent_cache_size]
-maximum=92160
+maximum=10000000

--- a/shared/metrics-util.c
+++ b/shared/metrics-util.c
@@ -23,11 +23,9 @@
 #include "metrics-util.h"
 
 #include <byteswap.h>
-#include <errno.h>
 #include <uuid/uuid.h>
 
 #include <glib.h>
-#include <gio/gio.h>
 
 static void
 trash_event_value (EventValue *event_value)

--- a/shared/metrics-util.c
+++ b/shared/metrics-util.c
@@ -27,120 +27,6 @@
 
 #include <glib.h>
 
-static void
-trash_event_value (EventValue *event_value)
-{
-  GVariant *auxiliary_payload = event_value->auxiliary_payload;
-  if (auxiliary_payload != NULL)
-    g_variant_unref (auxiliary_payload);
-}
-
-void
-trash_singular_event (SingularEvent *singular)
-{
-  EventValue *event_value = &singular->event_value;
-  trash_event_value (event_value);
-}
-
-void
-trash_aggregate_event (AggregateEvent *aggregate)
-{
-  SingularEvent *event = &aggregate->event;
-  trash_singular_event (event);
-}
-
-void
-trash_sequence_event (SequenceEvent *sequence)
-{
-  for (gint i = 0; i < sequence->num_event_values; ++i)
-    trash_event_value (sequence->event_values + i);
-
-  g_free (sequence->event_values);
-}
-
-void
-free_singular_buffer (SingularEvent *singular_buffer,
-                      gint           num_singulars_buffered)
-{
-  for (gint i = 0; i < num_singulars_buffered; i++)
-    trash_singular_event (singular_buffer + i);
-
-  g_free (singular_buffer);
-}
-
-void
-free_aggregate_buffer (AggregateEvent *aggregate_buffer,
-                       gint            num_aggregates_buffered)
-{
-  for (gint i = 0; i < num_aggregates_buffered; i++)
-    trash_aggregate_event (aggregate_buffer + i);
-
-  g_free (aggregate_buffer);
-}
-
-void
-free_sequence_buffer (SequenceEvent *sequence_buffer,
-                      gint           num_sequences_buffered)
-{
-  for (gint i = 0; i < num_sequences_buffered; i++)
-    trash_sequence_event (sequence_buffer + i);
-
-  g_free (sequence_buffer);
-}
-
-void
-free_variant_array (GVariant **variant_array)
-{
-  for (gint i = 0; variant_array[i] != NULL; i++)
-    g_variant_unref (variant_array[i]);
-
-  g_free (variant_array);
-}
-
-GVariant *
-singular_to_variant (SingularEvent *singular)
-{
-  GVariantBuilder event_id_builder;
-  get_uuid_builder (singular->event_id, &event_id_builder);
-  EventValue event_value = singular->event_value;
-  return g_variant_new ("(uayxmv)", singular->user_id, &event_id_builder,
-                        event_value.relative_timestamp,
-                        event_value.auxiliary_payload);
-}
-
-GVariant *
-aggregate_to_variant (AggregateEvent *aggregate)
-{
-  SingularEvent event = aggregate->event;
-  GVariantBuilder event_id_builder;
-  get_uuid_builder (event.event_id, &event_id_builder);
-  EventValue event_value = event.event_value;
-  return g_variant_new ("(uayxxmv)", event.user_id, &event_id_builder,
-                        aggregate->num_events, event_value.relative_timestamp,
-                        event_value.auxiliary_payload);
-}
-
-GVariant *
-sequence_to_variant (SequenceEvent *sequence)
-{
-  GVariantBuilder event_values_builder;
-  g_variant_builder_init (&event_values_builder, G_VARIANT_TYPE ("a(xmv)"));
-  for (gint i = 0; i < sequence->num_event_values; i++)
-    {
-      EventValue event_value = sequence->event_values[i];
-      g_variant_builder_add (&event_values_builder, "(xmv)",
-                             event_value.relative_timestamp,
-                             event_value.auxiliary_payload);
-    }
-
-  GVariantBuilder event_id_builder;
-  get_uuid_builder (sequence->event_id, &event_id_builder);
-
-  return g_variant_new ("(uaya(xmv))", sequence->user_id, &event_id_builder,
-                        &event_values_builder);
-
-}
-
 guint64
 swap_bytes_64_if_big_endian (guint64 value)
 {
@@ -184,4 +70,25 @@ get_uuid_builder (uuid_t           uuid,
   g_variant_builder_init (uuid_builder, G_VARIANT_TYPE_BYTESTRING);
   for (size_t i = 0; i < UUID_LENGTH; ++i)
     g_variant_builder_add (uuid_builder, "y", uuid[i]);
+}
+
+GVariant *
+deep_copy_variant (GVariant *variant)
+{
+  GBytes *bytes = g_variant_get_data_as_bytes (variant);
+  const GVariantType *variant_type = g_variant_get_type (variant);
+  gboolean trusted = g_variant_is_normal_form (variant);
+  GVariant *copy = g_variant_new_from_bytes (variant_type, bytes, trusted);
+  g_bytes_unref (bytes);
+  return copy;
+}
+
+void
+destroy_variants (GVariant **variants,
+                  gsize      num_variants)
+{
+  for (gsize i = 0; i < num_variants; i++)
+    g_variant_unref (variants[i]);
+
+  g_free (variants);
 }

--- a/shared/metrics-util.h
+++ b/shared/metrics-util.h
@@ -70,35 +70,35 @@ typedef struct SequenceEvent
   gsize num_event_values;
 } SequenceEvent;
 
-void      trash_singular_event         (SingularEvent   *singular);
+void      trash_singular_event        (SingularEvent   *singular);
 
-void      trash_aggregate_event        (AggregateEvent  *aggregate);
+void      trash_aggregate_event       (AggregateEvent  *aggregate);
 
-void      trash_sequence_event         (SequenceEvent   *sequence);
+void      trash_sequence_event        (SequenceEvent   *sequence);
 
-void      free_singular_buffer         (SingularEvent   *singular_buffer,
-                                        gint             num_singulars_buffered);
+void      free_singular_buffer        (SingularEvent   *singular_buffer,
+                                       gint             num_singulars_buffered);
 
-void      free_aggregate_buffer        (AggregateEvent  *aggregate_buffer,
-                                        gint             num_aggregates_buffered);
+void      free_aggregate_buffer       (AggregateEvent  *aggregate_buffer,
+                                       gint             num_aggregates_buffered);
 
-void      free_sequence_buffer         (SequenceEvent   *sequence_buffer,
-                                        gint             num_sequences_buffered);
+void      free_sequence_buffer        (SequenceEvent   *sequence_buffer,
+                                       gint             num_sequences_buffered);
 
-void      free_variant_array           (GVariant       **variant_array);
+void      free_variant_array          (GVariant       **variant_array);
 
-GVariant *singular_to_variant          (SingularEvent   *singular);
+GVariant *singular_to_variant         (SingularEvent   *singular);
 
-GVariant *aggregate_to_variant         (AggregateEvent  *aggregate);
+GVariant *aggregate_to_variant        (AggregateEvent  *aggregate);
 
-GVariant *sequence_to_variant          (SequenceEvent   *sequence);
+GVariant *sequence_to_variant         (SequenceEvent   *sequence);
 
-guint64    swap_bytes_64_if_big_endian (guint64          value);
+guint64   swap_bytes_64_if_big_endian (guint64          value);
 
-GVariant *swap_bytes_if_big_endian     (GVariant        *variant);
+GVariant *swap_bytes_if_big_endian    (GVariant        *variant);
 
-void      get_uuid_builder             (uuid_t           uuid,
-                                        GVariantBuilder *uuid_builder);
+void      get_uuid_builder            (uuid_t           uuid,
+                                       GVariantBuilder *uuid_builder);
 
 G_END_DECLS
 

--- a/shared/metrics-util.h
+++ b/shared/metrics-util.h
@@ -34,71 +34,17 @@
 
 G_BEGIN_DECLS
 
-typedef struct EventValue
-{
-  // Time elapsed in nanoseconds from an unspecified starting point.
-  gint64 relative_timestamp;
-
-  GVariant *auxiliary_payload;
-} EventValue;
-
-typedef struct SingularEvent
-{
-  guint32 user_id;
-  uuid_t event_id;
-  EventValue event_value;
-} SingularEvent;
-
-typedef struct AggregateEvent
-{
-  SingularEvent event;
-  gint64 num_events;
-} AggregateEvent;
-
-typedef struct SequenceEvent
-{
-  guint32 user_id;
-  uuid_t event_id;
-
-  /*
-   * The first element is the start event, the last element is the stop event,
-   * and any elements in between are progress events. The elements are ordered
-   * chronologically.
-   */
-  EventValue *event_values;
-
-  gsize num_event_values;
-} SequenceEvent;
-
-void      trash_singular_event        (SingularEvent   *singular);
-
-void      trash_aggregate_event       (AggregateEvent  *aggregate);
-
-void      trash_sequence_event        (SequenceEvent   *sequence);
-
-void      free_singular_buffer        (SingularEvent   *singular_buffer,
-                                       gint             num_singulars_buffered);
-
-void      free_aggregate_buffer       (AggregateEvent  *aggregate_buffer,
-                                       gint             num_aggregates_buffered);
-
-void      free_sequence_buffer        (SequenceEvent   *sequence_buffer,
-                                       gint             num_sequences_buffered);
-
-void      free_variant_array          (GVariant       **variant_array);
-
-GVariant *singular_to_variant         (SingularEvent   *singular);
-
-GVariant *aggregate_to_variant        (AggregateEvent  *aggregate);
-
-GVariant *sequence_to_variant         (SequenceEvent   *sequence);
-
 guint64   swap_bytes_64_if_big_endian (guint64          value);
 
 GVariant *swap_bytes_if_big_endian    (GVariant        *variant);
 
 void      get_uuid_builder            (uuid_t           uuid,
                                        GVariantBuilder *uuid_builder);
+
+GVariant *deep_copy_variant           (GVariant        *variant);
+
+void      destroy_variants            (GVariant       **variants,
+                                       gsize            num_variants);
 
 G_END_DECLS
 

--- a/shared/metrics-util.h
+++ b/shared/metrics-util.h
@@ -24,7 +24,6 @@
 #define METRICS_UTIL_H
 
 #include <glib.h>
-#include <gio/gio.h>
 #include <uuid/uuid.h>
 
 /*

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -20,6 +20,7 @@ noinst_PROGRAMS += \
 	tests/daemon/test-boot-id-provider \
 	tests/daemon/test-cache-size-provider \
 	tests/daemon/test-cache-version-provider \
+	tests/daemon/test-circular-file \
 	tests/daemon/test-daemon.dbusdaemon \
 	tests/daemon/test-machine-id-provider \
 	tests/daemon/test-network-send-provider \
@@ -58,6 +59,14 @@ tests_daemon_test_cache_version_provider_SOURCES = \
 	$(NULL)
 tests_daemon_test_cache_version_provider_CPPFLAGS = $(DAEMON_TEST_FLAGS)
 tests_daemon_test_cache_version_provider_LDADD = $(DAEMON_TEST_LIBS)
+
+tests_daemon_test_circular_file_SOURCES = \
+	tests/daemon/test-circular-file.c \
+	daemon/emer-circular-file.c daemon/emer-circular-file.h \
+	shared/metrics-util.c shared/metrics-util.h \
+	$(NULL)
+tests_daemon_test_circular_file_CPPFLAGS = $(DAEMON_TEST_FLAGS)
+tests_daemon_test_circular_file_LDADD = $(DAEMON_TEST_LIBS)
 
 tests_daemon_test_daemon_dbusdaemon_SOURCES = \
 	daemon/emer-daemon.c daemon/emer-daemon.h \
@@ -104,6 +113,7 @@ tests_daemon_test_persistent_cache_SOURCES = \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
 	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
 	daemon/emer-cache-version-provider.c daemon/emer-cache-version-provider.h \
+	tests/daemon/mock-circular-file.c daemon/emer-circular-file.h \
 	shared/metrics-util.c shared/metrics-util.h \
 	$(NULL)
 tests_daemon_test_persistent_cache_CPPFLAGS = $(DAEMON_TEST_FLAGS)
@@ -120,6 +130,7 @@ TESTS = \
 	tests/daemon/test-boot-id-provider \
 	tests/daemon/test-cache-size-provider \
 	tests/daemon/test-cache-version-provider \
+	tests/daemon/test-circular-file \
 	tests/daemon/test-daemon.dbusdaemon \
 	tests/daemon/test-machine-id-provider \
 	tests/daemon/test-network-send-provider \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -38,6 +38,13 @@ DAEMON_TEST_FLAGS = \
 	$(NULL)
 DAEMON_TEST_LIBS = @EOS_EVENT_RECORDER_DAEMON_LIBS@
 
+tests_daemon_test_boot_id_provider_SOURCES = \
+	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
+	tests/daemon/test-boot-id-provider.c \
+	$(NULL)
+tests_daemon_test_boot_id_provider_CPPFLAGS = $(DAEMON_TEST_FLAGS)
+tests_daemon_test_boot_id_provider_LDADD = $(DAEMON_TEST_LIBS)
+
 tests_daemon_test_cache_size_provider_SOURCES = \
 	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
 	tests/daemon/test-cache-size-provider.c \
@@ -51,13 +58,6 @@ tests_daemon_test_cache_version_provider_SOURCES = \
 	$(NULL)
 tests_daemon_test_cache_version_provider_CPPFLAGS = $(DAEMON_TEST_FLAGS)
 tests_daemon_test_cache_version_provider_LDADD = $(DAEMON_TEST_LIBS)
-
-tests_daemon_test_boot_id_provider_SOURCES = \
-	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
-	tests/daemon/test-boot-id-provider.c \
-	$(NULL)
-tests_daemon_test_boot_id_provider_CPPFLAGS = $(DAEMON_TEST_FLAGS)
-tests_daemon_test_boot_id_provider_LDADD = $(DAEMON_TEST_LIBS)
 
 tests_daemon_test_daemon_dbusdaemon_SOURCES = \
 	daemon/emer-daemon.c daemon/emer-daemon.h \

--- a/tests/daemon/mock-circular-file.c
+++ b/tests/daemon/mock-circular-file.c
@@ -1,0 +1,229 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2015 Endless Mobile, Inc. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "emer-circular-file.h"
+
+#include <string.h>
+
+#include <glib.h>
+
+typedef struct _EmerCircularFilePrivate
+{
+  guint8 *buffer;
+  gsize max_size;
+  gsize saved_size;
+  gsize unsaved_size;
+} EmerCircularFilePrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (EmerCircularFile, emer_circular_file,
+                            G_TYPE_OBJECT);
+
+enum
+{
+  PROP_0,
+  PROP_MAX_SIZE,
+  NPROPS
+};
+
+static GParamSpec *emer_circular_file_props[NPROPS] = { NULL, };
+
+static void
+set_max_size (EmerCircularFile *self,
+              guint64           max_size)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  priv->buffer = g_new (guint8, max_size);
+  priv->max_size = max_size;
+}
+
+static void
+emer_circular_file_set_property (GObject      *object,
+                                 guint         property_id,
+                                 const GValue *value,
+                                 GParamSpec   *pspec)
+{
+  EmerCircularFile *self = EMER_CIRCULAR_FILE (object);
+
+  switch (property_id)
+    {
+    case PROP_MAX_SIZE:
+      set_max_size (self, g_value_get_uint64 (value));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    }
+}
+
+static void
+emer_circular_file_init (EmerCircularFile *self)
+{
+  /* Nothing to do */
+}
+
+static void
+emer_circular_file_finalize (GObject *object)
+{
+  EmerCircularFile *self = EMER_CIRCULAR_FILE (object);
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  g_free (priv->buffer);
+
+  G_OBJECT_CLASS (emer_circular_file_parent_class)->finalize (object);
+}
+
+static void
+emer_circular_file_class_init (EmerCircularFileClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = emer_circular_file_set_property;
+  object_class->finalize = emer_circular_file_finalize;
+
+  emer_circular_file_props[PROP_MAX_SIZE] =
+    g_param_spec_uint64 ("max-size", "Max size",
+                         "The maximum number of bytes that may be stored.",
+                         0, G_MAXUINT, 0,
+                         G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE |
+                         G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class, NPROPS,
+                                     emer_circular_file_props);
+}
+
+EmerCircularFile *
+emer_circular_file_new (const gchar *path,
+                        guint64      max_size,
+                        GError     **error)
+{
+  return g_object_new (EMER_TYPE_CIRCULAR_FILE,
+                       "max-size", max_size,
+                       NULL);
+}
+
+gboolean
+emer_circular_file_append (EmerCircularFile *self,
+                           gconstpointer     elem,
+                           guint64           elem_size)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  gsize new_unsaved_size = priv->unsaved_size + sizeof (elem_size) + elem_size;
+  if (priv->saved_size + new_unsaved_size > priv->max_size)
+    return FALSE;
+
+  guint8 *tail = priv->buffer + priv->saved_size + priv->unsaved_size;
+  memcpy (tail, &elem_size, sizeof (elem_size));
+  memcpy (tail + sizeof (elem_size), elem, elem_size);
+  priv->unsaved_size = new_unsaved_size;
+  return TRUE;
+}
+
+gboolean
+emer_circular_file_save (EmerCircularFile *self,
+                         GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  priv->saved_size += priv->unsaved_size;
+  priv->unsaved_size = 0;
+  return TRUE;
+}
+
+gboolean
+emer_circular_file_read (EmerCircularFile *self,
+                         GBytes         ***elems,
+                         gsize             num_bytes,
+                         gsize            *num_elems,
+                         guint64          *token,
+                         GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  GPtrArray *elem_array = g_ptr_array_new ();
+  gsize curr_elem_bytes = 0;
+  guint64 curr_buffer_bytes = 0;
+  while (curr_buffer_bytes < priv->saved_size)
+    {
+      guint64 elem_size = *(guint64 *) (priv->buffer + curr_buffer_bytes);
+      gsize new_elem_bytes = curr_elem_bytes + elem_size;
+      if (new_elem_bytes > num_bytes)
+        break;
+
+      curr_elem_bytes = new_elem_bytes;
+
+      /* sizeof (elem_size) gives the number of bytes used to record the
+       * element's length.
+       */
+      curr_buffer_bytes += sizeof (elem_size);
+
+      GBytes *elem = g_bytes_new (priv->buffer + curr_buffer_bytes, elem_size);
+      curr_buffer_bytes += elem_size;
+      g_ptr_array_add (elem_array, elem);
+    }
+
+  *num_elems = elem_array->len;
+  *elems = (GBytes **) g_ptr_array_free (elem_array, FALSE);
+  *token = curr_buffer_bytes;
+  return TRUE;
+}
+
+gboolean
+emer_circular_file_has_more (EmerCircularFile *self,
+                             guint64           token)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  return token < priv->saved_size;
+}
+
+gboolean
+emer_circular_file_remove (EmerCircularFile *self,
+                           guint64           token,
+                           GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  priv->saved_size -= token;
+  gsize bytes_remaining = priv->saved_size + priv->unsaved_size;
+  memmove (priv->buffer, priv->buffer + token, bytes_remaining);
+  return TRUE;
+}
+
+gboolean
+emer_circular_file_purge (EmerCircularFile *self,
+                          GError          **error)
+{
+  EmerCircularFilePrivate *priv =
+    emer_circular_file_get_instance_private (self);
+
+  priv->saved_size = 0;
+  return TRUE;
+}

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -28,11 +28,8 @@
 
 typedef struct _EmerPersistentCachePrivate
 {
-  GArray *singular_buffer;
-  GArray *aggregate_buffer;
-  GArray *sequence_buffer;
+  GPtrArray *variant_array;
   gint num_timestamp_updates;
-  gint store_metrics_called;
 } EmerPersistentCachePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (EmerPersistentCache, emer_persistent_cache,
@@ -44,17 +41,8 @@ emer_persistent_cache_init (EmerPersistentCache *self)
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  priv->singular_buffer = g_array_new (TRUE, FALSE, sizeof (GVariant *));
-  g_array_set_clear_func (priv->singular_buffer,
-                          (GDestroyNotify) g_variant_unref);
-
-  priv->aggregate_buffer = g_array_new (TRUE, FALSE, sizeof (GVariant *));
-  g_array_set_clear_func (priv->aggregate_buffer,
-                          (GDestroyNotify) g_variant_unref);
-
-  priv->sequence_buffer = g_array_new (TRUE, FALSE, sizeof (GVariant *));
-  g_array_set_clear_func (priv->sequence_buffer,
-                          (GDestroyNotify) g_variant_unref);
+  priv->variant_array =
+    g_ptr_array_new_with_free_func ((GDestroyNotify) g_variant_unref);
 }
 
 static void
@@ -64,9 +52,7 @@ emer_persistent_cache_finalize (GObject *object)
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  g_array_unref (priv->singular_buffer);
-  g_array_unref (priv->aggregate_buffer);
-  g_array_unref (priv->sequence_buffer);
+  g_ptr_array_unref (priv->variant_array);
 
   G_OBJECT_CLASS (emer_persistent_cache_parent_class)->finalize (object);
 }
@@ -79,22 +65,27 @@ emer_persistent_cache_class_init (EmerPersistentCacheClass *klass)
 }
 
 EmerPersistentCache *
-emer_persistent_cache_new (GCancellable *cancellable,
-                           GError      **error)
+emer_persistent_cache_new (const gchar *directory,
+                           GError     **error)
 {
   return g_object_new (EMER_TYPE_PERSISTENT_CACHE, NULL);
 }
 
 EmerPersistentCache *
-emer_persistent_cache_new_full (GCancellable             *cancellable,
-                                GError                  **error,
-                                const gchar              *custom_directory,
+emer_persistent_cache_new_full (const gchar              *directory,
                                 EmerCacheSizeProvider    *cache_size_provider,
                                 EmerBootIdProvider       *boot_id_provider,
                                 EmerCacheVersionProvider *version_provider,
-                                guint                     boot_offset_update_interval)
+                                guint                     boot_offset_update_interval,
+                                GError                  **error)
 {
   g_assert_not_reached ();
+}
+
+gsize
+emer_persistent_cache_cost (GVariant *variant)
+{
+  return g_variant_get_size (variant);
 }
 
 gboolean
@@ -115,99 +106,82 @@ emer_persistent_cache_get_boot_time_offset (EmerPersistentCache *self,
   return TRUE;
 }
 
-static void
-drain_to_c_array (GArray    **variant_array,
-                  GVariant ***variant_c_array)
-{
-  *variant_c_array = (GVariant **) g_array_free (*variant_array, FALSE);
-  *variant_array = g_array_new (TRUE, FALSE, sizeof (GVariant *));
-}
-
-// TODO: Support max_num_bytes parameter once it's supported in production.
 gboolean
-emer_persistent_cache_drain_metrics (EmerPersistentCache *self,
-                                     GVariant          ***singular_array,
-                                     GVariant          ***aggregate_array,
-                                     GVariant          ***sequence_array,
-                                     gint                 max_num_bytes)
+emer_persistent_cache_store (EmerPersistentCache *self,
+                             GVariant           **variants,
+                             gsize                num_variants,
+                             gsize               *num_variants_stored,
+                             GError             **error)
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  drain_to_c_array (&priv->singular_buffer, singular_array);
-  drain_to_c_array (&priv->aggregate_buffer, aggregate_array);
-  drain_to_c_array (&priv->sequence_buffer, sequence_array);
+  for (gsize i = 0; priv->variant_array->len < MAX_NUM_VARIANTS &&
+       i < num_variants; i++)
+    {
+      g_variant_ref_sink (variants[i]);
+      g_ptr_array_add (priv->variant_array, variants[i]);
+    }
+
+  *num_variants_stored = num_variants;
 
   return TRUE;
 }
 
-static void
-append_singulars (GArray        *singular_variants,
-                  SingularEvent *singular_structs,
-                  gint           num_singulars_buffered)
-{
-  for (gint i = 0; i < num_singulars_buffered; i++)
-    {
-      GVariant *singular = singular_to_variant (singular_structs + i);
-      g_array_append_val (singular_variants, singular);
-    }
-}
-
-static void
-append_aggregates (GArray         *aggregate_variants,
-                   AggregateEvent *aggregate_structs,
-                   gint            num_aggregates_buffered)
-{
-  for (gint i = 0; i < num_aggregates_buffered; i++)
-    {
-      GVariant *aggregate = aggregate_to_variant (aggregate_structs + i);
-      g_array_append_val (aggregate_variants, aggregate);
-    }
-}
-
-static void
-append_sequences (GArray        *sequence_variants,
-                  SequenceEvent *sequence_structs,
-                  gint           num_sequences_buffered)
-{
-  for (gint i = 0; i < num_sequences_buffered; i++)
-    {
-      GVariant *sequence = sequence_to_variant (sequence_structs + i);
-      g_array_append_val (sequence_variants, sequence);
-    }
-}
-
 gboolean
-emer_persistent_cache_store_metrics (EmerPersistentCache *self,
-                                     SingularEvent       *singular_buffer,
-                                     AggregateEvent      *aggregate_buffer,
-                                     SequenceEvent       *sequence_buffer,
-                                     gint                 num_singulars_buffered,
-                                     gint                 num_aggregates_buffered,
-                                     gint                 num_sequences_buffered,
-                                     gint                *num_singulars_stored,
-                                     gint                *num_aggregates_stored,
-                                     gint                *num_sequences_stored,
-                                     capacity_t          *capacity)
+emer_persistent_cache_read (EmerPersistentCache *self,
+                            GVariant          ***variants,
+                            gsize                cost,
+                            gsize               *num_variants,
+                            guint64             *token,
+                            GError             **error)
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  append_singulars (priv->singular_buffer, singular_buffer,
-                    num_singulars_buffered);
-  *num_singulars_stored = num_singulars_buffered;
+  gsize curr_cost = 0, curr_num_variants = 0;
+  for (; curr_num_variants < priv->variant_array->len; curr_num_variants++)
+    {
+      GVariant *curr_variant =
+        g_ptr_array_index (priv->variant_array, curr_num_variants);
+      curr_cost += emer_persistent_cache_cost (curr_variant);
+      if (curr_cost > cost)
+        break;
+    }
 
-  append_aggregates (priv->aggregate_buffer, aggregate_buffer,
-                     num_aggregates_buffered);
-  *num_aggregates_stored = num_aggregates_buffered;
+  *num_variants = curr_num_variants;
 
-  append_sequences (priv->sequence_buffer, sequence_buffer,
-                    num_sequences_buffered);
-  *num_sequences_stored = num_sequences_buffered;
+  *variants = g_new (GVariant *, curr_num_variants);
+  for (gsize i = 0; i < curr_num_variants; i++)
+    {
+      GVariant *curr_variant = g_ptr_array_index (priv->variant_array, i);
+      (*variants)[i] = deep_copy_variant (curr_variant);
+    }
 
-  *capacity = CAPACITY_LOW;
+  *token = curr_num_variants;
+  return TRUE;
+}
 
-  priv->store_metrics_called++;
+gboolean
+emer_persistent_cache_has_more (EmerPersistentCache *self,
+                                guint64              token)
+{
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
+  return token < priv->variant_array->len;
+}
+
+gboolean
+emer_persistent_cache_remove (EmerPersistentCache *self,
+                              guint64              token,
+                              GError             **error)
+{
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
+  if (token > 0)
+    g_ptr_array_remove_range (priv->variant_array, 0, token);
 
   return TRUE;
 }
@@ -221,14 +195,4 @@ mock_persistent_cache_get_num_timestamp_updates (EmerPersistentCache *self)
     emer_persistent_cache_get_instance_private (self);
 
   return priv->num_timestamp_updates;
-}
-
-/* Return number of calls to emer_persistent_cache_store_metrics() */
-gint
-mock_persistent_cache_get_store_metrics_called (EmerPersistentCache *self)
-{
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
-
-  return priv->store_metrics_called;
 }

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -94,7 +94,7 @@ emer_persistent_cache_new_full (GCancellable             *cancellable,
                                 EmerCacheVersionProvider *version_provider,
                                 guint                     boot_offset_update_interval)
 {
-  return g_object_new (EMER_TYPE_PERSISTENT_CACHE, NULL);
+  g_assert_not_reached ();
 }
 
 gboolean

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -91,8 +91,8 @@ emer_persistent_cache_cost (GVariant *variant)
 gboolean
 emer_persistent_cache_get_boot_time_offset (EmerPersistentCache *self,
                                             gint64              *offset,
-                                            GError             **error,
-                                            gboolean             always_update_timestamps)
+                                            gboolean             always_update_timestamps,
+                                            GError             **error)
 {
   if (always_update_timestamps)
     {

--- a/tests/daemon/mock-persistent-cache.h
+++ b/tests/daemon/mock-persistent-cache.h
@@ -30,9 +30,9 @@
 G_BEGIN_DECLS
 
 #define BOOT_TIME_OFFSET G_GINT64_CONSTANT (73)
+#define MAX_NUM_VARIANTS 10
 
 gint mock_persistent_cache_get_num_timestamp_updates (EmerPersistentCache *self);
-gint mock_persistent_cache_get_store_metrics_called  (EmerPersistentCache *self);
 
 G_END_DECLS
 

--- a/tests/daemon/test-circular-file.c
+++ b/tests/daemon/test-circular-file.c
@@ -1,0 +1,662 @@
+/* Copyright 2015 Endless Mobile, Inc. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "daemon/emer-circular-file.h"
+
+#include <string.h>
+
+#include <glib.h>
+#include <glib/gstdio.h>
+
+typedef struct _Fixture
+{
+  gchar *data_file_path;
+} Fixture;
+
+static void
+setup (Fixture      *fixture,
+       gconstpointer unused)
+{
+  GFileIOStream *stream;
+  GFile *data_file =
+    g_file_new_tmp ("circular-file-XXXXXX.dat", &stream, NULL /* GError */);
+  g_assert_nonnull (data_file);
+  g_object_unref (stream);
+  fixture->data_file_path = g_file_get_path (data_file);
+  g_object_unref (data_file);
+}
+
+static void
+teardown (Fixture      *fixture,
+          gconstpointer unused)
+{
+  g_unlink (fixture->data_file_path);
+  gchar *metadata_file_path =
+    g_strconcat (fixture->data_file_path, METADATA_EXTENSION, NULL);
+  g_free (fixture->data_file_path);
+
+  g_unlink (metadata_file_path);
+  g_free (metadata_file_path);
+}
+
+static gsize
+get_elem_size (const gchar *string)
+{
+  return strlen (string) + 1 /* terminal null byte */;
+}
+
+static gsize
+get_total_elem_size (const gchar * const *strings,
+                     gsize                num_strings)
+{
+  gsize total_elem_size = 0;
+  for (gsize i = 0; i < num_strings; i++)
+    total_elem_size += get_elem_size (strings[i]);
+
+  return total_elem_size;
+}
+
+/* Returns the number of bytes the given string will consume when saved in a
+ * circular file. See emer_circular_file_append for more details.
+ */
+static guint64
+get_disk_size (const gchar *string)
+{
+  gsize elem_size = get_elem_size (string);
+  return sizeof (guint64) + elem_size;
+}
+
+/* Returns the number of bytes the given array of strings will consume when
+ * each string is appended as a separate element to a circular file. See
+ * emer_circular_file_append for more details.
+ */
+static guint64
+get_total_disk_size (const gchar * const *strings,
+                     gsize                num_strings)
+{
+  guint64 total_disk_size = 0;
+  for (gsize i = 0; i < num_strings; i++)
+    total_disk_size += get_disk_size (strings[i]);
+
+  return total_disk_size;
+}
+
+static EmerCircularFile *
+make_circular_file (Fixture *fixture,
+                    guint64  max_size)
+{
+  GError *error = NULL;
+  EmerCircularFile *circular_file =
+    emer_circular_file_new (fixture->data_file_path, max_size, &error);
+
+  g_assert_no_error (error);
+  g_assert_nonnull (circular_file);
+
+  return circular_file;
+}
+
+static EmerCircularFile *
+make_minimal_circular_file (Fixture             *fixture,
+                            const gchar * const *strings,
+                            gsize                num_strings)
+{
+  guint64 max_size = get_total_disk_size (strings, num_strings);
+  return make_circular_file (fixture, max_size);
+}
+
+static void
+assert_strings_saved (EmerCircularFile    *circular_file,
+                      const gchar * const *strings,
+                      gsize                num_strings)
+{
+  for (gsize i = 0; i < num_strings; i++)
+    {
+      const gchar *curr_elem = strings[i];
+      gsize elem_size = get_elem_size (curr_elem);
+      emer_circular_file_append (circular_file, curr_elem, elem_size);
+    }
+
+  GError *error = NULL;
+  gboolean save_succeeded = emer_circular_file_save (circular_file, &error);
+  g_assert_no_error (error);
+  g_assert_true (save_succeeded);
+}
+
+static guint64
+assert_strings_read (EmerCircularFile    *circular_file,
+                     const gchar * const *strings,
+                     gsize                num_strings)
+{
+  GBytes **elems;
+
+  gsize total_elem_size = get_total_elem_size (strings, num_strings);
+  gsize total_disk_size = get_total_disk_size (strings, num_strings);
+
+  /* These arbitrary values should be overwritten. */
+  gsize num_elems = num_strings + 1;
+  guint64 token = total_disk_size + 1;
+
+  GError *error = NULL;
+  gboolean read_succeeded =
+    emer_circular_file_read (circular_file, &elems, total_elem_size, &num_elems,
+                             &token, &error);
+
+  g_assert_no_error (error);
+  g_assert_true (read_succeeded);
+  g_assert_cmpuint (num_elems, ==, num_strings);
+
+  for (gsize i = 0; i < num_elems; i++)
+    {
+      gsize actual_elem_size;
+      gconstpointer elem_data = g_bytes_get_data (elems[i], &actual_elem_size);
+      g_assert_cmpstr (elem_data, ==, strings[i]);
+      gsize expected_elem_size = get_elem_size (strings[i]);
+      g_assert_cmpuint (actual_elem_size, ==, expected_elem_size);
+      g_bytes_unref (elems[i]);
+    }
+
+  g_free (elems);
+  g_assert_cmpuint (token, ==, total_disk_size);
+
+  return token;
+}
+
+static void
+assert_circular_file_is_empty (EmerCircularFile *circular_file)
+{
+  g_assert_false (emer_circular_file_has_more (circular_file, 0));
+
+  GBytes **elems;
+
+  /* These arbitrary values should be overwritten. */
+  gsize num_elems = 1;
+  guint64 token = 1;
+
+  GError *error = NULL;
+  gboolean read_succeeded =
+    emer_circular_file_read (circular_file, &elems, G_MAXSIZE, &num_elems,
+                             &token, &error);
+
+  g_assert_no_error (error);
+  g_assert_true (read_succeeded);
+  g_assert_null (elems);
+  g_assert_cmpuint (num_elems, ==, 0);
+  g_assert_cmpuint (token, ==, 0);
+}
+
+static void
+assert_strings_removed (EmerCircularFile    *circular_file,
+                        const gchar * const *strings,
+                        gsize                num_strings)
+{
+  guint64 token = assert_strings_read (circular_file, strings, num_strings);
+  GError *error = NULL;
+  gboolean remove_succeeded =
+    emer_circular_file_remove (circular_file, token, &error);
+
+  g_assert_no_error (error);
+  g_assert_true (remove_succeeded);
+}
+
+static void
+assert_circular_file_purged (EmerCircularFile *circular_file)
+{
+  GError *error = NULL;
+  gboolean purge_succeeded = emer_circular_file_purge (circular_file, &error);
+
+  g_assert_no_error (error);
+  g_assert_true (purge_succeeded);
+  assert_circular_file_is_empty (circular_file);
+}
+
+static void
+test_circular_file_new (Fixture      *fixture,
+                        gconstpointer unused)
+{
+  EmerCircularFile *circular_file = make_circular_file (fixture, 0);
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_append_when_empty (Fixture      *fixture,
+                                      gconstpointer unused)
+{
+  const gchar *STRING = "Karl";
+  guint64 max_size = get_disk_size (STRING);
+  EmerCircularFile *circular_file = make_circular_file (fixture, max_size);
+
+  gsize elem_size = get_elem_size (STRING);
+  emer_circular_file_append (circular_file, STRING, elem_size);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_append_when_full (Fixture      *fixture,
+                                     gconstpointer unused)
+{
+  const gchar * const STRINGS[] =
+    {
+      "Sneezy", "phylum", "Europe", "sloth", "guacamole", "data link",
+      "Colossus of Rhodes"
+    };
+  gsize NUM_STRINGS = G_N_ELEMENTS (STRINGS);
+  EmerCircularFile *circular_file =
+    make_minimal_circular_file (fixture, STRINGS, NUM_STRINGS);
+
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+
+  const gchar * const STRINGS_2[] = { "Marx" };
+  gsize NUM_STRINGS_2 = G_N_ELEMENTS (STRINGS_2);
+  gboolean will_fit =
+    emer_circular_file_append (circular_file, STRINGS_2, NUM_STRINGS_2);
+  g_assert_false (will_fit);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_save_none (Fixture      *fixture,
+                              gconstpointer unused)
+{
+  EmerCircularFile *circular_file = make_circular_file (fixture, 7823);
+
+  assert_strings_saved (circular_file, NULL /* strings */, 0);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_save_one (Fixture      *fixture,
+                             gconstpointer unused)
+{
+  const gchar * const STRINGS[] = { "Gave" };
+  gsize NUM_STRINGS = G_N_ELEMENTS (STRINGS);
+  EmerCircularFile *circular_file =
+    make_minimal_circular_file (fixture, STRINGS, NUM_STRINGS);
+
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_save_many (Fixture      *fixture,
+                              gconstpointer unused)
+{
+  const gchar * const STRINGS[] =
+    {
+      "Dopey", "class", "Australia", "wrath", "salsa", "physical",
+      "Lighthouse of Alexandria"
+    };
+  gsize NUM_STRINGS = G_N_ELEMENTS (STRINGS);
+  EmerCircularFile *circular_file =
+    make_minimal_circular_file (fixture, STRINGS, NUM_STRINGS);
+
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_read_none (Fixture      *fixture,
+                              gconstpointer unused)
+{
+  EmerCircularFile *circular_file = make_circular_file (fixture, 0);
+
+  assert_strings_saved (circular_file, NULL /* strings */, 0);
+  assert_strings_read (circular_file, NULL /* strings */, 0);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_read_one (Fixture      *fixture,
+                             gconstpointer unused)
+{
+  const gchar * const STRINGS[] = { "The" };
+  gsize NUM_STRINGS = G_N_ELEMENTS (STRINGS);
+  EmerCircularFile *circular_file =
+    make_minimal_circular_file (fixture, STRINGS, NUM_STRINGS);
+
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+  assert_strings_read (circular_file, STRINGS, NUM_STRINGS);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_read_many (Fixture      *fixture,
+                              gconstpointer unused)
+{
+  const gchar * const STRINGS[] =
+    {
+      "Doc", "order", "Asia", "envy", "olives", "application",
+      "Great Pyramid of Giza"
+    };
+  gsize NUM_STRINGS = G_N_ELEMENTS (STRINGS);
+  EmerCircularFile *circular_file =
+    make_minimal_circular_file (fixture, STRINGS, NUM_STRINGS);
+
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+  assert_strings_read (circular_file, STRINGS, NUM_STRINGS);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_read_when_empty (Fixture      *fixture,
+                                    gconstpointer unused)
+{
+  EmerCircularFile *circular_file = make_circular_file (fixture, 86);
+
+  assert_circular_file_is_empty (circular_file);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_has_more (Fixture      *fixture,
+                             gconstpointer unused)
+{
+  const gchar * const STRINGS[] =
+    {
+      "Grumpy", "family", "Africa", "pride", "refried beans", "presentation",
+      "Hanging Gardens of Babylon"
+    };
+  gsize NUM_STRINGS = G_N_ELEMENTS (STRINGS);
+
+  gsize NUM_STRINGS_2 = (2 * NUM_STRINGS) - 1;
+  const gchar *STRINGS_2[NUM_STRINGS_2];
+  for (gsize i = 0; i < NUM_STRINGS_2; i++)
+    STRINGS_2[i] = STRINGS[(i + 1) % NUM_STRINGS];
+
+  EmerCircularFile *circular_file =
+    make_minimal_circular_file (fixture, STRINGS_2, NUM_STRINGS_2);
+
+  assert_circular_file_is_empty (circular_file);
+
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+  g_assert_true (emer_circular_file_has_more (circular_file, 0));
+
+  guint64 token = assert_strings_read (circular_file, STRINGS, NUM_STRINGS - 1);
+  g_assert_true (emer_circular_file_has_more (circular_file, token));
+
+  token = assert_strings_read (circular_file, STRINGS, NUM_STRINGS);
+  g_assert_false (emer_circular_file_has_more (circular_file, token));
+
+  assert_strings_removed (circular_file, STRINGS, 1);
+  g_assert_true (emer_circular_file_has_more (circular_file, 0));
+
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+  g_assert_true (emer_circular_file_has_more (circular_file, 0));
+
+  token = assert_strings_read (circular_file, STRINGS_2, NUM_STRINGS_2 - 1);
+  g_assert_true (emer_circular_file_has_more (circular_file, token));
+
+  token = assert_strings_read (circular_file, STRINGS_2, NUM_STRINGS_2);
+  g_assert_false (emer_circular_file_has_more (circular_file, token));
+
+  assert_strings_removed (circular_file, STRINGS_2, NUM_STRINGS_2);
+  assert_circular_file_is_empty (circular_file);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_remove_none (Fixture      *fixture,
+                                gconstpointer unused)
+{
+  EmerCircularFile *circular_file = make_circular_file (fixture, 50);
+
+  assert_strings_saved (circular_file, NULL /* strings */, 0);
+  assert_strings_removed (circular_file, NULL /* strings */, 0);
+  assert_circular_file_is_empty (circular_file);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_remove_one (Fixture      *fixture,
+                               gconstpointer unused)
+{
+  const gchar * const STRINGS[] = { "Proletariat" };
+  gsize NUM_STRINGS = G_N_ELEMENTS (STRINGS);
+  EmerCircularFile *circular_file =
+    make_minimal_circular_file (fixture, STRINGS, NUM_STRINGS);
+
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+  assert_strings_removed (circular_file, STRINGS, NUM_STRINGS);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_remove_many (Fixture      *fixture,
+                                gconstpointer unused)
+{
+  const gchar * const STRINGS[] =
+    {
+      "Happy", "genus", "North America", "lust", "cheese", "session",
+      "Statue of Zeus at Olympia"
+    };
+  gsize NUM_STRINGS = G_N_ELEMENTS (STRINGS);
+  EmerCircularFile *circular_file =
+    make_minimal_circular_file (fixture, STRINGS, NUM_STRINGS);
+
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+  assert_strings_removed (circular_file, STRINGS, NUM_STRINGS);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_remove_when_empty (Fixture      *fixture,
+                                      gconstpointer unused)
+{
+  EmerCircularFile *circular_file = make_circular_file (fixture, 0);
+
+  assert_strings_removed (circular_file, NULL /* strings */, 0);
+  assert_circular_file_is_empty (circular_file);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_purge_none (Fixture      *fixture,
+                               gconstpointer unused)
+{
+  EmerCircularFile *circular_file = make_circular_file (fixture, 33);
+
+  assert_strings_saved (circular_file, NULL /* strings */, 0);
+  assert_circular_file_purged (circular_file);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_purge_one (Fixture      *fixture,
+                              gconstpointer unused)
+{
+  const gchar * const STRINGS[] = { "Eleven" };
+  gsize NUM_STRINGS = G_N_ELEMENTS (STRINGS);
+  EmerCircularFile *circular_file =
+    make_minimal_circular_file (fixture, STRINGS, NUM_STRINGS);
+
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+  assert_circular_file_purged (circular_file);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_purge_many (Fixture      *fixture,
+                               gconstpointer unused)
+{
+  const gchar * const STRINGS[] =
+    {
+      "Sleepy", "species", "South America", "gluttony", "ground beef",
+      "transport", "Temple of Artemis at Ephesus"
+    };
+  gsize NUM_STRINGS = G_N_ELEMENTS (STRINGS);
+  EmerCircularFile *circular_file =
+    make_minimal_circular_file (fixture, STRINGS, NUM_STRINGS);
+
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+  assert_circular_file_purged (circular_file);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_purge_when_empty (Fixture      *fixture,
+                                     gconstpointer unused)
+{
+  EmerCircularFile *circular_file = make_circular_file (fixture, 33);
+
+  assert_circular_file_purged (circular_file);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_ignores_unsaved_elems (Fixture      *fixture,
+                                          gconstpointer unused)
+{
+  const gchar * const STRINGS[] = { "Zeppelins" };
+  gsize NUM_STRINGS = G_N_ELEMENTS (STRINGS);
+  EmerCircularFile *circular_file =
+    make_minimal_circular_file (fixture, STRINGS, NUM_STRINGS);
+
+  gsize elem_size = get_elem_size (STRINGS[0]);
+  emer_circular_file_append (circular_file, STRINGS[0], elem_size);
+  assert_circular_file_is_empty (circular_file);
+
+  g_object_unref (circular_file);
+}
+
+static void
+test_circular_file_grow (Fixture      *fixture,
+                         gconstpointer unused)
+{
+  const gchar * const STRINGS[] = { "Yo" };
+  gsize NUM_STRINGS = G_N_ELEMENTS (STRINGS);
+  gsize max_size = get_total_disk_size (STRINGS, NUM_STRINGS);
+  EmerCircularFile *circular_file = make_circular_file (fixture, max_size);
+
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+  assert_strings_removed (circular_file, STRINGS, NUM_STRINGS);
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+
+  g_object_unref (circular_file);
+
+  gsize max_size_2 = 2 * max_size;
+  EmerCircularFile *circular_file_2 = make_circular_file (fixture, max_size_2);
+
+  assert_strings_saved (circular_file_2, STRINGS, NUM_STRINGS);
+  assert_strings_removed (circular_file_2, STRINGS, NUM_STRINGS);
+  assert_strings_removed (circular_file_2, STRINGS, NUM_STRINGS);
+  assert_circular_file_is_empty (circular_file_2);
+
+  g_object_unref (circular_file_2);
+}
+
+static void
+test_circular_file_shrink (Fixture      *fixture,
+                           gconstpointer unused)
+{
+  const gchar * const STRINGS[] =
+    {
+      "Bashful", "kingdom", "Antarctica", "greed", "sour cream", "network",
+      "Mausoleum at Halicarnassus"
+    };
+  gsize NUM_STRINGS = G_N_ELEMENTS (STRINGS);
+  gsize max_size = get_total_disk_size (STRINGS, NUM_STRINGS);
+  EmerCircularFile *circular_file = make_circular_file (fixture, max_size);
+
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+  assert_strings_removed (circular_file, STRINGS, NUM_STRINGS);
+  assert_strings_saved (circular_file, STRINGS, NUM_STRINGS);
+
+  g_object_unref (circular_file);
+
+  gsize max_size_2 = max_size - 1;
+  EmerCircularFile *circular_file_2 = make_circular_file (fixture, max_size_2);
+
+  assert_strings_removed (circular_file_2, STRINGS, NUM_STRINGS - 1);
+
+  g_object_unref (circular_file_2);
+}
+
+int
+main (int                argc,
+      const char * const argv[])
+{
+  g_test_init (&argc, (char ***) &argv, NULL);
+
+#define ADD_CIRCULAR_FILE_TEST_FUNC(path, func) \
+  g_test_add((path), Fixture, NULL, setup, (func), teardown)
+
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/new", test_circular_file_new);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/append-when-empty",
+                               test_circular_file_append_when_empty);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/append-when-full",
+                               test_circular_file_append_when_full);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/save-none",
+                               test_circular_file_save_none);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/save-one",
+                               test_circular_file_save_one);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/save-many",
+                               test_circular_file_save_many);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/read-none",
+                               test_circular_file_read_none);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/read-one",
+                               test_circular_file_read_one);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/read-many",
+                               test_circular_file_read_many);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/read-when-empty",
+                               test_circular_file_read_when_empty);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/has-more",
+                               test_circular_file_has_more);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/remove-none",
+                               test_circular_file_remove_none);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/remove-one",
+                               test_circular_file_remove_one);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/remove-many",
+                               test_circular_file_remove_many);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/remove-when-empty",
+                               test_circular_file_remove_when_empty);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/purge-none",
+                               test_circular_file_purge_none);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/purge-one",
+                               test_circular_file_purge_one);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/purge-many",
+                               test_circular_file_purge_many);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/purge-when-empty",
+                               test_circular_file_purge_when_empty);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/ignores-unsaved-elems",
+                               test_circular_file_ignores_unsaved_elems);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/grow", test_circular_file_grow);
+  ADD_CIRCULAR_FILE_TEST_FUNC ("/circular-file/shrink",
+                               test_circular_file_shrink);
+#undef ADD_CIRCULAR_FILE_TEST_FUNC
+
+  return g_test_run ();
+}

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -984,7 +984,7 @@ setup (Fixture      *fixture,
   fixture->test_object =
     emer_daemon_new_full (g_rand_new_with_seed (18),
                           server_uri,
-                          2, // Network Send Interval
+                          2 /* network send interval */,
                           fixture->mock_machine_id_provider,
                           fixture->mock_network_send_provider,
                           fixture->mock_permissions_provider,
@@ -1256,7 +1256,7 @@ test_daemon_flushes_to_persistent_cache_on_shutdown (Fixture      *fixture,
                           NULL /* user_data */);
   emit_shutdown_signal (TRUE);
 
-  // Wait for EmerDaemon to handle the signal.
+  /* Wait for daemon to handle the signal. */
   while (g_main_context_pending (NULL))
     g_main_context_iteration (NULL, TRUE);
 

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -552,7 +552,6 @@ static void assert_machine_id_matches (GVariant              *machine_id_variant
   g_assert_cmpint (compare_result, ==, 0);
 }
 
-
 static void
 assert_singular_matches (GVariantIter *singular_iterator,
                          GVariant     *expected_auxiliary_payload)

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -679,7 +679,7 @@ get_events_from_request (GByteArray    *request,
 
   gchar *checksum =
     g_compute_checksum_for_bytes (G_CHECKSUM_SHA512, request_bytes);
-  gchar *expected_request_path = g_strconcat ("/2/", checksum, NULL);
+  gchar *expected_request_path = g_build_filename ("/2/", checksum, NULL);
   g_free (checksum);
   g_assert_cmpstr (fixture->request_path, ==, expected_request_path);
   g_free (expected_request_path);

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -81,7 +81,6 @@ write_cache_size_file (void)
   g_key_file_unref (key_file);
 }
 
-
 static void
 write_mock_system_boot_id_file (void)
 {

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -1337,7 +1337,6 @@ static void
 test_persistent_cache_drain_empty_succeeds (gboolean     *unused,
                                             gconstpointer dontuseme)
 {
-  // Don't store anything.
   EmerPersistentCache *cache = make_testing_cache ();
   GVariant **singulars_drained, **aggregates_drained, **sequences_drained;
   gboolean success = emer_persistent_cache_drain_metrics (cache,

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -859,7 +859,7 @@ test_persistent_cache_builds_boot_metadata_file (gboolean     *unused,
 
   GError *error = NULL;
   gboolean get_succeeded =
-    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, TRUE, &error);
   g_assert_no_error (error);
   g_assert_true (get_succeeded);
 
@@ -870,7 +870,7 @@ test_persistent_cache_builds_boot_metadata_file (gboolean     *unused,
   g_assert_true (emtr_util_get_current_time (CLOCK_REALTIME, &absolute_time));
 
   get_succeeded =
-    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, TRUE, &error);
   g_assert_no_error (error);
   g_assert_true (get_succeeded);
 
@@ -946,7 +946,7 @@ test_persistent_cache_does_not_compute_offset_when_boot_id_is_same (gboolean    
 
   GError *error = NULL;
   gboolean get_succeeded =
-    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, TRUE, &error);
   g_assert_no_error (error);
   g_assert_true (get_succeeded);
   g_assert_true (boot_offset_was_reset ());
@@ -964,7 +964,7 @@ test_persistent_cache_does_not_compute_offset_when_boot_id_is_same (gboolean    
 
   // This call should have to compute the boot offset itself.
   get_succeeded =
-    emer_persistent_cache_get_boot_time_offset (cache2, NULL, &error, TRUE);
+    emer_persistent_cache_get_boot_time_offset (cache2, NULL, TRUE, &error);
 
   g_assert_no_error (error);
   g_assert_true (get_succeeded);
@@ -979,7 +979,7 @@ test_persistent_cache_does_not_compute_offset_when_boot_id_is_same (gboolean    
   EmerPersistentCache *cache3 = make_testing_cache ();
 
   get_succeeded =
-    emer_persistent_cache_get_boot_time_offset (cache3, NULL, &error, TRUE);
+    emer_persistent_cache_get_boot_time_offset (cache3, NULL, TRUE, &error);
   g_assert_no_error (error);
   g_assert_true (get_succeeded);
 
@@ -1002,8 +1002,8 @@ test_persistent_cache_reads_cached_boot_offset (gboolean     *unused,
   gint64 first_offset;
   GError *error = NULL;
   gboolean get_succeeded =
-    emer_persistent_cache_get_boot_time_offset (cache, &first_offset, &error,
-                                                TRUE);
+    emer_persistent_cache_get_boot_time_offset (cache, &first_offset, TRUE,
+                                                &error);
   g_assert_no_error (error);
   g_assert_true (get_succeeded);
 
@@ -1026,8 +1026,8 @@ test_persistent_cache_reads_cached_boot_offset (gboolean     *unused,
    * on disk.
    */
   get_succeeded =
-    emer_persistent_cache_get_boot_time_offset (cache, &second_offset, &error,
-                                                TRUE);
+    emer_persistent_cache_get_boot_time_offset (cache, &second_offset, TRUE,
+                                                &error);
   g_assert_no_error (error);
   g_assert_true (get_succeeded);
 
@@ -1058,7 +1058,7 @@ test_persistent_cache_get_offset_wont_update_timestamps_if_it_isnt_supposed_to (
 
   // This call shouldn't update the metadata file.
   gboolean get_succeeded =
-    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, FALSE);
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, FALSE, &error);
 
   g_assert_no_error (error);
   g_assert_true (get_succeeded);
@@ -1091,7 +1091,7 @@ test_persistent_cache_get_offset_updates_timestamps_when_requested (gboolean    
 
   // This call should update the timestamps in the metadata file.
   gboolean get_succeeded =
-    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, TRUE, &error);
 
   g_assert_no_error (error);
   g_assert_true (get_succeeded);
@@ -1115,7 +1115,7 @@ test_persistent_cache_updates_timestamps_on_finalize (gboolean     *unused,
 
   // Update metadata file to reasonable values.
   gboolean get_succeeded =
-    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, TRUE, &error);
 
   g_assert_no_error (error);
   g_assert_true (get_succeeded);
@@ -1156,7 +1156,7 @@ test_persistent_cache_get_offset_can_build_boot_metadata_file (gboolean     *unu
    * always_update_timestamps parameter is FALSE.
    */
   gboolean get_succeeded =
-    emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, FALSE);
+    emer_persistent_cache_get_boot_time_offset (cache, NULL, FALSE, &error);
 
   g_assert_no_error (error);
   g_assert_true (get_succeeded);

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -1087,8 +1087,8 @@ test_persistent_cache_store_when_full_succeeds (gboolean     *unused,
   g_assert_no_error (error);
   g_assert_nonnull (cache);
 
-  g_object_unref (cache_version_provider);
   g_object_unref (boot_id_provider);
+  g_object_unref (cache_version_provider);
 
   capacity_t capacity = CAPACITY_LOW;
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -20,6 +20,8 @@
 
 #include "daemon/emer-persistent-cache.h"
 
+#include <string.h>
+
 #include <glib.h>
 #include <glib/gstdio.h>
 
@@ -50,18 +52,15 @@
  */
 #define BOOT_FILE_LENGTH 37
 
-// TODO: Replace this with a reasonable value once it is used.
-#define MAX_BYTES_TO_READ 0
-
 #define ACCEPTABLE_OFFSET_VARIANCE 500000000 // 500 milliseconds
 
 #define CACHE_SIZE_KEY_FILE_DATA \
   "[persistent_cache_size]\n" \
-  "maximum=92160\n"
+  "maximum=10000000\n"
 
 #define DEFAULT_CACHE_VERSION_KEY_FILE_DATA \
   "[cache_version_info]\n" \
-  "version=2\n"
+  "version=4\n"
 
 // ---- Helper functions come first ----
 
@@ -109,38 +108,11 @@ write_default_cache_version_key_file (void)
 }
 
 static void
-write_empty_metrics_file (gchar *suffix)
-{
-  gchar *filename = g_strconcat (CACHE_PREFIX, suffix, NULL);
-  gchar *path = g_build_filename (TEST_DIRECTORY, filename, NULL);
-  g_free (filename);
-  GFile *file = g_file_new_for_path (path);
-  g_free (path);
-
-  GError *error = NULL;
-  g_file_replace_contents (file, "", 0, NULL, FALSE,
-                           G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL,
-                           &error);
-  g_assert_no_error (error);
-  g_object_unref (file);
-}
-
-static void
-write_empty_metrics_files (void)
-{
-  write_empty_metrics_file (INDIVIDUAL_SUFFIX);
-  write_empty_metrics_file (AGGREGATE_SUFFIX);
-  write_empty_metrics_file (SEQUENCE_SUFFIX);
-}
-
-static void
 teardown (gboolean     *unused,
           gconstpointer dontuseme)
 {
-  g_unlink (TEST_DIRECTORY CACHE_PREFIX INDIVIDUAL_SUFFIX);
-  g_unlink (TEST_DIRECTORY CACHE_PREFIX AGGREGATE_SUFFIX);
-  g_unlink (TEST_DIRECTORY CACHE_PREFIX SEQUENCE_SUFFIX);
   g_unlink (TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE);
+  g_unlink (TEST_DIRECTORY TEST_CACHE_SIZE_FILE);
   g_unlink (TEST_DIRECTORY TEST_CACHE_VERSION_FILE);
   g_unlink (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   g_rmdir (TEST_DIRECTORY);
@@ -155,24 +127,22 @@ setup (gboolean     *unused,
   write_cache_size_file ();
   write_mock_system_boot_id_file ();
   write_default_cache_version_key_file ();
-  write_empty_metrics_files ();
 }
 
 static EmerPersistentCache *
 make_testing_cache (void)
 {
-  GError *error = NULL;
   EmerCacheSizeProvider *cache_size_provider =
     emer_cache_size_provider_new_full (TEST_DIRECTORY TEST_CACHE_SIZE_FILE);
   EmerBootIdProvider *boot_id_provider =
     emer_boot_id_provider_new_full (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   EmerCacheVersionProvider *cache_version_provider =
     emer_cache_version_provider_new_full (TEST_DIRECTORY TEST_CACHE_VERSION_FILE);
+  GError *error = NULL;
   EmerPersistentCache *cache =
-    emer_persistent_cache_new_full (NULL, &error, TEST_DIRECTORY,
-                                    cache_size_provider, boot_id_provider,
-                                    cache_version_provider,
-                                    TEST_UPDATE_OFFSET_INTERVAL);
+    emer_persistent_cache_new_full (TEST_DIRECTORY, cache_size_provider,
+                                    boot_id_provider, cache_version_provider,
+                                    TEST_UPDATE_OFFSET_INTERVAL, &error);
   g_assert_no_error (error);
   g_assert_nonnull (cache);
 
@@ -331,1065 +301,517 @@ boot_timestamp_is_valid (gint64 previous_relative_time,
           stored_absolute_time   <= after_absolute_time);
 }
 
-static void
-event_value_own (EventValue *event_value)
-{
-  GVariant *auxiliary_payload = event_value->auxiliary_payload;
-  if (auxiliary_payload != NULL)
-    g_variant_ref_sink (auxiliary_payload);
-}
-
-static void
-singular_event_own (SingularEvent *singular)
-{
-  EventValue *event_value = &singular->event_value;
-  event_value_own (event_value);
-}
-
-static void
-aggregate_event_own (AggregateEvent *aggregate)
-{
-  SingularEvent *event = &aggregate->event;
-  singular_event_own (event);
-}
-
-static void
-sequence_event_own (SequenceEvent *sequence)
-{
-  for (gint i = 0; i < sequence->num_event_values; i++)
-    event_value_own (sequence->event_values + i);
-}
-
-static void
-singular_buffer_own (SingularEvent *singular_buffer,
-                     gint           num_singulars_buffered)
-{
-  for (gint i = 0; i < num_singulars_buffered; i++)
-    singular_event_own (singular_buffer + i);
-}
-
-static void
-aggregate_buffer_own (AggregateEvent *aggregate_buffer,
-                      gint            num_aggregates_buffered)
-{
-  for (gint i = 0; i < num_aggregates_buffered; i++)
-    aggregate_event_own (aggregate_buffer + i);
-}
-
-static void
-sequence_buffer_own (SequenceEvent *sequence_buffer,
-                     gint           num_sequences_buffered)
-{
-  for (gint i = 0; i < num_sequences_buffered; i++)
-    sequence_event_own (sequence_buffer + i);
-}
-
-static void
-make_event_value (gint        choice,
-                  EventValue *event_value)
+static GVariant *
+make_variant (gint choice)
 {
   switch (choice)
     {
     case 0:
-      {
-        EventValue value =
-          { G_GINT64_CONSTANT (1876), g_variant_new_double (3.14159) };
-        *event_value = value;
-        break;
-      }
+      return g_variant_new ("(xmv)", G_GINT64_CONSTANT (1876),
+                            g_variant_new_double (3.14159));
 
     case 1:
-      {
-        EventValue value =
-          {
-            G_GINT64_CONSTANT (0),
-            g_variant_new_string ("negative-1-point-steve")
-          };
-        *event_value = value;
-        break;
-      }
+      return g_variant_new ("(xmv)", G_GINT64_CONSTANT (0),
+                            g_variant_new_string ("minus-1-steve"));
 
     case 2:
-      {
-        EventValue value = { G_GINT64_CONSTANT (-1), NULL };
-        *event_value = value;
-        break;
-      }
+      return g_variant_new ("(xmv)", G_GINT64_CONSTANT (-1), NULL);
 
     case 3:
-      {
-        EventValue value =
-          { G_GINT64_CONSTANT (7), g_variant_new_double (2.71828) };
-        *event_value = value;
-        break;
-      }
+      return g_variant_new ("(xmv)", G_GINT64_CONSTANT (7),
+                            g_variant_new_double (2.71828));
 
     case 4:
-      {
-        EventValue value =
-          {
-            G_GINT64_CONSTANT (67352),
-            g_variant_new_string ("Help! I'm trapped in a testing string!")
-          };
-        *event_value = value;
-        break;
-      }
+      return g_variant_new ("(xmv)", G_GINT64_CONSTANT (67352),
+                            g_variant_new_string ("Help!"));
 
     case 5:
-      {
-        EventValue value = { G_GINT64_CONSTANT (747), NULL };
-        *event_value = value;
-        break;
-      }
+      return g_variant_new ("(xmv)", G_GINT64_CONSTANT (747), NULL);
 
     case 6:
-      {
-        EventValue value =
-          {
-            G_GINT64_CONSTANT (57721),
-            g_variant_new_string ("Secret message to the Russians: The "
-                                  "'rooster' has 'laid' an 'egg'.")
-          };
-        *event_value = value;
-        break;
-      }
+      return g_variant_new ("(xmv)", G_GINT64_CONSTANT (57721),
+                            g_variant_new_string ("Secret"));
 
     case 7:
-      {
-        EventValue value =
-          { G_GINT64_CONSTANT (-100), g_variant_new_double (120.20569) };
-        *event_value = value;
-        break;
-      }
+      return g_variant_new ("(xmv)", G_GINT64_CONSTANT (-100),
+                            g_variant_new_double (120.20569));
 
     case 8:
-      {
-        EventValue value =
-          { G_GINT64_CONSTANT (127384), g_variant_new_double (-2.685452) };
-        *event_value = value;
-        break;
-      }
+      return g_variant_new ("(xmv)", G_GINT64_CONSTANT (127384),
+                            g_variant_new_double (-2.685452));
+
+    case 9:
+      return g_variant_new ("(uxmv)", 234u, G_GINT64_CONSTANT (42),
+                            g_variant_new_string ("murphy"));
+
+    case 10:
+      return g_variant_new ("(uxmv)", 121u, G_GINT64_CONSTANT (999),
+                            g_variant_new_int32 (404));
+
+    case 11:
+      return g_variant_new ("(uxmv)", 555u, G_GINT64_CONSTANT (1201),
+                            g_variant_new_string ("baa!"));
+
+    case 12:
+      return g_variant_new ("(uxmv)", 411u, G_GINT64_CONSTANT (-128),
+                            g_variant_new_int32 (64));
+
+    case 13:
+      return g_variant_new ("(uxxmv)", 12u, G_GINT64_CONSTANT (111),
+                            G_GINT64_CONSTANT (9876),
+                            g_variant_new_string ("meepo"));
+
+    case 14:
+      return g_variant_new ("(uxxmv)", 1019u, G_GINT64_CONSTANT (1),
+                            G_GINT64_CONSTANT (-333),
+                            g_variant_new_string ("la la la"));
+
+    case 15:
+      return g_variant_new ("(uxxmv)", 5u, G_GINT64_CONSTANT (-3984),
+                            G_GINT64_CONSTANT (5965),
+                            g_variant_new_string ("Gandalf"));
 
     default:
-      {
-        g_error ("Tried to use a choice for make_event_values that hasn't been "
-                 "programmed.");
-      }
+      g_error ("Tried to make a variant that hasn't been programmed.");
     }
 }
 
-static void
-make_singular_event (gint           choice,
-                     SingularEvent *singular)
+static GPtrArray *
+make_many_variants (void)
 {
-  switch (choice)
+  gsize NUM_VARIANTS = 16;
+  GPtrArray *variants =
+    g_ptr_array_new_full (NUM_VARIANTS, (GDestroyNotify) g_variant_unref);
+  for (gsize i = 0; i < NUM_VARIANTS; i++)
     {
-    case 0:
-      {
-        EventValue event_value =
-          { G_GINT64_CONSTANT (42), g_variant_new_string ("murphy") };
-        SingularEvent singular_event =
-          {
-            234u,
-            { 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe,
-              0xef, 0xde, 0xad, 0xbe, 0xef },
-            event_value
-          };
-        *singular = singular_event;
-        break;
-      }
-
-    case 1:
-      {
-        EventValue event_value =
-          { G_GINT64_CONSTANT (999), g_variant_new_int32 (404) };
-        SingularEvent singular_event =
-          {
-            121u,
-            { 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01,
-              0x23, 0x45, 0x67, 0x89, 0x01 },
-            event_value
-          };
-        *singular = singular_event;
-        break;
-      }
-
-    case 2:
-      {
-        EventValue event_value =
-          {
-            G_GINT64_CONSTANT (12012),
-            g_variant_new_string ("I am a banana!")
-          };
-        SingularEvent singular_event =
-          {
-            555u,
-            { 0x4b, 0x4b, 0x4b, 0x4b, 0x4b, 0x4b, 0x4b, 0x4b, 0x4b, 0x4b, 0x4b,
-              0x4b, 0x4b, 0x4b, 0x4b, 0x4b },
-            event_value
-          };
-        *singular = singular_event;
-        break;
-      }
-
-    case 3:
-      {
-        EventValue event_value =
-          { G_GINT64_CONSTANT (-128), g_variant_new_int32 (64) };
-        SingularEvent singular_event =
-          {
-            411u,
-            { 0x55, 0x2c, 0x55, 0x2c, 0x55, 0x2c, 0x55, 0x2c, 0x55, 0x2c, 0x55,
-              0x2c, 0x55, 0x2c, 0x55, 0x2c },
-            event_value
-          };
-        *singular = singular_event;
-        break;
-      }
-
-    default:
-      {
-        g_error ("Tried to use a choice for make_singular_event that hasn't "
-                 "been programmed.");
-      }
+      GVariant *curr_variant = make_variant (i);
+      g_variant_ref_sink (curr_variant);
+      g_ptr_array_add (variants, curr_variant);
     }
+
+  return variants;
 }
 
-static void
-make_aggregate_event (gint            choice,
-                      AggregateEvent *aggregate)
-{
-  switch (choice)
-    {
-    case 0:
-      {
-        EventValue event_value =
-          { G_GINT64_CONSTANT (9876), g_variant_new_string ("meepo") };
-        SingularEvent event =
-          {
-            12u,
-            { 0xde, 0xaf, 0x00, 0x01, 0xde, 0xaf, 0x00, 0x01, 0xde, 0xaf, 0x00,
-              0x01, 0xde, 0xaf, 0x00, 0x01 },
-            event_value
-          };
-        AggregateEvent aggregate_event = { event, G_GINT64_CONSTANT (111) };
-        *aggregate = aggregate_event;
-        break;
-      }
-
-    case 1:
-      {
-        EventValue event_value =
-          {
-            G_GINT64_CONSTANT (-333),
-            g_variant_new_string ("My spoon is too big.")
-          };
-        SingularEvent event =
-          {
-            1019u,
-            { 0x33, 0x44, 0x95, 0x2a, 0x33, 0x44, 0x95, 0x2a, 0x33, 0x44, 0x95,
-              0x2a, 0x33, 0x44, 0x95, 0x2a },
-            event_value
-          };
-        AggregateEvent aggregate_event = { event, G_GINT64_CONSTANT (1) };
-        *aggregate = aggregate_event;
-        break;
-      }
-
-    case 2:
-      {
-        EventValue event_value =
-          { G_GINT64_CONSTANT (5965), g_variant_new_string ("!^@#@#^#$") };
-        SingularEvent event =
-          {
-            5u,
-            { 0x33, 0x44, 0x95, 0x2a, 0xb4, 0x9c, 0x2d, 0x14, 0x45, 0xaa, 0x33,
-              0x44, 0x95, 0x2a, 0xb4, 0x9c },
-            event_value
-          };
-        AggregateEvent aggregate_event = { event, G_GINT64_CONSTANT (-3984) };
-        *aggregate = aggregate_event;
-        break;
-      }
-
-    default:
-      {
-        g_error ("Tried to use a choice for make_aggregate_event that hasn't "
-                 "been programmed.");
-      }
-    }
-}
-
-static void
-make_sequence_event (gint           choice,
-                     SequenceEvent *sequence)
-{
-  switch (choice)
-    {
-    case 0:
-      {
-        EventValue *event_values = g_new (EventValue, 3);
-        for (gint i = 0; i < 3; i++)
-          make_event_value (i, event_values + i);
-
-        SequenceEvent sequence_event =
-          {
-            1277u,
-            { 0x13, 0x37, 0x13, 0x37, 0x13, 0x37, 0x13, 0x37, 0x13, 0x37, 0x13,
-              0x37, 0x13, 0x37, 0x13, 0x37 },
-            event_values,
-            3
-          };
-        *sequence = sequence_event;
-        break;
-      }
-
-    case 1:
-      {
-        EventValue *event_values = g_new (EventValue, 2);
-        for (gint i = 0; i < 2; i++)
-          make_event_value (i + 3, event_values + i);
-
-        SequenceEvent sequence_event =
-          {
-            91912u,
-            { 0x13, 0x37, 0xd0, 0x0d, 0x13, 0x37, 0xd0, 0x0d, 0x13, 0x37, 0xd0,
-              0x0d, 0x13, 0x37, 0xd0, 0x0d },
-            event_values,
-            2
-          };
-        *sequence = sequence_event;
-        break;
-      }
-
-    case 2:
-      {
-        EventValue *event_values = g_new (EventValue, 4);
-        for (gint i = 0; i < 4; i++)
-          make_event_value (i + 5, event_values + i);
-
-        SequenceEvent sequence_event =
-          {
-            113u,
-            { 0xe1, 0xe1, 0xe1, 0xe1, 0xe1, 0xe1, 0xe1, 0xe1, 0xe1, 0xe1, 0xe1,
-              0xe1, 0xe1, 0xe1, 0xe1, 0xe1 },
-            event_values,
-            4
-          };
-        *sequence = sequence_event;
-        break;
-      }
-
-    default:
-      {
-        g_error ("Tried to use a choice for make_sequence_event that hasn't "
-                 "been programmed.");
-      }
-    }
-}
-
-/*
- * Stores a single singular event and asserts that it (and nothing else) was
- * stored.
+/* Returns the number of bytes the given variant will consume when stored in a
+ * persistent cache. See emer_circular_file_append for more details.
  */
-static gboolean
-store_single_singular_event (EmerPersistentCache *cache,
-                             capacity_t          *capacity)
+static guint64
+get_size_when_stored (GVariant *variant)
 {
-  SingularEvent singular_array[1];
-  make_singular_event (0, singular_array);
-
-  AggregateEvent aggregate_array[] = {};
-  SequenceEvent sequence_array [] = {};
-
-  gint num_singulars_stored, num_aggregates_stored, num_sequences_stored;
-
-  gboolean success =
-    emer_persistent_cache_store_metrics (cache,
-                                         singular_array,
-                                         aggregate_array,
-                                         sequence_array,
-                                         1, 0, 0,
-                                         &num_singulars_stored,
-                                         &num_aggregates_stored,
-                                         &num_sequences_stored,
-                                         capacity);
-
-  g_assert_cmpint (num_singulars_stored, ==, 1);
-  g_assert_cmpint (num_aggregates_stored, ==, 0);
-  g_assert_cmpint (num_sequences_stored, ==, 0);
-
-  return success;
-}
-
-/*
- * Stores a single aggregate event and asserts that it (and nothing else) was
- * stored.
- */
-static gboolean
-store_single_aggregate_event (EmerPersistentCache *cache,
-                              capacity_t          *capacity)
-{
-  SingularEvent singular_array[] = {};
-
-  AggregateEvent aggregate_array[1];
-  make_aggregate_event (0, aggregate_array);
-
-  SequenceEvent sequence_array[] = {};
-
-  gint num_singulars_stored, num_aggregates_stored, num_sequences_stored;
-
-  gboolean success =
-    emer_persistent_cache_store_metrics (cache,
-                                         singular_array,
-                                         aggregate_array,
-                                         sequence_array,
-                                         0, 1, 0,
-                                         &num_singulars_stored,
-                                         &num_aggregates_stored,
-                                         &num_sequences_stored,
-                                         capacity);
-
-  g_assert_cmpint (num_singulars_stored, ==, 0);
-  g_assert_cmpint (num_aggregates_stored, ==, 1);
-  g_assert_cmpint (num_sequences_stored, ==, 0);
-
-  return success;
-}
-
-/*
- * Stores a single sequence event and asserts that it (and nothing else) was
- * stored.
- */
-static gboolean
-store_single_sequence_event (EmerPersistentCache *cache,
-                             capacity_t          *capacity)
-{
-  SingularEvent singular_array[] = {};
-  AggregateEvent aggregate_array[] = {};
-
-  SequenceEvent sequence_array[1];
-  make_sequence_event (0, sequence_array);
-
-  gint num_singulars_stored, num_aggregates_stored, num_sequences_stored;
-
-  gboolean success =
-    emer_persistent_cache_store_metrics (cache,
-                                         singular_array,
-                                         aggregate_array,
-                                         sequence_array,
-                                         0, 0, 1,
-                                         &num_singulars_stored,
-                                         &num_aggregates_stored,
-                                         &num_sequences_stored,
-                                         capacity);
-
-  g_assert_cmpint (num_singulars_stored, ==, 0);
-  g_assert_cmpint (num_aggregates_stored, ==, 0);
-  g_assert_cmpint (num_sequences_stored, ==, 1);
-
-  return success;
+  gsize cost = emer_persistent_cache_cost (variant);
+  return sizeof (guint64) + cost;
 }
 
 static void
-make_many_events (SingularEvent  **singular_array,
-                  AggregateEvent **aggregate_array,
-                  SequenceEvent  **sequence_array,
-                  gint            *num_singulars_made,
-                  gint            *num_aggregates_made,
-                  gint            *num_sequences_made)
+assert_variants_equal (GVariant **actual_variants,
+                       GVariant **expected_variants,
+                       gsize      num_variants)
 {
-  *num_singulars_made = 4;
-  *singular_array = g_new (SingularEvent, *num_singulars_made);
-  for (gint i = 0; i < *num_singulars_made; i++)
-    make_singular_event (i, *singular_array + i);
-
-  *num_aggregates_made = 3;
-  *aggregate_array = g_new (AggregateEvent, *num_aggregates_made);
-  for (gint i = 0; i < *num_aggregates_made; i++)
-    make_aggregate_event (i, *aggregate_array + i);
-
-  *num_sequences_made = 3;
-  *sequence_array = g_new (SequenceEvent, *num_sequences_made);
-  for (gint i = 0; i < *num_sequences_made; i++)
-    make_sequence_event (i, *sequence_array + i);
-}
-
-static void
-free_variant_c_array (GVariant *array[])
-{
-  g_return_if_fail (array != NULL);
-
-  for (gint i = 0; array[i] != NULL; i++)
-    g_variant_unref (array[i]);
-  g_free (array);
-}
-
-static gint
-c_array_len (GVariant *array[])
-{
-  gint i;
-  for (i = 0; array[i] != NULL; i++)
-    ; // Do nothing.
-  return i;
-}
-
-static gboolean
-store_many (EmerPersistentCache *cache,
-            gint                *num_singulars_made,
-            gint                *num_aggregates_made,
-            gint                *num_sequences_made,
-            gint                *num_singulars_stored,
-            gint                *num_aggregates_stored,
-            gint                *num_sequences_stored,
-            capacity_t          *capacity)
-{
-  SingularEvent *singular_array;
-  AggregateEvent *aggregate_array;
-  SequenceEvent *sequence_array;
-
-  make_many_events (&singular_array,
-                    &aggregate_array,
-                    &sequence_array,
-                    num_singulars_made,
-                    num_aggregates_made,
-                    num_sequences_made);
-
-  gboolean success = emer_persistent_cache_store_metrics (cache,
-                                                          singular_array,
-                                                          aggregate_array,
-                                                          sequence_array,
-                                                          *num_singulars_made,
-                                                          *num_aggregates_made,
-                                                          *num_sequences_made,
-                                                          num_singulars_stored,
-                                                          num_aggregates_stored,
-                                                          num_sequences_stored,
-                                                          capacity);
-
-  g_free (singular_array);
-  g_free (aggregate_array);
-  for (gint i = 0; i < *num_sequences_made; i++)
-    g_free (sequence_array[i].event_values);
-  g_free (sequence_array);
-
-  return success;
-}
-
-static void
-assert_singulars_equal_variants (SingularEvent *singular_array,
-                                 gint           singular_array_length,
-                                 GVariant     **variants)
-{
-  for (gint i = 0; i < singular_array_length || variants[i] != NULL; i++)
+  if (num_variants == 0)
     {
-      g_assert_true (i < singular_array_length && variants[i] != NULL);
-
-      GVariant *singular_variant = singular_to_variant (singular_array + i);
-      g_assert_true (g_variant_equal (singular_variant, variants[i]));
-      g_variant_unref (singular_variant);
+      g_assert_null (actual_variants);
+      return;
     }
+
+  for (gsize i = 0; i < num_variants; i++)
+    g_assert_true (g_variant_equal (actual_variants[i], expected_variants[i]));
 }
 
 static void
-assert_aggregates_equal_variants (AggregateEvent *aggregate_array,
-                                  gint            aggregate_array_length,
-                                  GVariant      **variants)
+assert_variants_stored (EmerPersistentCache *cache,
+                        GVariant           **variants,
+                        gsize                num_variants)
 {
-  for (gint i = 0; i < aggregate_array_length || variants[i] != NULL; i++)
-    {
-      g_assert_true (i < aggregate_array_length && variants[i] != NULL);
+  /* This arbitrary value should be overwritten. */
+  gsize num_variants_stored = num_variants + 1;
 
-      GVariant *aggregate_variant = aggregate_to_variant (aggregate_array + i);
-      g_assert_true (g_variant_equal (aggregate_variant, variants[i]));
-      g_variant_unref (aggregate_variant);
-    }
-}
-
-static void
-assert_sequences_equal_variants (SequenceEvent *sequence_array,
-                                 gint           sequence_array_length,
-                                 GVariant     **variants)
-{
-  for (gint i = 0; i < sequence_array_length || variants[i] != NULL; i++)
-    {
-      g_assert_true (i < sequence_array_length && variants[i] != NULL);
-
-      GVariant *sequence_variant = sequence_to_variant (sequence_array + i);
-      g_assert_true (g_variant_equal (sequence_variant, variants[i]));
-      g_variant_unref (sequence_variant);
-    }
-}
-
-// ----- Actual Test Cases below ------
-
-static void
-test_persistent_cache_new_succeeds (gboolean     *unused,
-                                    gconstpointer dontuseme)
-{
   GError *error = NULL;
-  EmerPersistentCache *cache = make_testing_cache ();
-  g_assert_nonnull (cache);
-  g_object_unref (cache);
-  if (error != NULL)
-    g_error_free (error);
+  gboolean store_succeeded =
+    emer_persistent_cache_store (cache, variants, num_variants,
+                                 &num_variants_stored, &error);
+
   g_assert_no_error (error);
+  g_assert_true (store_succeeded);
+  g_assert_cmpuint (num_variants_stored, ==, num_variants);
 }
 
-/*
- * Test ensures the store function properly sets its out parameters, even if
- * no metrics are being stored via the call.
- */
-static void
-test_persistent_cache_store_sets_out_parameters (gboolean     *unused,
-                                                 gconstpointer dontuseme)
+static guint64
+assert_variants_read (EmerPersistentCache *cache,
+                      GVariant           **variants,
+                      gsize                num_variants)
 {
-  EmerPersistentCache *cache = make_testing_cache ();
+  GVariant **variants_read;
 
-  capacity_t capacity = 700; // Totally invalid value!
-  SingularEvent singular_array[] = {};
-  AggregateEvent aggregate_array[] = {};
-  SequenceEvent sequence_array [] = {};
+  gsize total_elem_size = 0;
+  gsize total_size_when_stored = 0;
+  for (gsize i = 0; i < num_variants; i++)
+    {
+      total_elem_size += emer_persistent_cache_cost (variants[i]);
+      total_size_when_stored += get_size_when_stored (variants[i]);
+    }
 
-  // Arbitrary values that should be overwritten:
-  gint num_singulars_stored = -1;
-  gint num_aggregates_stored = -50;
-  gint num_sequences_stored = 555;
+  /* These arbitrary values should be overwritten. */
+  gsize num_variants_read = num_variants + 1;
+  guint64 token = total_size_when_stored + 1;
 
-  g_assert_true (emer_persistent_cache_store_metrics (cache,
-                                                      singular_array,
-                                                      aggregate_array,
-                                                      sequence_array,
-                                                      0, 0, 0,
-                                                      &num_singulars_stored,
-                                                      &num_aggregates_stored,
-                                                      &num_sequences_stored,
-                                                      &capacity));
-
-  // An empty cache should be in the LOW capacity state.
-  g_assert_cmpint (capacity, ==, CAPACITY_LOW);
-  g_assert_cmpint (num_singulars_stored, ==, 0);
-  g_assert_cmpint (num_aggregates_stored, ==, 0);
-  g_assert_cmpint (num_sequences_stored, ==, 0);
-
-  g_object_unref (cache);
-}
-
-static void
-test_persistent_cache_store_one_singular_event_succeeds (gboolean     *unused,
-                                                         gconstpointer dontuseme)
-{
-  EmerPersistentCache *cache = make_testing_cache ();
-  capacity_t capacity;
-  g_assert_true (store_single_singular_event (cache, &capacity));
-  g_object_unref (cache);
-  g_assert_cmpint (capacity, ==, CAPACITY_LOW);
-}
-
-static void
-test_persistent_cache_store_one_aggregate_event_succeeds (gboolean     *unused,
-                                                          gconstpointer dontuseme)
-{
-  EmerPersistentCache *cache = make_testing_cache ();
-  capacity_t capacity;
-  g_assert_true (store_single_aggregate_event (cache, &capacity));
-  g_object_unref (cache);
-  g_assert_cmpint (capacity, ==, CAPACITY_LOW);
-}
-
-static void
-test_persistent_cache_store_one_sequence_event_succeeds (gboolean     *unused,
-                                                         gconstpointer dontuseme)
-{
-  EmerPersistentCache *cache = make_testing_cache ();
-  capacity_t capacity;
-  g_assert_true (store_single_sequence_event (cache, &capacity));
-  g_object_unref (cache);
-  g_assert_cmpint (capacity, ==, CAPACITY_LOW);
-}
-
-static void
-test_persistent_cache_store_one_of_each_succeeds (gboolean     *unused,
-                                                  gconstpointer dontuseme)
-{
-  EmerPersistentCache *cache = make_testing_cache ();
-
-  SingularEvent singular_array[1];
-  make_singular_event (0, singular_array);
-
-  AggregateEvent aggregate_array[1];
-  make_aggregate_event (0, aggregate_array);
-
-  SequenceEvent sequence_array[1];
-  make_sequence_event (0, sequence_array);
-
-  gint num_singulars_stored, num_aggregates_stored, num_sequences_stored;
-  capacity_t capacity;
-
-  gboolean success =
-    emer_persistent_cache_store_metrics (cache,
-                                         singular_array,
-                                         aggregate_array,
-                                         sequence_array,
-                                         1, 1, 1,
-                                         &num_singulars_stored,
-                                         &num_aggregates_stored,
-                                         &num_sequences_stored,
-                                         &capacity);
-  g_object_unref (cache);
-
-  g_free (sequence_array[0].event_values);
-
-  g_assert_true (success);
-
-  g_assert_cmpint (num_singulars_stored, ==, 1);
-  g_assert_cmpint (num_aggregates_stored, ==, 1);
-  g_assert_cmpint (num_sequences_stored, ==, 1);
-
-  g_assert_cmpint (capacity, ==, CAPACITY_LOW);
-}
-
-static void
-test_persistent_cache_store_many_succeeds (gboolean     *unused,
-                                           gconstpointer dontuseme)
-{
-  EmerPersistentCache *cache = make_testing_cache ();
-
-  gint num_singulars_made, num_aggregates_made, num_sequences_made;
-  gint num_singulars_stored, num_aggregates_stored, num_sequences_stored;
-  capacity_t capacity;
-  gboolean success =
-    store_many (cache, &num_singulars_made, &num_aggregates_made,
-                &num_sequences_made, &num_singulars_stored,
-                &num_aggregates_stored, &num_sequences_stored, &capacity);
-  g_object_unref (cache);
-  g_assert_true (success);
-
-  g_assert_cmpint (num_singulars_stored, ==, num_singulars_made);
-  g_assert_cmpint (num_aggregates_stored, ==, num_aggregates_made);
-  g_assert_cmpint (num_sequences_stored, ==, num_sequences_made);
-}
-
-static void
-test_persistent_cache_store_when_full_succeeds (gboolean     *unused,
-                                                gconstpointer dontuseme)
-{
   GError *error = NULL;
+  gboolean read_succeeded =
+    emer_persistent_cache_read (cache, &variants_read, total_elem_size,
+                                &num_variants_read, &token, &error);
+
+  g_assert_no_error (error);
+  g_assert_true (read_succeeded);
+  g_assert_cmpuint (num_variants_read, ==, num_variants);
+  assert_variants_equal (variants_read, variants, num_variants);
+  g_assert_cmpuint (token, ==, total_size_when_stored);
+
+  destroy_variants (variants_read, num_variants);
+
+  return token;
+}
+
+static void
+assert_cache_is_empty (EmerPersistentCache *cache)
+{
+  g_assert_false (emer_persistent_cache_has_more (cache, 0));
+
+  GVariant **variants;
+
+  /* These arbitrary values should be overwritten. */
+  gsize num_variants = 1;
+  guint64 token = 1;
+
+  GError *error = NULL;
+  gboolean read_succeeded =
+    emer_persistent_cache_read (cache, &variants, G_MAXSIZE, &num_variants,
+                                &token, &error);
+
+  g_assert_no_error (error);
+  g_assert_true (read_succeeded);
+  g_assert_null (variants);
+  g_assert_cmpuint (num_variants, ==, 0);
+  g_assert_cmpuint (token, ==, 0);
+}
+
+static void
+assert_variants_removed (EmerPersistentCache *cache,
+                         GVariant           **variants,
+                         gsize                num_variants)
+{
+  guint64 token = assert_variants_read (cache, variants, num_variants);
+  GError *error = NULL;
+  gboolean remove_succeeded =
+    emer_persistent_cache_remove (cache, token, &error);
+
+  g_assert_no_error (error);
+  g_assert_true (remove_succeeded);
+}
+
+/* ----- Actual Test Cases below ------ */
+
+static void
+test_persistent_cache_new (gboolean     *unused,
+                           gconstpointer dontuseme)
+{
+  EmerPersistentCache *cache = make_testing_cache ();
+  g_object_unref (cache);
+}
+
+static void
+test_persistent_cache_cost (gboolean     *unused,
+                            gconstpointer dontuseme)
+{
+  GPtrArray *variants = make_many_variants ();
+  for (gsize i = 0; i < variants->len; i++)
+    {
+      GVariant *curr_variant = g_ptr_array_index (variants, i);
+      gsize actual_cost = emer_persistent_cache_cost (curr_variant);
+      const gchar *type_string = g_variant_get_type_string (curr_variant);
+      gsize type_string_length = strlen (type_string) + 1;
+      gsize variant_size = g_variant_get_size (curr_variant);
+      gsize expected_cost = type_string_length + variant_size;
+      g_assert_cmpuint (actual_cost, ==, expected_cost);
+    }
+
+  g_ptr_array_unref (variants);
+}
+
+static void
+test_persistent_cache_store_none (gboolean     *unused,
+                                  gconstpointer dontuseme)
+{
+  EmerPersistentCache *cache = make_testing_cache ();
+
+  assert_variants_stored (cache, NULL /* variants */, 0);
+
+  g_object_unref (cache);
+}
+
+static void
+test_persistent_cache_store_one (gboolean     *unused,
+                                 gconstpointer dontuseme)
+{
+  EmerPersistentCache *cache = make_testing_cache ();
+
+  GVariant *variants[] = { make_variant (0) };
+  gsize num_variants = G_N_ELEMENTS (variants);
+  assert_variants_stored (cache, variants, num_variants);
+
+  g_object_unref (cache);
+}
+
+static void
+test_persistent_cache_store_many (gboolean     *unused,
+                                  gconstpointer dontuseme)
+{
+  EmerPersistentCache *cache = make_testing_cache ();
+
+  GPtrArray *variants = make_many_variants ();
+  assert_variants_stored (cache, (GVariant **) variants->pdata, variants->len);
+  g_ptr_array_unref (variants);
+
+  g_object_unref (cache);
+}
+
+static void
+test_persistent_cache_store_when_full (gboolean     *unused,
+                                       gconstpointer dontuseme)
+{
   EmerCacheSizeProvider *cache_size_provider =
     emer_cache_size_provider_new_full (TEST_DIRECTORY TEST_CACHE_SIZE_FILE);
   EmerBootIdProvider *boot_id_provider =
     emer_boot_id_provider_new_full (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   EmerCacheVersionProvider *cache_version_provider =
     emer_cache_version_provider_new_full (TEST_DIRECTORY TEST_CACHE_VERSION_FILE);
+  GError *error = NULL;
   EmerPersistentCache *cache =
-    emer_persistent_cache_new_full (NULL, &error, TEST_DIRECTORY,
-                                    cache_size_provider, boot_id_provider,
-                                    cache_version_provider,
-                                    TEST_UPDATE_OFFSET_INTERVAL);
+    emer_persistent_cache_new_full (TEST_DIRECTORY, cache_size_provider,
+                                    boot_id_provider, cache_version_provider,
+                                    TEST_UPDATE_OFFSET_INTERVAL, &error);
   g_assert_no_error (error);
   g_assert_nonnull (cache);
 
   g_object_unref (boot_id_provider);
   g_object_unref (cache_version_provider);
 
-  capacity_t capacity = CAPACITY_LOW;
-
-  // Store a ton, until it is full.
-  // TODO: Find a less hacky way of doing this.
   guint64 max_cache_size =
     emer_cache_size_provider_get_max_cache_size (cache_size_provider);
   g_object_unref (cache_size_provider);
-  gint iterations = max_cache_size / 150;
-  for (gint i = 0; i < iterations; i++)
+
+  GVariant *variant = make_variant (0);
+  g_variant_ref_sink (variant);
+  gsize num_variants = max_cache_size / get_size_when_stored (variant);
+  GVariant *variants[num_variants];
+  for (gsize i = 0; i < num_variants; i++)
+    variants[i] = variant;
+
+  assert_variants_stored (cache, variants, num_variants);
+
+  /* This arbitrary value should be overwritten. */
+  gsize num_variants_stored = 1;
+
+  gboolean store_succeeded =
+    emer_persistent_cache_store (cache, &variant, 1, &num_variants_stored,
+                                 &error);
+
+  g_assert_no_error (error);
+  g_assert_true (store_succeeded);
+  g_assert_cmpuint (num_variants_stored, ==, 0);
+
+  g_variant_unref (variant);
+  g_object_unref (cache);
+}
+
+static void
+test_persistent_cache_read_none (gboolean     *unused,
+                                 gconstpointer dontuseme)
+{
+  EmerPersistentCache *cache = make_testing_cache ();
+
+  assert_variants_stored (cache, NULL /* variants */, 0);
+  assert_variants_read (cache, NULL /* variants */, 0);
+
+  g_object_unref (cache);
+}
+
+static void
+test_persistent_cache_read_one (gboolean     *unused,
+                                gconstpointer dontuseme)
+{
+  EmerPersistentCache *cache = make_testing_cache ();
+
+  GVariant *variant = make_variant (0);
+  g_variant_ref_sink (variant);
+  GVariant *variants[] = { variant };
+  gsize num_variants = G_N_ELEMENTS (variants);
+  assert_variants_stored (cache, variants, num_variants);
+  assert_variants_read (cache, variants, num_variants);
+
+  g_variant_unref (variant);
+  g_object_unref (cache);
+}
+
+static void
+test_persistent_cache_read_many (gboolean     *unused,
+                                 gconstpointer dontuseme)
+{
+  EmerPersistentCache *cache = make_testing_cache ();
+
+  GPtrArray *variants = make_many_variants ();
+
+  assert_variants_stored (cache, (GVariant **) variants->pdata, variants->len);
+  assert_variants_read (cache, (GVariant **) variants->pdata, variants->len);
+
+  g_ptr_array_unref (variants);
+  g_object_unref (cache);
+}
+
+static void
+test_persistent_cache_read_when_empty (gboolean     *unused,
+                                       gconstpointer dontuseme)
+{
+  EmerPersistentCache *cache = make_testing_cache ();
+  assert_cache_is_empty (cache);
+  g_object_unref (cache);
+}
+
+static void
+test_persistent_cache_has_more (gboolean     *unused,
+                                gconstpointer dontuseme)
+{
+  EmerPersistentCache *cache = make_testing_cache ();
+
+  assert_cache_is_empty (cache);
+
+  GPtrArray *variants = make_many_variants ();
+
+  assert_variants_stored (cache, (GVariant **) variants->pdata, variants->len);
+  g_assert_true (emer_persistent_cache_has_more (cache, 0));
+
+  guint64 token =
+    assert_variants_read (cache, (GVariant **) variants->pdata,
+                          variants->len - 1);
+  g_assert_true (emer_persistent_cache_has_more (cache, token));
+
+  token =
+    assert_variants_read (cache, (GVariant **) variants->pdata, variants->len);
+  g_assert_false (emer_persistent_cache_has_more (cache, token));
+
+  assert_variants_removed (cache, (GVariant **) variants->pdata, 1);
+  g_assert_true (emer_persistent_cache_has_more (cache, 0));
+
+  assert_variants_stored (cache, (GVariant **) variants->pdata, variants->len);
+  g_assert_true (emer_persistent_cache_has_more (cache, 0));
+
+  gsize curr_length = variants->len;
+  for (gsize i = 0; i < curr_length; i++)
     {
-      gint num_singulars_made, num_aggregates_made, num_sequences_made;
-      gint num_singulars_stored, num_aggregates_stored, num_sequences_stored;
-      gboolean success =
-        store_many (cache, &num_singulars_made, &num_aggregates_made,
-                    &num_sequences_made, &num_singulars_stored,
-                    &num_aggregates_stored, &num_sequences_stored, &capacity);
-      g_assert_true (success);
-
-      if (capacity == CAPACITY_MAX)
-        {
-          g_assert_cmpint (num_singulars_stored, <=, num_singulars_made);
-          g_assert_cmpint (num_aggregates_stored, <=, num_aggregates_made);
-          g_assert_cmpint (num_sequences_stored, <=, num_sequences_made);
-          break;
-        }
-
-      g_assert_cmpint (num_singulars_stored, ==, num_singulars_made);
-      g_assert_cmpint (num_aggregates_stored, ==, num_aggregates_made);
-      g_assert_cmpint (num_sequences_stored, ==, num_sequences_made);
+      GVariant *curr_variant = g_ptr_array_index (variants, i);
+      g_variant_ref (curr_variant);
+      g_ptr_array_add (variants, curr_variant);
     }
 
+  g_ptr_array_remove_index (variants, 0);
+
+  token =
+    assert_variants_read (cache, (GVariant **) variants->pdata,
+                          variants->len - 1);
+  g_assert_true (emer_persistent_cache_has_more (cache, token));
+
+  token =
+    assert_variants_read (cache, (GVariant **) variants->pdata, variants->len);
+  g_assert_false (emer_persistent_cache_has_more (cache, token));
+
+  assert_variants_removed (cache, (GVariant **) variants->pdata, variants->len);
+  assert_cache_is_empty (cache);
+
+  g_ptr_array_unref (variants);
   g_object_unref (cache);
-  g_assert_cmpint (capacity, ==, CAPACITY_MAX);
 }
 
 static void
-test_persistent_cache_drain_one_singular_event_succeeds (gboolean     *unused,
-                                                         gconstpointer dontuseme)
+test_persistent_cache_remove_none (gboolean     *unused,
+                                   gconstpointer dontuseme)
 {
   EmerPersistentCache *cache = make_testing_cache ();
 
-  SingularEvent singulars_stored[1];
-  make_singular_event (1, singulars_stored);
-  singular_event_own (singulars_stored);
+  assert_variants_stored (cache, NULL /* variants */, 0);
+  assert_variants_removed (cache, NULL /* variants */, 0);
+  assert_cache_is_empty (cache);
 
-  AggregateEvent aggregates_stored[] = {};
-  SequenceEvent sequences_stored[] = {};
-
-  gint num_singulars_stored, num_aggregates_stored, num_sequences_stored;
-  capacity_t capacity;
-
-  emer_persistent_cache_store_metrics (cache,
-                                       singulars_stored,
-                                       aggregates_stored,
-                                       sequences_stored,
-                                       1, 0, 0,
-                                       &num_singulars_stored,
-                                       &num_aggregates_stored,
-                                       &num_sequences_stored,
-                                       &capacity);
-
-  GVariant **singulars_drained, **aggregates_drained, **sequences_drained;
-  gboolean success = emer_persistent_cache_drain_metrics (cache,
-                                                          &singulars_drained,
-                                                          &aggregates_drained,
-                                                          &sequences_drained,
-                                                          MAX_BYTES_TO_READ);
   g_object_unref (cache);
-
-  g_assert_true (success);
-
-  assert_singulars_equal_variants (singulars_stored, 1, singulars_drained);
-  g_assert_cmpint (c_array_len (aggregates_drained), ==, 0);
-  g_assert_cmpint (c_array_len (sequences_drained), ==, 0);
-
-  trash_singular_event (singulars_stored);
-
-  free_variant_c_array (singulars_drained);
-  free_variant_c_array (aggregates_drained);
-  free_variant_c_array (sequences_drained);
 }
 
 static void
-test_persistent_cache_drain_one_aggregate_event_succeeds (gboolean     *unused,
-                                                          gconstpointer dontuseme)
+test_persistent_cache_remove_one (gboolean     *unused,
+                                  gconstpointer dontuseme)
 {
   EmerPersistentCache *cache = make_testing_cache ();
 
-  SingularEvent singulars_stored[] = {};
+  GVariant *variant = make_variant (0);
+  g_variant_ref_sink (variant);
+  GVariant *variants[] = { variant };
+  gsize num_variants = G_N_ELEMENTS (variants);
+  assert_variants_stored (cache, variants, num_variants);
+  assert_variants_removed (cache, variants, num_variants);
+  g_variant_unref (variant);
 
-  AggregateEvent aggregates_stored[1];
-  make_aggregate_event (1, aggregates_stored);
-  aggregate_event_own (aggregates_stored);
-
-  SequenceEvent sequences_stored[] = {};
-
-  gint num_singulars_stored, num_aggregates_stored, num_sequences_stored;
-  capacity_t capacity;
-
-  emer_persistent_cache_store_metrics (cache,
-                                       singulars_stored,
-                                       aggregates_stored,
-                                       sequences_stored,
-                                       0, 1, 0,
-                                       &num_singulars_stored,
-                                       &num_aggregates_stored,
-                                       &num_sequences_stored,
-                                       &capacity);
-
-  GVariant **singulars_drained, **aggregates_drained, **sequences_drained;
-  gboolean success = emer_persistent_cache_drain_metrics (cache,
-                                                          &singulars_drained,
-                                                          &aggregates_drained,
-                                                          &sequences_drained,
-                                                          MAX_BYTES_TO_READ);
+  assert_cache_is_empty (cache);
   g_object_unref (cache);
-
-  g_assert_true (success);
-
-  g_assert_cmpint (c_array_len (singulars_drained), ==, 0);
-  assert_aggregates_equal_variants (aggregates_stored, 1, aggregates_drained);
-  g_assert_cmpint (c_array_len (sequences_drained), ==, 0);
-
-  trash_aggregate_event (aggregates_stored);
-
-  free_variant_c_array (singulars_drained);
-  free_variant_c_array (aggregates_drained);
-  free_variant_c_array (sequences_drained);
 }
 
 static void
-test_persistent_cache_drain_one_sequence_event_succeeds (gboolean     *unused,
-                                                         gconstpointer dontuseme)
+test_persistent_cache_remove_many (gboolean     *unused,
+                                   gconstpointer dontuseme)
 {
   EmerPersistentCache *cache = make_testing_cache ();
 
-  SingularEvent singulars_stored[] = {};
-  AggregateEvent aggregates_stored[] = {};
+  GPtrArray *variants = make_many_variants ();
 
-  SequenceEvent sequences_stored[1];
-  make_sequence_event (1, sequences_stored);
-  sequence_event_own (sequences_stored);
+  assert_variants_stored (cache, (GVariant **) variants->pdata, variants->len);
+  assert_variants_removed (cache, (GVariant **) variants->pdata, variants->len);
+  g_ptr_array_unref (variants);
 
-  gint num_singulars_stored, num_aggregates_stored, num_sequences_stored;
-  capacity_t capacity;
-
-  emer_persistent_cache_store_metrics (cache,
-                                       singulars_stored,
-                                       aggregates_stored,
-                                       sequences_stored,
-                                       0, 0, 1,
-                                       &num_singulars_stored,
-                                       &num_aggregates_stored,
-                                       &num_sequences_stored,
-                                       &capacity);
-
-  g_assert_cmpint (num_sequences_stored, ==, 1);
-
-  GVariant **singulars_drained, **aggregates_drained, **sequences_drained;
-
-  gboolean success = emer_persistent_cache_drain_metrics (cache,
-                                                          &singulars_drained,
-                                                          &aggregates_drained,
-                                                          &sequences_drained,
-                                                          MAX_BYTES_TO_READ);
+  assert_cache_is_empty (cache);
   g_object_unref (cache);
-
-  g_assert_true (success);
-
-  g_assert_cmpint (c_array_len (singulars_drained), ==, 0);
-  g_assert_cmpint (c_array_len (aggregates_drained), ==, 0);
-  assert_sequences_equal_variants (sequences_stored, 1, sequences_drained);
-
-  trash_sequence_event (sequences_stored);
-
-  free_variant_c_array (singulars_drained);
-  free_variant_c_array (aggregates_drained);
-  free_variant_c_array (sequences_drained);
 }
 
 static void
-test_persistent_cache_drain_many_succeeds (gboolean     *unused,
-                                           gconstpointer dontuseme)
+test_persistent_cache_remove_when_empty (gboolean     *unused,
+                                         gconstpointer dontuseme)
 {
   EmerPersistentCache *cache = make_testing_cache ();
 
-  // Fill it up first.
-  SingularEvent *singulars_stored;
-  AggregateEvent *aggregates_stored;
-  SequenceEvent *sequences_stored;
+  assert_variants_removed (cache, NULL /* variants */, 0);
+  assert_cache_is_empty (cache);
 
-  gint num_singulars_made, num_aggregates_made, num_sequences_made;
-
-  make_many_events (&singulars_stored,
-                    &aggregates_stored,
-                    &sequences_stored,
-                    &num_singulars_made,
-                    &num_aggregates_made,
-                    &num_sequences_made);
-
-  singular_buffer_own (singulars_stored, num_singulars_made);
-  aggregate_buffer_own (aggregates_stored, num_aggregates_made);
-  sequence_buffer_own (sequences_stored, num_sequences_made);
-
-  gint num_singulars_stored, num_aggregates_stored, num_sequences_stored;
-  capacity_t capacity;
-
-  emer_persistent_cache_store_metrics (cache,
-                                       singulars_stored,
-                                       aggregates_stored,
-                                       sequences_stored,
-                                       num_singulars_made,
-                                       num_aggregates_made,
-                                       num_sequences_made,
-                                       &num_singulars_stored,
-                                       &num_aggregates_stored,
-                                       &num_sequences_stored,
-                                       &capacity);
-
-  // Check if we get the same things back.
-  GVariant **singulars_drained, **aggregates_drained, **sequences_drained;
-  gboolean success = emer_persistent_cache_drain_metrics (cache,
-                                                          &singulars_drained,
-                                                          &aggregates_drained,
-                                                          &sequences_drained,
-                                                          MAX_BYTES_TO_READ);
   g_object_unref (cache);
-
-  g_assert_true (success);
-  assert_singulars_equal_variants (singulars_stored, num_singulars_made,
-                                   singulars_drained);
-  assert_aggregates_equal_variants (aggregates_stored, num_aggregates_made,
-                                    aggregates_drained);
-  assert_sequences_equal_variants (sequences_stored, num_sequences_made,
-                                   sequences_drained);
-
-  free_singular_buffer (singulars_stored, num_singulars_made);
-  free_aggregate_buffer (aggregates_stored, num_aggregates_made);
-  free_sequence_buffer (sequences_stored, num_sequences_made);
-
-  free_variant_c_array (singulars_drained);
-  free_variant_c_array (aggregates_drained);
-  free_variant_c_array (sequences_drained);
 }
 
 static void
-test_persistent_cache_drain_empty_succeeds (gboolean     *unused,
-                                            gconstpointer dontuseme)
+test_persistent_cache_purges_when_out_of_date (gboolean     *unused,
+                                               gconstpointer dontuseme)
 {
-  EmerPersistentCache *cache = make_testing_cache ();
-  GVariant **singulars_drained, **aggregates_drained, **sequences_drained;
-  gboolean success = emer_persistent_cache_drain_metrics (cache,
-                                                          &singulars_drained,
-                                                          &aggregates_drained,
-                                                          &sequences_drained,
-                                                          MAX_BYTES_TO_READ);
-  g_object_unref (cache);
-
-  g_assert_true (success);
-
-  g_assert_cmpint (c_array_len (singulars_drained), ==, 0);
-  g_assert_cmpint (c_array_len (aggregates_drained), ==, 0);
-  g_assert_cmpint (c_array_len (sequences_drained), ==, 0);
-
-  free_variant_c_array (singulars_drained);
-  free_variant_c_array (aggregates_drained);
-  free_variant_c_array (sequences_drained);
-}
-
-static void
-test_persistent_cache_purges_when_out_of_date_succeeds (gboolean     *unused,
-                                                        gconstpointer dontuseme)
-{
-  GError *error = NULL;
   EmerCacheSizeProvider *cache_size_provider =
     emer_cache_size_provider_new_full (TEST_DIRECTORY TEST_CACHE_SIZE_FILE);
   EmerBootIdProvider *boot_id_provider =
     emer_boot_id_provider_new_full (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   EmerCacheVersionProvider *cache_version_provider =
     emer_cache_version_provider_new_full (TEST_DIRECTORY TEST_CACHE_VERSION_FILE);
+  GError *error = NULL;
   EmerPersistentCache *cache =
-    emer_persistent_cache_new_full (NULL, &error, TEST_DIRECTORY,
-                                    cache_size_provider, boot_id_provider,
-                                    cache_version_provider,
-                                    TEST_UPDATE_OFFSET_INTERVAL);
+    emer_persistent_cache_new_full (TEST_DIRECTORY, cache_size_provider,
+                                    boot_id_provider, cache_version_provider,
+                                    TEST_UPDATE_OFFSET_INTERVAL, &error);
   g_assert_no_error (error);
   g_assert_nonnull (cache);
 
   g_object_unref (cache_size_provider);
   g_object_unref (boot_id_provider);
 
-  gint num_singulars_made, num_aggregates_made, num_sequences_made;
-  gint num_singulars_stored, num_aggregates_stored, num_sequences_stored;
-  capacity_t capacity;
-
-  store_many (cache, &num_singulars_made, &num_aggregates_made,
-              &num_sequences_made, &num_singulars_stored,
-              &num_aggregates_stored, &num_sequences_stored, &capacity);
+  GPtrArray *variants = make_many_variants ();
+  assert_variants_stored (cache, (GVariant **) variants->pdata, variants->len);
+  g_ptr_array_unref (variants);
 
   gint current_version;
   gboolean get_succeeded =
@@ -1406,24 +828,19 @@ test_persistent_cache_purges_when_out_of_date_succeeds (gboolean     *unused,
   g_object_unref (cache_version_provider);
   g_object_unref (cache);
 
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                         "Failed to unlink old cache file " TEST_DIRECTORY
+                         "cache_individual.metrics. Error: *.");
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                         "Failed to unlink old cache file " TEST_DIRECTORY
+                         "cache_aggregate.metrics. Error: *.");
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                         "Failed to unlink old cache file " TEST_DIRECTORY
+                         "cache_sequence.metrics. Error: *.");
   EmerPersistentCache *cache2 = make_testing_cache ();
-
-  // Metrics should all be purged now.
-  GVariant **singulars_drained, **aggregates_drained, **sequences_drained;
-  emer_persistent_cache_drain_metrics (cache2,
-                                       &singulars_drained,
-                                       &aggregates_drained,
-                                       &sequences_drained,
-                                       MAX_BYTES_TO_READ);
+  g_test_assert_expected_messages ();
+  assert_cache_is_empty (cache2);
   g_object_unref (cache2);
-
-  g_assert_cmpint (c_array_len (singulars_drained), ==, 0);
-  g_assert_cmpint (c_array_len (aggregates_drained), ==, 0);
-  g_assert_cmpint (c_array_len (sequences_drained), ==, 0);
-
-  free_variant_c_array (singulars_drained);
-  free_variant_c_array (aggregates_drained);
-  free_variant_c_array (sequences_drained);
 }
 
 /*
@@ -1750,37 +1167,6 @@ test_persistent_cache_get_offset_can_build_boot_metadata_file (gboolean     *unu
   g_object_unref (cache);
 }
 
-// Tests for required libraries:
-
-/*
- * We include this test because we are relying on this function returning zero
- * when an empty file is read to indicate we don't need to overwrite an empty
- * file. This will preserve some lifetime on our users' storage.
- */
-static void
-test_g_file_measure_disk_usage_returns_zero_on_empty_file (gboolean     *unused,
-                                                           gconstpointer dontuseme)
-{
-  GFile *file = g_file_new_for_path (TEST_DIRECTORY "empty_file");
-
-  GError *error = NULL;
-  g_file_replace_contents (file, "", 0, NULL, FALSE,
-                           G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL,
-                           &error);
-  g_assert_no_error (error);
-
-  guint64 disk_usage = 555; // Arbitrary non-zero value
-  gboolean measure_succeeded =
-    g_file_measure_disk_usage (file, G_FILE_MEASURE_REPORT_ANY_ERROR, NULL,
-                               NULL, NULL, &disk_usage, NULL, NULL, &error);
-  g_assert_true (measure_succeeded);
-  g_assert_no_error (error);
-  g_assert_cmpint (disk_usage, ==, 0);
-
-  g_object_unref (file);
-  g_unlink (TEST_DIRECTORY "empty_file");
-}
-
 int
 main (int                argc,
       const char * const argv[])
@@ -1791,34 +1177,36 @@ main (int                argc,
 #define ADD_CACHE_TEST_FUNC(path, func) \
   g_test_add((path), gboolean, NULL, setup, (func), teardown)
 
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/new-succeeds",
-                       test_persistent_cache_new_succeeds);
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/store-sets-out-parameters",
-                       test_persistent_cache_store_sets_out_parameters);
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/store-one-singular-event-succeeds",
-                       test_persistent_cache_store_one_singular_event_succeeds);
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/store-one-aggregate-event-succeeds",
-                       test_persistent_cache_store_one_aggregate_event_succeeds);
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/store-one-sequence-event-succeeds",
-                       test_persistent_cache_store_one_sequence_event_succeeds);
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/store-one-of-each-succeeds",
-                       test_persistent_cache_store_one_of_each_succeeds);
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/store-many-succeeds",
-                       test_persistent_cache_store_many_succeeds);
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/store-when-full-succeeds",
-                       test_persistent_cache_store_when_full_succeeds);
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/drain-one-singular-event-succeeds",
-                       test_persistent_cache_drain_one_singular_event_succeeds);
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/drain-one-aggregate-event-succeeds",
-                       test_persistent_cache_drain_one_aggregate_event_succeeds);
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/drain-one-sequence-event-succeeds",
-                       test_persistent_cache_drain_one_sequence_event_succeeds);
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/drain-many-succeeds",
-                       test_persistent_cache_drain_many_succeeds);
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/drain-empty-succeeds",
-                       test_persistent_cache_drain_empty_succeeds);
-  ADD_CACHE_TEST_FUNC ("/persistent-cache/purges-when-out-of-date-succeeds",
-                       test_persistent_cache_purges_when_out_of_date_succeeds);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/new", test_persistent_cache_new);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/cost", test_persistent_cache_cost);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/store-none",
+                       test_persistent_cache_store_none);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/store-one",
+                       test_persistent_cache_store_one);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/store-many",
+                       test_persistent_cache_store_many);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/store-when-full",
+                       test_persistent_cache_store_when_full);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/read-none",
+                       test_persistent_cache_read_none);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/read-one",
+                       test_persistent_cache_read_one);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/read-many",
+                       test_persistent_cache_read_many);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/read-when-empty",
+                       test_persistent_cache_read_when_empty);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/has-more",
+                       test_persistent_cache_has_more);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/remove-none",
+                       test_persistent_cache_remove_none);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/remove-one",
+                       test_persistent_cache_remove_one);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/remove-many",
+                       test_persistent_cache_remove_many);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/remove-when-empty",
+                       test_persistent_cache_remove_when_empty);
+  ADD_CACHE_TEST_FUNC ("/persistent-cache/purges-when-out-of-date",
+                       test_persistent_cache_purges_when_out_of_date);
   ADD_CACHE_TEST_FUNC ("/persistent-cache/builds-boot-metadata-file",
                        test_persistent_cache_builds_boot_metadata_file);
   ADD_CACHE_TEST_FUNC ("/persistent-cache/computes-reasonable-offset",
@@ -1835,8 +1223,6 @@ main (int                argc,
                        test_persistent_cache_updates_timestamps_on_finalize);
   ADD_CACHE_TEST_FUNC ("/persistent-cache/get-offset-can-build-boot-metadata-file",
                        test_persistent_cache_get_offset_can_build_boot_metadata_file);
-  ADD_CACHE_TEST_FUNC ("/g-file/measure-disk-usage-returns-zero-on-empty-file",
-                       test_g_file_measure_disk_usage_returns_zero_on_empty_file);
 #undef ADD_CACHE_TEST_FUNC
 
   return g_test_run ();

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -1398,9 +1398,9 @@ test_persistent_cache_purges_when_out_of_date_succeeds (gboolean     *unused,
   gboolean set_succeeded =
     emer_cache_version_provider_set_version (cache_version_provider,
                                              current_version - 1, &error);
+  g_assert_no_error (error);
   g_assert_true (set_succeeded);
 
-  g_assert_no_error (error);
   g_object_unref (cache_version_provider);
   g_object_unref (cache);
 
@@ -1441,8 +1441,8 @@ test_persistent_cache_builds_boot_metadata_file (gboolean     *unused,
   GError *error = NULL;
   gboolean get_succeeded =
     emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
-  g_assert_true (get_succeeded);
   g_assert_no_error (error);
+  g_assert_true (get_succeeded);
 
   gint64 first_offset = read_offset ();
 
@@ -1452,8 +1452,8 @@ test_persistent_cache_builds_boot_metadata_file (gboolean     *unused,
 
   get_succeeded =
     emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
-  g_assert_true (get_succeeded);
   g_assert_no_error (error);
+  g_assert_true (get_succeeded);
 
   g_assert_true (boot_timestamp_is_valid (relative_time, absolute_time));
   gint64 second_offset = read_offset();
@@ -1528,8 +1528,8 @@ test_persistent_cache_does_not_compute_offset_when_boot_id_is_same (gboolean    
   GError *error = NULL;
   gboolean get_succeeded =
     emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
-  g_assert_true (get_succeeded);
   g_assert_no_error (error);
+  g_assert_true (get_succeeded);
   g_assert_true (boot_offset_was_reset ());
 
   gint64 relative_time;
@@ -1547,8 +1547,8 @@ test_persistent_cache_does_not_compute_offset_when_boot_id_is_same (gboolean    
   get_succeeded =
     emer_persistent_cache_get_boot_time_offset (cache2, NULL, &error, TRUE);
 
-  g_assert_true (get_succeeded);
   g_assert_no_error (error);
+  g_assert_true (get_succeeded);
 
   g_assert_true (boot_timestamp_is_valid (relative_time, absolute_time));
   gint64 second_offset = read_offset ();
@@ -1561,8 +1561,8 @@ test_persistent_cache_does_not_compute_offset_when_boot_id_is_same (gboolean    
 
   get_succeeded =
     emer_persistent_cache_get_boot_time_offset (cache3, NULL, &error, TRUE);
-  g_assert_true (get_succeeded);
   g_assert_no_error (error);
+  g_assert_true (get_succeeded);
 
   gint64 third_offset = read_offset ();
   g_assert_cmpint (third_offset, ==, second_offset);
@@ -1585,8 +1585,8 @@ test_persistent_cache_reads_cached_boot_offset (gboolean     *unused,
   gboolean get_succeeded =
     emer_persistent_cache_get_boot_time_offset (cache, &first_offset, &error,
                                                 TRUE);
-  g_assert_true (get_succeeded);
   g_assert_no_error (error);
+  g_assert_true (get_succeeded);
 
   gint64 relative_time;
   g_assert_true (emtr_util_get_current_time (CLOCK_BOOTTIME, &relative_time));
@@ -1609,8 +1609,8 @@ test_persistent_cache_reads_cached_boot_offset (gboolean     *unused,
   get_succeeded =
     emer_persistent_cache_get_boot_time_offset (cache, &second_offset, &error,
                                                 TRUE);
-  g_assert_true (get_succeeded);
   g_assert_no_error (error);
+  g_assert_true (get_succeeded);
 
   g_assert_true (boot_timestamp_is_valid (relative_time, absolute_time));
 
@@ -1641,8 +1641,8 @@ test_persistent_cache_get_offset_wont_update_timestamps_if_it_isnt_supposed_to (
   gboolean get_succeeded =
     emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, FALSE);
 
-  g_assert_true (get_succeeded);
   g_assert_no_error (error);
+  g_assert_true (get_succeeded);
 
   // These timestamps should not have changed.
   g_assert_cmpint (relative_time, ==, read_relative_time ());
@@ -1673,9 +1673,9 @@ test_persistent_cache_get_offset_updates_timestamps_when_requested (gboolean    
   // This call should update the timestamps in the metadata file.
   gboolean get_succeeded =
     emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
-  g_assert_true (get_succeeded);
 
   g_assert_no_error (error);
+  g_assert_true (get_succeeded);
 
   // These timestamps should have increased.
   g_assert_cmpint (relative_time, <, read_relative_time ());
@@ -1698,8 +1698,8 @@ test_persistent_cache_updates_timestamps_on_finalize (gboolean     *unused,
   gboolean get_succeeded =
     emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, TRUE);
 
-  g_assert_true (get_succeeded);
   g_assert_no_error (error);
+  g_assert_true (get_succeeded);
 
   gint64 relative_time = read_relative_time ();
   gint64 absolute_time = read_absolute_time ();
@@ -1739,8 +1739,8 @@ test_persistent_cache_get_offset_can_build_boot_metadata_file (gboolean     *unu
   gboolean get_succeeded =
     emer_persistent_cache_get_boot_time_offset (cache, NULL, &error, FALSE);
 
-  g_assert_true (get_succeeded);
   g_assert_no_error (error);
+  g_assert_true (get_succeeded);
 
   // The previous request should have reset the metadata file.
   g_assert_true (boot_offset_was_reset ());

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -172,6 +172,7 @@ make_testing_cache (void)
                                     cache_version_provider,
                                     TEST_UPDATE_OFFSET_INTERVAL);
   g_assert_no_error (error);
+  g_assert_nonnull (cache);
 
   g_object_unref (cache_size_provider);
   g_object_unref (boot_id_provider);
@@ -1084,6 +1085,7 @@ test_persistent_cache_store_when_full_succeeds (gboolean     *unused,
                                     cache_version_provider,
                                     TEST_UPDATE_OFFSET_INTERVAL);
   g_assert_no_error (error);
+  g_assert_nonnull (cache);
 
   g_object_unref (cache_version_provider);
   g_object_unref (boot_id_provider);
@@ -1374,6 +1376,7 @@ test_persistent_cache_purges_when_out_of_date_succeeds (gboolean     *unused,
                                     cache_version_provider,
                                     TEST_UPDATE_OFFSET_INTERVAL);
   g_assert_no_error (error);
+  g_assert_nonnull (cache);
 
   g_object_unref (cache_size_provider);
   g_object_unref (boot_id_provider);

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -111,7 +111,9 @@ write_default_cache_version_key_file (void)
 static void
 write_empty_metrics_file (gchar *suffix)
 {
-  gchar *path = g_strconcat (TEST_DIRECTORY, CACHE_PREFIX, suffix, NULL);
+  gchar *filename = g_strconcat (CACHE_PREFIX, suffix, NULL);
+  gchar *path = g_build_filename (TEST_DIRECTORY, filename, NULL);
+  g_free (filename);
   GFile *file = g_file_new_for_path (path);
   g_free (path);
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -189,10 +189,10 @@ static GKeyFile *
 load_boot_offset_key_file (void)
 {
   GKeyFile *boot_offset_key_file = g_key_file_new ();
-  gchar *full_path =
-    g_strconcat (TEST_DIRECTORY, BOOT_OFFSET_METADATA_FILE, NULL);
   gboolean load_succeeded =
-    g_key_file_load_from_file (boot_offset_key_file, full_path, G_KEY_FILE_NONE,
+    g_key_file_load_from_file (boot_offset_key_file,
+                               TEST_DIRECTORY BOOT_OFFSET_METADATA_FILE,
+                               G_KEY_FILE_NONE,
                                NULL);
   g_assert_true (load_succeeded);
   return boot_offset_key_file;
@@ -1759,8 +1759,7 @@ static void
 test_g_file_measure_disk_usage_returns_zero_on_empty_file (gboolean     *unused,
                                                            gconstpointer dontuseme)
 {
-  gchar *path = g_strconcat (TEST_DIRECTORY, "empty_file", NULL);
-  GFile *file = g_file_new_for_path (path);
+  GFile *file = g_file_new_for_path (TEST_DIRECTORY "empty_file");
 
   GError *error = NULL;
   g_file_replace_contents (file, "", 0, NULL, FALSE,
@@ -1777,8 +1776,7 @@ test_g_file_measure_disk_usage_returns_zero_on_empty_file (gboolean     *unused,
   g_assert_cmpint (disk_usage, ==, 0);
 
   g_object_unref (file);
-  g_unlink (path);
-  g_free (path);
+  g_unlink (TEST_DIRECTORY "empty_file");
 }
 
 int

--- a/tools/Makefile.am.inc
+++ b/tools/Makefile.am.inc
@@ -36,6 +36,7 @@ tools_print_persistent_cache_SOURCES = \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
 	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
 	daemon/emer-cache-version-provider.c daemon/emer-cache-version-provider.h \
+	daemon/emer-circular-file.c daemon/emer-circular-file.h \
 	daemon/emer-persistent-cache.c daemon/emer-persistent-cache.h \
 	shared/metrics-util.c shared/metrics-util.h \
 	tools/print-persistent-cache.c \

--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -30,352 +30,17 @@
 
 #define TMP_DIR_TEMPLATE "persistent-cache-XXXXXX"
 
-// TODO: Replace this with a reasonable value once it is used.
-#define MAX_BYTES_TO_READ G_GUINT64_CONSTANT (0)
-
 #define CACHE_VERSION_FILENAME "local_version_file"
 #define BOOT_OFFSET_UPDATE_INTERVAL (60u * 60u) // 1 hour
 
-#define SINGULAR_OUTPUT_FILE "singulars.printed"
-#define AGGREGATE_OUTPUT_FILE "aggregates.printed"
-#define SEQUENCE_OUTPUT_FILE "sequences.printed"
-
-typedef struct CopySpec
-{
-  GFile *source_directory;
-  GFile *destination_directory;
-} CopySpec;
-
-typedef gboolean (*DirTraversalCallback) (GFile   *file,
-                                          gpointer user_data);
-
-static gboolean traverse_file_or_dir (GFile               *file,
-                                      gboolean             pre_order,
-                                      DirTraversalCallback callback,
-                                      gpointer             user_data);
-
-/*
- * Returns a GFile * for the path in the destination directory that corresponds
- * to the given file's path. Assumes the given file resides in the source
- * directory. Free the return value with g_object_unref. Returns NULL on
- * failure.
- */
-static GFile *
-get_corresponding_file (GFile    *file,
-                        CopySpec *copy_spec)
-{
-
-  gchar *relative_path =
-    g_file_get_relative_path (copy_spec->source_directory, file);
-  if (relative_path == NULL)
-    {
-      g_warning ("Recursive copy failed. Could not get file path in "
-                 "destination directory that corresponds to a file path in the "
-                 "source directory.");
-      return NULL;
-    }
-
-  GFile *corresponding_file =
-    g_file_resolve_relative_path (copy_spec->destination_directory,
-                                  relative_path);
-  g_free (relative_path);
-  if (corresponding_file == NULL)
-    g_warning ("Recursive copy failed. Could not get file in destination "
-               "directory that corresponds to a file in the source directory.");
-  return corresponding_file;
-}
+#define OUTPUT_FILE "variants.txt"
 
 static gboolean
-copy_file (GFile *source_file,
-           GFile *destination_file)
+print_variants_to_file (GVariant   **variants,
+                        gsize        num_variants,
+                        const gchar *path)
 {
-  GError *error = NULL;
-  gboolean copy_succeeded =
-    g_file_copy (source_file, destination_file, G_FILE_COPY_NOFOLLOW_SYMLINKS,
-                 NULL /* GCancellable */, NULL /* GFileProgressCallback */,
-                 NULL /* progress_callback_data */, &error);
-
-  if (!copy_succeeded)
-    {
-      g_warning ("Could not copy a file: %s.", error->message);
-      g_error_free (error);
-    }
-
-  return copy_succeeded;
-}
-
-static gboolean
-make_directory (GFile *directory)
-{
-  GError *error = NULL;
-  gboolean make_directory_succeeded =
-    g_file_make_directory (directory, NULL /* GCancellable */, &error);
-
-  if (!make_directory_succeeded)
-    {
-      g_warning ("Could not make an empty directory: %s.", error->message);
-      g_error_free (error);
-    }
-
-  return make_directory_succeeded;
-}
-
-static gboolean
-shallow_copy_file_or_dir (GFile *source_file,
-                          GFile *destination_file)
-{
-  GFileType source_file_type =
-    g_file_query_file_type (source_file, G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
-                            NULL /* GCancellable */);
-  switch (source_file_type)
-    {
-    case G_FILE_TYPE_REGULAR:
-      return copy_file (source_file, destination_file);
-
-    case G_FILE_TYPE_DIRECTORY:
-      return make_directory (destination_file);
-
-    default:
-      g_warning ("Could not copy a file because it had unexpected type %d.",
-                 source_file_type);
-      return FALSE;
-    }
-}
-
-// Intended for use as a pre-order DirTraversalCallback function.
-static gboolean
-shallow_copy_file_or_dir_to_dir (GFile    *source_file,
-                                 CopySpec *copy_spec)
-{
-  GFile *destination_file = get_corresponding_file (source_file, copy_spec);
-  if (destination_file == NULL)
-    return FALSE;
-
-  gboolean copy_succeeded =
-    shallow_copy_file_or_dir (source_file, destination_file);
-
-  g_object_unref (destination_file);
-
-  return copy_succeeded;
-}
-
-// Intended for use as a post-order DirTraversalCallback function.
-static gboolean
-delete_file (GFile   *file,
-             gpointer unused)
-{
-  GError *error = NULL;
-  gboolean delete_succeeded =
-    g_file_delete (file, NULL /* GCancellable */, &error);
-
-  if (!delete_succeeded)
-    {
-      g_warning ("Could not delete file: %s.", error->message);
-      g_error_free (error);
-    }
-
-  return delete_succeeded;
-}
-
-// Assumes file_enumerator can be queried for G_FILE_ATTRIBUTE_STANDARD_NAME.
-static gboolean
-traverse_enumerator (GFileEnumerator     *file_enumerator,
-                     gboolean             pre_order,
-                     DirTraversalCallback callback,
-                     gpointer             user_data)
-{
-  while (TRUE)
-    {
-      GError *error = NULL;
-      GFileInfo *curr_file_info =
-        g_file_enumerator_next_file (file_enumerator, NULL /* GCancellable */,
-                                     &error);
-
-      if (error != NULL)
-        {
-          g_warning ("Recursive directory traversal failed. Could not get info "
-                     "about a file: %s.", error->message);
-          g_error_free (error);
-          return FALSE;
-        }
-
-      if (curr_file_info == NULL)
-        // We reached the end of the file enumerator.
-        return TRUE;
-
-      GFile *curr_file =
-        g_file_enumerator_get_child (file_enumerator, curr_file_info);
-      g_object_unref (curr_file_info);
-
-      gboolean traverse_succeeded =
-        traverse_file_or_dir (curr_file, pre_order, callback, user_data);
-      g_object_unref (curr_file);
-
-      if (!traverse_succeeded)
-        return FALSE;
-    }
-}
-
-static gboolean
-traverse_directory (GFile               *directory,
-                    gboolean             pre_order,
-                    DirTraversalCallback callback,
-                    gpointer             user_data)
-{
-  GError *error = NULL;
-  GFileEnumerator *directory_enumerator =
-    g_file_enumerate_children (directory,
-                               G_FILE_ATTRIBUTE_STANDARD_NAME,
-                               G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
-                               NULL /* GCancellable */,
-                               &error);
-
-  if (directory_enumerator == NULL)
-    {
-      g_warning ("Recursive directory traversal failed. Could not list "
-                 "contents of directory: %s.", error->message);
-      g_error_free (error);
-      return FALSE;
-    }
-
-  gboolean traverse_succeeded =
-    traverse_enumerator (directory_enumerator, pre_order, callback, user_data);
-
-  g_object_unref (directory_enumerator);
-  return traverse_succeeded;
-}
-
-static gboolean
-traverse_file_or_dir (GFile               *file,
-                      gboolean             pre_order,
-                      DirTraversalCallback callback,
-                      gpointer             user_data)
-{
-  GFileType file_type =
-    g_file_query_file_type (file, G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
-                            NULL /* GCancellable */);
-  switch (file_type)
-    {
-    case G_FILE_TYPE_REGULAR:
-      return callback (file, user_data);
-
-    case G_FILE_TYPE_DIRECTORY:
-      {
-        gboolean traversal_succeeded = TRUE;
-        if (pre_order)
-          traversal_succeeded = callback (file, user_data);
-
-        traversal_succeeded = traversal_succeeded &&
-          traverse_directory (file, pre_order, callback, user_data);
-
-        if (!pre_order)
-          traversal_succeeded = traversal_succeeded &&
-            callback (file, user_data);
-
-        return traversal_succeeded;
-      }
-
-    default:
-      g_warning ("Recursive directory traversal failed. A file had unexpected "
-                 "type %d.", file_type);
-      char *filename = g_file_get_path (file);
-      if (filename != NULL)
-        {
-          g_warning ("File with unexpected type has name: %s.", filename);
-          g_free (filename);
-        }
-      else
-        {
-          g_warning ("File with unexpected type has NULL name.");
-        }
-      return FALSE;
-    }
-}
-
-// Assumes the destination directory already exists.
-static gboolean
-copy_directory (GFile *source_directory,
-                GFile *destination_directory)
-{
-  CopySpec copy_spec = { source_directory, destination_directory };
-  return traverse_directory (source_directory, TRUE,
-                             (DirTraversalCallback)
-                             shallow_copy_file_or_dir_to_dir,
-                             &copy_spec);
-
-}
-
-static gboolean
-delete_directory (GFile *directory)
-{
-  return traverse_file_or_dir (directory, FALSE,
-                               (DirTraversalCallback) delete_file,
-                               NULL /* user_data */);
-}
-
-/*
- * Recursively copies the directory at the given path to a new temporary
- * directory, which is returned. Free the return value with g_object_unref.
- * Returns NULL on failure.
- */
-static GFile *
-copy_persistent_cache (const gchar *persistent_cache_path)
-{
-  GError *error = NULL;
-  gchar *tmp_dir_name = g_dir_make_tmp (TMP_DIR_TEMPLATE, &error);
-  if (tmp_dir_name == NULL)
-    {
-      g_warning ("Could not create temporary directory from template %s: %s.",
-                 TMP_DIR_TEMPLATE, error->message);
-      g_error_free (error);
-      return NULL;
-    }
-
-  GFile *tmp_dir = g_file_new_for_path (tmp_dir_name);
-  g_free (tmp_dir_name);
-
-  GFile *persistent_cache_dir = g_file_new_for_path (persistent_cache_path);
-
-  gboolean copy_succeeded = copy_directory (persistent_cache_dir, tmp_dir);
-
-  g_object_unref (persistent_cache_dir);
-
-  if (!copy_succeeded)
-    {
-      g_object_unref (tmp_dir);
-      return NULL;
-    }
-
-  return tmp_dir;
-}
-
-static gboolean
-print_variant_to_file (GVariant      *variant,
-                       GOutputStream *output_stream)
-{
-  gchar *variant_str = g_variant_print (variant, TRUE);
-  gsize variant_str_length = strlen (variant_str);
-  gsize bytes_written;
-  GError *error = NULL;
-  gboolean write_succeeded =
-    g_output_stream_write_all (output_stream, variant_str, variant_str_length,
-                               &bytes_written, NULL /* GCancellable */, &error);
-  g_free (variant_str);
-
-  if (!write_succeeded)
-    {
-      g_warning ("Failed to print event to file: %s.", error->message);
-      g_error_free (error);
-    }
-
-  return write_succeeded;
-}
-
-static gboolean
-print_variant_array_to_file (GVariant **variant_array,
-                             gchar     *filename)
-{
-  GFile *file = g_file_new_for_path (filename);
+  GFile *file = g_file_new_for_path (path);
   GError *error = NULL;
   GFileOutputStream *file_output_stream =
     g_file_append_to (file, G_FILE_CREATE_NONE, NULL /* GCancellable */,
@@ -390,56 +55,49 @@ print_variant_array_to_file (GVariant **variant_array,
       return FALSE;
     }
 
-  GOutputStream *output_stream = G_OUTPUT_STREAM (file_output_stream);
-
-  gboolean write_succeeded = TRUE;
-  for (gint i = 0; variant_array[i] != NULL; i++)
+  GByteArray *byte_array = g_byte_array_new ();
+  for (gint i = 0; i < num_variants; i++)
     {
-      write_succeeded =
-        print_variant_to_file (variant_array[i], output_stream);
-      if (!write_succeeded)
-        break;
+      gchar *variant_str = g_variant_print (variants[i], TRUE);
+      gsize variant_str_length = strlen (variant_str);
+      g_byte_array_append (byte_array, (const guint8 *) variant_str,
+                           variant_str_length);
+      g_byte_array_append (byte_array, (const guint8 *) "\n", 1);
+      g_free (variant_str);
     }
 
+  GOutputStream *output_stream = G_OUTPUT_STREAM (file_output_stream);
+
+  gboolean write_succeeded =
+    g_output_stream_write_all (output_stream, byte_array->data, byte_array->len,
+                               NULL /* bytes written */,
+                               NULL /* GCancellable */, &error);
+
   g_object_unref (file_output_stream);
+  g_byte_array_unref (byte_array);
+
+  if (!write_succeeded)
+    {
+      g_warning ("Failed to print variants to file: %s.", error->message);
+      g_error_free (error);
+    }
+
   return write_succeeded;
 }
 
 static EmerPersistentCache *
-make_persistent_cache (GFile *directory)
+make_persistent_cache (const gchar *directory)
 {
   GError *error = NULL;
-
-  gchar *directory_path = g_file_get_path (directory);
-  if (directory_path == NULL)
-    {
-      g_warning ("Could not get path of directory.");
-      return NULL;
-    }
-
-
-  EmerCacheSizeProvider *cache_size_provider = emer_cache_size_provider_new ();
-  EmerBootIdProvider *boot_id_provider = emer_boot_id_provider_new ();
-
-  gchar *cache_version_path =
-    g_build_filename (directory_path, CACHE_VERSION_FILENAME, NULL);
-  EmerCacheVersionProvider *cache_version_provider =
-    emer_cache_version_provider_new_full (cache_version_path);
-  g_free (cache_version_path);
-
   EmerPersistentCache *persistent_cache =
-    emer_persistent_cache_new_full (NULL /* GCancellable */, &error,
-                                    directory_path,
-                                    cache_size_provider, boot_id_provider,
-                                    cache_version_provider,
-                                    BOOT_OFFSET_UPDATE_INTERVAL);
-  g_free (directory_path);
-  g_object_unref (cache_size_provider);
-  g_object_unref (boot_id_provider);
-  g_object_unref (cache_version_provider);
+    emer_persistent_cache_new (directory, &error);
 
   if (persistent_cache == NULL)
-    g_error_free (error);
+    {
+      g_warning ("Could not create persistent cache. Error: %s.",
+                 error->message);
+      g_error_free (error);
+    }
 
   return persistent_cache;
 }
@@ -490,47 +148,31 @@ main (int   argc,
       return EXIT_FAILURE;
     }
 
-  GFile *tmp_dir = copy_persistent_cache (persistent_cache_path);
+  EmerPersistentCache *persistent_cache =
+    make_persistent_cache (persistent_cache_path);
   g_free (persistent_cache_path);
-
-  if (tmp_dir == NULL)
+  if (persistent_cache == NULL)
     return EXIT_FAILURE;
 
-  EmerPersistentCache *persistent_cache = make_persistent_cache (tmp_dir);
-  if (persistent_cache == NULL)
-    {
-      g_object_unref (tmp_dir);
-      return EXIT_FAILURE;
-    }
-
-  GVariant **singulars, **aggregates, **sequences;
-  gboolean drain_succeeded =
-    emer_persistent_cache_drain_metrics (persistent_cache, &singulars,
-                                         &aggregates, &sequences,
-                                         MAX_BYTES_TO_READ);
-
+  GVariant **variants;
+  gsize num_variants;
+  guint64 token;
+  gboolean read_succeeded =
+    emer_persistent_cache_read (persistent_cache, &variants, G_MAXSIZE,
+                                &num_variants, &token, &error);
   g_object_unref (persistent_cache);
 
-  if (!drain_succeeded)
+  if (!read_succeeded)
     {
-      g_object_unref (tmp_dir);
+      g_warning ("Could not read from persistent cache. Error: %s.",
+                 error->message);
+      g_error_free (error);
       return EXIT_FAILURE;
     }
 
   gboolean print_succeeded =
-    print_variant_array_to_file (singulars, SINGULAR_OUTPUT_FILE);
-  free_variant_array (singulars);
+    print_variants_to_file (variants, num_variants, OUTPUT_FILE);
+  destroy_variants (variants, num_variants);
 
-  print_succeeded = print_succeeded &&
-    print_variant_array_to_file (aggregates, AGGREGATE_OUTPUT_FILE);
-  free_variant_array (aggregates);
-
-  print_succeeded = print_succeeded &&
-    print_variant_array_to_file (sequences, SEQUENCE_OUTPUT_FILE);
-  free_variant_array (sequences);
-
-  gboolean delete_succeeded = delete_directory (tmp_dir);
-  g_object_unref (tmp_dir);
-
-  return print_succeeded && delete_succeeded ? EXIT_SUCCESS : EXIT_FAILURE;
+  return print_succeeded ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -417,25 +417,23 @@ make_persistent_cache (GFile *directory)
       return NULL;
     }
 
-  gchar *directory_path_with_slash = g_strconcat (directory_path, "/", NULL);
-  g_free (directory_path);
 
   EmerCacheSizeProvider *cache_size_provider = emer_cache_size_provider_new ();
   EmerBootIdProvider *boot_id_provider = emer_boot_id_provider_new ();
 
   gchar *cache_version_path =
-    g_strconcat (directory_path_with_slash, CACHE_VERSION_FILENAME, NULL);
+    g_build_filename (directory_path, CACHE_VERSION_FILENAME, NULL);
   EmerCacheVersionProvider *cache_version_provider =
     emer_cache_version_provider_new_full (cache_version_path);
   g_free (cache_version_path);
 
   EmerPersistentCache *persistent_cache =
     emer_persistent_cache_new_full (NULL /* GCancellable */, &error,
-                                    directory_path_with_slash,
+                                    directory_path,
                                     cache_size_provider, boot_id_provider,
                                     cache_version_provider,
                                     BOOT_OFFSET_UPDATE_INTERVAL);
-  g_free (directory_path_with_slash);
+  g_free (directory_path);
   g_object_unref (cache_size_provider);
   g_object_unref (boot_id_provider);
   g_object_unref (cache_version_provider);


### PR DESCRIPTION
Eliminate SingularEvent, AggregateEvent, and SequenceEvent types. Use
variants instead for all three to eliminate a lot of code
near-duplication. Introduce a persistent ring buffer (circular file) to
allow the persistent cache to be efficiently partially removed from.
Increase persistent cache size to from 90 KiB to 10 MB to take advantage
of the new circular file. Also leverage the circular file to only delete
events once they've been delivered. Set out errors rather than logging
them internally within the persistent cache. This allows more helpful
error messages to be reported when users run eos-upload-metrics and
minimizes the number of log statements.

[endlessm/eos-sdk#599]