### PR TITLE
Remove unnecessary error checking.

### DIFF
--- a/daemon/emer-circular-file.c
+++ b/daemon/emer-circular-file.c
@@ -499,9 +499,7 @@ emer_circular_file_initable_init (GInitable    *initable,
   g_free (metadata_filepath);
   if (!load_succeeded)
     {
-      if (!g_error_matches (local_error, G_KEY_FILE_ERROR,
-                            G_KEY_FILE_ERROR_NOT_FOUND) &&
-          !g_error_matches (local_error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+      if (!g_error_matches (local_error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
         goto handle_failed_read;
 
       g_key_file_set_uint64 (priv->metadata_key_file, METADATA_GROUP_NAME,

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -121,8 +121,7 @@ read_config_file_sync (EmerPermissionsProvider *self)
     {
       load_fallback_data (self);
 
-      if (!g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT) &&
-          !g_error_matches (error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_NOT_FOUND))
+      if (!g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
         g_critical ("Permissions config file '%s' was invalid or could not be "
                     "read. Loading fallback data. Error: %s.", path,
                     error->message);

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -468,9 +468,7 @@ update_boot_offset (EmerPersistentCache *self,
                                &local_error);
   if (!load_succeeded)
     {
-      if (!g_error_matches (local_error, G_KEY_FILE_ERROR,
-                            G_KEY_FILE_ERROR_NOT_FOUND) &&
-          !g_error_matches (local_error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+      if (!g_error_matches (local_error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
         {
           g_propagate_error (error, local_error);
           return FALSE;


### PR DESCRIPTION
When attempting to load a key file that doesn't exist,
G_FILE_ERROR_NO_ENT is set, not G_KEY_FILE_ERROR_NOT_FOUND. We don't
want to handle G_KEY_FILE_ERROR_NOT_FOUND as though it meant the key
file didn't exist.

[endlessm/eos-sdk#3040]