### PR TITLE
Use maximum timeout for gdbus call.

### DIFF
--- a/tools/eos-upload-metrics
+++ b/tools/eos-upload-metrics
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-UPLOAD_EVENTS_OUTPUT=$(gdbus call --system \
+UPLOAD_EVENTS_OUTPUT=$(gdbus call --system --timeout 2147483 \
     --dest com.endlessm.Metrics --object-path /com/endlessm/Metrics \
     --method com.endlessm.Metrics.EventRecorderServer.UploadEvents)
 


### PR DESCRIPTION
The default timeout, 25 seconds, is too short for many uploads. Use the
maximum permitted timeout, 2,147,483 seconds instead. The unusual
maximum arises from the fact that gdbus multiplies the given timeout by
1000 and stores the result in an int, which on our current hardware will
be at least 32 bits.

[endlessm/eos-sdk#3168]