### PR TITLE
Fix double unref of auxiliary payload.

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -683,6 +683,7 @@ get_nullable_payload (GVariant *payload,
 {
   if (!has_payload)
     {
+      g_variant_ref_sink (payload);
       g_variant_unref (payload);
       return NULL;
     }

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -626,12 +626,15 @@ record_singulars (EmerDaemon *daemon)
                                      RELATIVE_TIMESTAMP,
                                      FALSE,
                                      g_variant_new_string ("This must be ignored."));
+  GVariant *auxiliary_payload = g_variant_new_boolean (FALSE);
+  g_variant_ref_sink (auxiliary_payload);
   emer_daemon_record_singular_event (daemon,
                                      USER_ID,
                                      make_event_id_variant (),
                                      RELATIVE_TIMESTAMP,
                                      FALSE,
-                                     g_variant_new_string ("This must be ignored."));
+                                     auxiliary_payload);
+  g_variant_unref (auxiliary_payload);
   emer_daemon_record_singular_event (daemon,
                                      USER_ID,
                                      make_event_id_variant (),


### PR DESCRIPTION
Take ownership of the auxiliary payload passed to the event recorder
daemon via D-Bus before releasing it. This fixes a double unref that can
be triggered with the gdbus command-line tool.

[endlessm/eos-sdk#3437]