### PR TITLE
Corrected log message and comment.

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -52,7 +52,7 @@
 
 /*
  * The maximum number of attempts to upload a particular batch of metric events
- * before giving up and dropping them.
+ * before giving up.
  */
 #define NETWORK_ATTEMPT_LIMIT 8
 
@@ -881,8 +881,7 @@ log_upload_error (EmerDaemon   *self,
       if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED) ||
           (g_strcmp0 (error->message, METRICS_DISABLED_MESSAGE) != 0 &&
            g_strcmp0 (error->message, UPLOADING_DISABLED_MESSAGE) != 0))
-        g_warning ("Dropped events because they could not be uploaded: %s.",
-                   error->message);
+        g_warning ("Failed to upload events: %s.", error->message);
       g_error_free (error);
     }
 }

--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -26,9 +26,9 @@
 #include <glib-object.h>
 #include <gio/gio.h>
 
-#include "daemon/emer-boot-id-provider.h"
-#include "daemon/emer-cache-size-provider.h"
-#include "daemon/emer-cache-version-provider.h"
+#include "emer-boot-id-provider.h"
+#include "emer-cache-size-provider.h"
+#include "emer-cache-version-provider.h"
 #include "shared/metrics-util.h"
 
 G_BEGIN_DECLS

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -73,7 +73,6 @@ tests_daemon_test_daemon_dbusdaemon_SOURCES = \
 	tests/daemon/test-daemon.c \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
 	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
-	daemon/emer-cache-version-provider.c daemon/emer-cache-version-provider.h \
 	tests/daemon/mock-machine-id-provider.c daemon/emer-machine-id-provider.h \
 	tests/daemon/mock-network-send-provider.c \
 	daemon/emer-network-send-provider.h \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -111,7 +111,8 @@ tests_daemon_test_persistent_cache_SOURCES = \
 	daemon/emer-persistent-cache.c daemon/emer-persistent-cache.h \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
 	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
-	daemon/emer-cache-version-provider.c daemon/emer-cache-version-provider.h \
+	tests/daemon/mock-cache-version-provider.c \
+	daemon/emer-cache-version-provider.h \
 	tests/daemon/mock-circular-file.c daemon/emer-circular-file.h \
 	shared/metrics-util.c shared/metrics-util.h \
 	$(NULL)

--- a/tests/daemon/mock-cache-version-provider.c
+++ b/tests/daemon/mock-cache-version-provider.c
@@ -1,0 +1,52 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#include "emer-cache-version-provider.h"
+
+typedef struct _EmerCacheVersionProviderPrivate
+{
+  gboolean foo;
+} EmerCacheVersionProviderPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (EmerCacheVersionProvider,
+                            emer_cache_version_provider,
+                            G_TYPE_OBJECT);
+
+static void
+emer_cache_version_provider_class_init (EmerCacheVersionProviderClass *klass)
+{
+}
+
+static void
+emer_cache_version_provider_init (EmerCacheVersionProvider *self)
+{
+}
+
+EmerCacheVersionProvider *
+emer_cache_version_provider_new ()
+{
+  return g_object_new (EMER_TYPE_CACHE_VERSION_PROVIDER, NULL);
+}
+
+EmerCacheVersionProvider *
+emer_cache_version_provider_new_full (const gchar *cache_version_file_path)
+{
+  return g_object_new (EMER_TYPE_CACHE_VERSION_PROVIDER, NULL);
+}
+
+gboolean
+emer_cache_version_provider_get_version (EmerCacheVersionProvider *self,
+                                         gint                     *version)
+{
+  *version = 0;
+  return TRUE;
+}
+
+gboolean
+emer_cache_version_provider_set_version (EmerCacheVersionProvider *self,
+                                         gint                      new_version,
+                                         GError                  **error)
+{
+  return TRUE;
+}

--- a/tests/daemon/mock-persistent-cache.h
+++ b/tests/daemon/mock-persistent-cache.h
@@ -20,7 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MOCK_PESISTENT_CACHE_H
+#ifndef MOCK_PERSISTENT_CACHE_H
 #define MOCK_PERSISTENT_CACHE_H
 
 #include <glib-object.h>

--- a/tests/daemon/test-circular-file.c
+++ b/tests/daemon/test-circular-file.c
@@ -18,7 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#include "daemon/emer-circular-file.h"
+#include "emer-circular-file.h"
 
 #include <string.h>
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -18,7 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#include "daemon/emer-persistent-cache.h"
+#include "emer-persistent-cache.h"
 
 #include <string.h>
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -27,6 +27,9 @@
 
 #include <eosmetrics/eosmetrics.h>
 
+#include "emer-boot-id-provider.h"
+#include "emer-cache-size-provider.h"
+#include "emer-cache-version-provider.h"
 #include "shared/metrics-util.h"
 
 #define TEST_DIRECTORY "/tmp/metrics_testing/"

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -140,12 +140,22 @@ make_testing_cache (void)
   EmerBootIdProvider *boot_id_provider =
     emer_boot_id_provider_new_full (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   EmerCacheVersionProvider *cache_version_provider =
-    emer_cache_version_provider_new_full (TEST_DIRECTORY TEST_CACHE_VERSION_FILE);
+    emer_cache_version_provider_new_full (NULL);
   GError *error = NULL;
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                         "Failed to unlink old cache file " TEST_DIRECTORY
+                         "cache_individual.metrics. Error: *.");
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                         "Failed to unlink old cache file " TEST_DIRECTORY
+                         "cache_aggregate.metrics. Error: *.");
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                         "Failed to unlink old cache file " TEST_DIRECTORY
+                         "cache_sequence.metrics. Error: *.");
   EmerPersistentCache *cache =
     emer_persistent_cache_new_full (TEST_DIRECTORY, cache_size_provider,
                                     boot_id_provider, cache_version_provider,
                                     TEST_UPDATE_OFFSET_INTERVAL, &error);
+  g_test_assert_expected_messages ();
   g_assert_no_error (error);
   g_assert_nonnull (cache);
 
@@ -585,12 +595,22 @@ test_persistent_cache_store_when_full (gboolean     *unused,
   EmerBootIdProvider *boot_id_provider =
     emer_boot_id_provider_new_full (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   EmerCacheVersionProvider *cache_version_provider =
-    emer_cache_version_provider_new_full (TEST_DIRECTORY TEST_CACHE_VERSION_FILE);
+    emer_cache_version_provider_new_full (NULL);
   GError *error = NULL;
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                         "Failed to unlink old cache file " TEST_DIRECTORY
+                         "cache_individual.metrics. Error: *.");
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                         "Failed to unlink old cache file " TEST_DIRECTORY
+                         "cache_aggregate.metrics. Error: *.");
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                         "Failed to unlink old cache file " TEST_DIRECTORY
+                         "cache_sequence.metrics. Error: *.");
   EmerPersistentCache *cache =
     emer_persistent_cache_new_full (TEST_DIRECTORY, cache_size_provider,
                                     boot_id_provider, cache_version_provider,
                                     TEST_UPDATE_OFFSET_INTERVAL, &error);
+  g_test_assert_expected_messages ();
   g_assert_no_error (error);
   g_assert_nonnull (cache);
 
@@ -800,12 +820,22 @@ test_persistent_cache_purges_when_out_of_date (gboolean     *unused,
   EmerBootIdProvider *boot_id_provider =
     emer_boot_id_provider_new_full (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   EmerCacheVersionProvider *cache_version_provider =
-    emer_cache_version_provider_new_full (TEST_DIRECTORY TEST_CACHE_VERSION_FILE);
+    emer_cache_version_provider_new_full (NULL);
   GError *error = NULL;
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                         "Failed to unlink old cache file " TEST_DIRECTORY
+                         "cache_individual.metrics. Error: *.");
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                         "Failed to unlink old cache file " TEST_DIRECTORY
+                         "cache_aggregate.metrics. Error: *.");
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                         "Failed to unlink old cache file " TEST_DIRECTORY
+                         "cache_sequence.metrics. Error: *.");
   EmerPersistentCache *cache =
     emer_persistent_cache_new_full (TEST_DIRECTORY, cache_size_provider,
                                     boot_id_provider, cache_version_provider,
                                     TEST_UPDATE_OFFSET_INTERVAL, &error);
+  g_test_assert_expected_messages ();
   g_assert_no_error (error);
   g_assert_nonnull (cache);
 
@@ -831,17 +861,7 @@ test_persistent_cache_purges_when_out_of_date (gboolean     *unused,
   g_object_unref (cache_version_provider);
   g_object_unref (cache);
 
-  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
-                         "Failed to unlink old cache file " TEST_DIRECTORY
-                         "cache_individual.metrics. Error: *.");
-  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
-                         "Failed to unlink old cache file " TEST_DIRECTORY
-                         "cache_aggregate.metrics. Error: *.");
-  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
-                         "Failed to unlink old cache file " TEST_DIRECTORY
-                         "cache_sequence.metrics. Error: *.");
   EmerPersistentCache *cache2 = make_testing_cache ();
-  g_test_assert_expected_messages ();
   assert_cache_is_empty (cache2);
   g_object_unref (cache2);
 }

--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -25,7 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "daemon/emer-persistent-cache.h"
+#include "emer-persistent-cache.h"
 #include "shared/metrics-util.h"
 
 #define TMP_DIR_TEMPLATE "persistent-cache-XXXXXX"


### PR DESCRIPTION
Events are no longer dropped when network requests fail.

[endlessm/eos-sdk#3439]