### PR TITLE
Remove requirement on dbus.service

### DIFF
--- a/data/eos-metrics-event-recorder.service.in
+++ b/data/eos-metrics-event-recorder.service.in
@@ -1,8 +1,6 @@
 [Unit]
 Description=EndlessOS Metrics Event Recorder Server
-Requires=dbus.service
 Wants=systemd-logind.service
-After=dbus.service
 
 [Service]
 Environment=DCONF_PROFILE=/dev/null


### PR DESCRIPTION
Since the service is type dbus, systemd will already add an implicit
dependency on dbus.socket (see systemd.service(5)). This allows the
event-recorder to begin initialization and then block in the dbus call
until the dbus service has taken over the socket from systemd.

This is how all other dbus service units on the system are managed and
allows systemd to start more services in parallel.

[endlessm/eos-shell#5502]