### PR TITLE
Support persistent cache dir command line arg.

### DIFF
--- a/daemon/emer-boot-id-provider.c
+++ b/daemon/emer-boot-id-provider.c
@@ -214,7 +214,8 @@ read_boot_id (EmerBootIdProvider *self)
 
   if (!read_succeeded)
     {
-      g_critical ("Failed to read boot ID file (%s).", priv->path);
+      g_critical ("Failed to read boot ID file (%s). Error: %s.", priv->path,
+                  error->message);
       g_error_free (error);
       return FALSE;
     }

--- a/daemon/emer-boot-id-provider.c
+++ b/daemon/emer-boot-id-provider.c
@@ -238,7 +238,7 @@ read_boot_id (EmerBootIdProvider *self)
   // Remove newline.
   g_strchomp (boot_id_string);
 
-  int parse_failed = uuid_parse (boot_id_string, priv->id);
+  gint parse_failed = uuid_parse (boot_id_string, priv->id);
   g_free (boot_id_string);
 
   if (parse_failed != 0)

--- a/daemon/emer-cache-size-provider.c
+++ b/daemon/emer-cache-size-provider.c
@@ -197,8 +197,10 @@ read_cache_size_data (EmerCacheSizeProvider *self)
     return;
 
   GError *error = NULL;
-  if (!g_key_file_load_from_file (priv->key_file, priv->path, G_KEY_FILE_NONE,
-                                  &error))
+  gboolean load_succeeded =
+    g_key_file_load_from_file (priv->key_file, priv->path, G_KEY_FILE_NONE,
+                               &error);
+  if (!load_succeeded)
     {
       if (!g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
         goto handle_failed_read;
@@ -207,10 +209,9 @@ read_cache_size_data (EmerCacheSizeProvider *self)
       write_cache_size (self, DEFAULT_MAX_CACHE_SIZE);
     }
 
-  priv->max_cache_size = g_key_file_get_uint64 (priv->key_file,
-                                                CACHE_SIZE_GROUP,
-                                                MAX_CACHE_SIZE_KEY,
-                                                &error);
+  priv->max_cache_size =
+    g_key_file_get_uint64 (priv->key_file, CACHE_SIZE_GROUP, MAX_CACHE_SIZE_KEY,
+                           &error);
   if (error != NULL)
     goto handle_failed_read;
 

--- a/daemon/emer-cache-version-provider.c
+++ b/daemon/emer-cache-version-provider.c
@@ -32,12 +32,6 @@ typedef struct EmerCacheVersionProviderPrivate
 
 G_DEFINE_TYPE_WITH_PRIVATE (EmerCacheVersionProvider, emer_cache_version_provider, G_TYPE_OBJECT)
 
-/*
- * This is the filepath to the metadata file containing the local network
- * protocol version.
- */
-#define DEFAULT_CACHE_VERSION_FILE_PATH PERSISTENT_CACHE_DIR "local_version_file"
-
 #define CACHE_VERSION_GROUP "cache_version_info"
 #define CACHE_VERSION_KEY   "version"
 
@@ -117,7 +111,7 @@ emer_cache_version_provider_class_init (EmerCacheVersionProviderClass *klass)
   emer_cache_version_provider_props[PROP_PATH] =
     g_param_spec_string ("path", "Path",
                          "The path to the file where the cache version is stored.",
-                         DEFAULT_CACHE_VERSION_FILE_PATH,
+                         NULL,
                          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   object_class->set_property = emer_cache_version_provider_set_property;
@@ -137,34 +131,19 @@ emer_cache_version_provider_init (EmerCacheVersionProvider *self)
 
 /*
  * emer_cache_version_provider_new:
+ * @path: see #EmerCacheVersionProvider:path
  *
- * Constructs the ID provider used to obtain a cache format version
- * via the default filepath.
- *
- * Returns: (transfer full): A new #EmerCacheVersionProvider.
- * Free with g_object_unref().
- */
-EmerCacheVersionProvider *
-emer_cache_version_provider_new (void)
-{
-  return g_object_new (EMER_TYPE_CACHE_VERSION_PROVIDER, NULL);
-}
-
-/*
- * emer_cache_version_provider_new_full:
- * @cache_version_file_path: path to a file; see #EmerCacheVersionProvider:path
- *
- * Constructs the ID provider used to obtain a cache format version
- * via a given filepath.
+ * Constructs a provider that stores the cache format version in a file at the
+ * given path.
  *
  * Returns: (transfer full): A new #EmerCacheVersionProvider.
  * Free with g_object_unref().
  */
 EmerCacheVersionProvider *
-emer_cache_version_provider_new_full (const gchar *cache_version_file_path)
+emer_cache_version_provider_new (const gchar *path)
 {
   return g_object_new (EMER_TYPE_CACHE_VERSION_PROVIDER,
-                       "path", cache_version_file_path,
+                       "path", path,
                        NULL);
 }
 

--- a/daemon/emer-cache-version-provider.h
+++ b/daemon/emer-cache-version-provider.h
@@ -78,9 +78,7 @@ struct _EmerCacheVersionProviderClass
 
 GType                     emer_cache_version_provider_get_type    (void) G_GNUC_CONST;
 
-EmerCacheVersionProvider *emer_cache_version_provider_new         (void);
-
-EmerCacheVersionProvider *emer_cache_version_provider_new_full    (const gchar              *version_file_path);
+EmerCacheVersionProvider *emer_cache_version_provider_new         (const gchar              *path);
 
 gboolean                  emer_cache_version_provider_get_version (EmerCacheVersionProvider *self,
                                                                    gint                     *version);

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1140,7 +1140,7 @@ set_machine_id_provider (EmerDaemon            *self,
 }
 
 static void
-set_network_send_provider (EmerDaemon *self,
+set_network_send_provider (EmerDaemon              *self,
                            EmerNetworkSendProvider *network_send_prov)
 {
   EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1302,7 +1302,7 @@ emer_daemon_finalize (GObject *object)
   g_clear_pointer (&priv->variant_array, g_ptr_array_unref);
 
   g_rand_free (priv->rand);
-  g_free (priv->server_uri);
+  g_clear_pointer (&priv->server_uri, g_free);
   g_clear_object (&priv->machine_id_provider);
   g_clear_object (&priv->network_send_provider);
   g_clear_object (&priv->permissions_provider);

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -106,11 +106,11 @@
 
 #define METRICS_DISABLED_MESSAGE "Could not upload events because the " \
   "metrics system is disabled. You may enable the metrics system via " \
-  "Settings > Privacy > Metrics."
+  "Settings > Privacy > Metrics"
 
 #define UPLOADING_DISABLED_MESSAGE "Could not upload events because " \
   "uploading is disabled. You may enable uploading by setting " \
-  "uploading_enabled to true in " PERMISSIONS_FILE "."
+  "uploading_enabled to true in " PERMISSIONS_FILE
 
 typedef struct _NetworkCallbackData
 {
@@ -390,7 +390,7 @@ get_offset_timestamps (EmerDaemon *self,
       !emtr_util_get_current_time (CLOCK_REALTIME, abs_timestamp_ptr))
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Could not get current time.");
+                   "Could not get current time");
       return FALSE;
     }
 
@@ -465,7 +465,7 @@ handle_http_response (SoupSession         *http_session,
       g_task_return_new_error (callback_data->upload_task, G_IO_ERROR,
                                G_IO_ERROR_FAILED,
                                "Maximum number of network attempts (%d) "
-                               "reached.", NETWORK_ATTEMPT_LIMIT);
+                               "reached", NETWORK_ATTEMPT_LIMIT);
       finish_network_callback (callback_data);
       return;
     }
@@ -496,7 +496,7 @@ handle_http_response (SoupSession         *http_session,
           g_task_return_new_error (callback_data->upload_task, G_IO_ERROR,
                                    G_IO_ERROR_INVALID_DATA,
                                    "Could not serialize updated network "
-                                   "request body.");
+                                   "request body");
           finish_network_callback (callback_data);
           return;
         }
@@ -523,7 +523,7 @@ handle_http_response (SoupSession         *http_session,
     }
 
   g_task_return_new_error (callback_data->upload_task, G_IO_ERROR,
-                           G_IO_ERROR_FAILED, "Received HTTP status code: %u.",
+                           G_IO_ERROR_FAILED, "Received HTTP status code: %u",
                            status_code);
   finish_network_callback (callback_data);
 }
@@ -637,7 +637,7 @@ create_request_body (EmerDaemon *self,
   if (!read_id)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Could not read machine ID.");
+                   "Could not read machine ID");
       return NULL;
     }
 
@@ -739,7 +739,7 @@ handle_network_monitor_can_reach (GNetworkMonitor *network_monitor,
   if (serialized_request_body == NULL)
     {
       g_task_return_new_error (upload_task, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
-                               "Could not serialize network request body.");
+                               "Could not serialize network request body");
       goto handle_upload_failed;
     }
 

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1079,16 +1079,6 @@ connect_to_login_manager (EmerDaemon *self)
                       G_CALLBACK (handle_login_manager_name_owner_set), self);
 }
 
-static gchar *
-get_user_agent (void)
-{
-  guint libsoup_major_version = soup_get_major_version ();
-  guint libsoup_minor_version = soup_get_minor_version ();
-  guint libsoup_micro_version = soup_get_micro_version ();
-  return g_strdup_printf ("libsoup/%u.%u.%u", libsoup_major_version,
-                          libsoup_minor_version, libsoup_micro_version);
-}
-
 static void
 on_permissions_changed (EmerPermissionsProvider *permissions_provider,
                         GParamSpec              *pspec,
@@ -1481,17 +1471,12 @@ emer_daemon_init (EmerDaemon *self)
 
   priv->upload_queue = g_queue_new ();
 
-  gchar *user_agent = get_user_agent ();
-
   priv->http_session =
     soup_session_new_with_options (SOUP_SESSION_MAX_CONNS, 1,
                                    SOUP_SESSION_MAX_CONNS_PER_HOST, 1,
-                                   SOUP_SESSION_USER_AGENT, user_agent,
                                    SOUP_SESSION_ADD_FEATURE_BY_TYPE,
                                    SOUP_TYPE_CACHE,
                                    NULL);
-
-  g_free (user_agent);
 
   priv->variant_array =
     g_ptr_array_new_with_free_func ((GDestroyNotify) g_variant_unref);

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -784,10 +784,8 @@ get_ping_socket (EmerDaemon *self)
     g_network_address_parse_uri (priv->server_uri, 443 /* SSL default port */,
                                  &error);
   if (ping_socket == NULL)
-  {
     g_error ("Invalid server URI '%s' could not be parsed because: %s.",
              priv->server_uri, error->message);
-  }
 
   return ping_socket;
 }

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -20,6 +20,8 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "emer-daemon.h"
+
 #include <time.h>
 #include <uuid/uuid.h>
 
@@ -32,7 +34,6 @@
 
 #include <eosmetrics/eosmetrics.h>
 
-#include "emer-daemon.h"
 #include "emer-machine-id-provider.h"
 #include "emer-network-send-provider.h"
 #include "emer-permissions-provider.h"

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -58,8 +58,8 @@
 #define NETWORK_ATTEMPT_LIMIT 8
 
 /*
- * How many seconds to delay between trying to send metrics to the proxy server
- * if we are online, or to the persistent cache, if we are offline.
+ * How many seconds to delay between trying to send events to the metrics
+ * servers if we are online, or to the persistent cache, if we are offline.
  *
  * For QA, the "dev" environment delay is much shorter.
  */
@@ -1358,8 +1358,8 @@ emer_daemon_class_init (EmerDaemonClass *klass)
    */
   emer_daemon_props[PROP_NETWORK_SEND_INTERVAL] =
     g_param_spec_uint ("network-send-interval", "Network send interval",
-                       "Number of seconds between attempts to flush metrics to "
-                       "proxy server",
+                       "Number of seconds between attempts to upload events to "
+                       "server",
                        0, G_MAXUINT, 0,
                        G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE |
                        G_PARAM_STATIC_STRINGS);
@@ -1427,15 +1427,15 @@ emer_daemon_class_init (EmerDaemonClass *klass)
   /*
    * EmerDaemon:persistent-cache:
    *
-   * An #EmerPersistentCache for storing metrics until they are sent to the
-   * proxy server.
+   * An #EmerPersistentCache for storing events until they are uploaded to the
+   * metrics servers.
    * If this property is not specified, a default persistent cache (created by
    * emer_persistent_cache_new ()) will be used.
    */
   emer_daemon_props[PROP_PERSISTENT_CACHE] =
     g_param_spec_object ("persistent-cache", "Persistent cache",
-                         "Object managing persistent storage of metrics until "
-                         "they are sent to the proxy server",
+                         "Object managing persistent storage of events until "
+                         "they are uploaded to the metrics servers",
                          EMER_TYPE_PERSISTENT_CACHE,
                          G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE |
                          G_PARAM_STATIC_STRINGS);

--- a/daemon/emer-daemon.h
+++ b/daemon/emer-daemon.h
@@ -72,7 +72,7 @@ struct _EmerDaemonClass
 
 GType                    emer_daemon_get_type                 (void) G_GNUC_CONST;
 
-EmerDaemon *             emer_daemon_new                      (void);
+EmerDaemon *             emer_daemon_new                      (const gchar             *persistent_cache_directory);
 
 EmerDaemon *             emer_daemon_new_full                 (GRand                   *rand,
                                                                const gchar             *server_uri,

--- a/daemon/emer-daemon.h
+++ b/daemon/emer-daemon.h
@@ -23,13 +23,13 @@
 #ifndef EMER_DAEMON_H
 #define EMER_DAEMON_H
 
+#include <gio/gio.h>
+#include <glib-object.h>
+
 #include "emer-machine-id-provider.h"
 #include "emer-network-send-provider.h"
 #include "emer-permissions-provider.h"
 #include "emer-persistent-cache.h"
-
-#include <gio/gio.h>
-#include <glib-object.h>
 
 G_BEGIN_DECLS
 

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -261,7 +261,7 @@ read_machine_id (EmerMachineIdProvider *self)
   gchar *hyphenated_machine_id = hyphenate_uuid (machine_id_sans_hyphens);
   g_free (machine_id_sans_hyphens);
 
-  int parse_failed = uuid_parse (hyphenated_machine_id, priv->id);
+  gint parse_failed = uuid_parse (hyphenated_machine_id, priv->id);
   g_free (hyphenated_machine_id);
 
   if (parse_failed != 0)

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -22,13 +22,13 @@
 
 #include "emer-machine-id-provider.h"
 
-#include "shared/metrics-util.h"
-
 #include <string.h>
 #include <uuid/uuid.h>
 
 #include <glib/gprintf.h>
 #include <glib/gstdio.h>
+
+#include "shared/metrics-util.h"
 
 typedef struct EmerMachineIdProviderPrivate
 {

--- a/daemon/emer-machine-id-provider.h
+++ b/daemon/emer-machine-id-provider.h
@@ -23,8 +23,9 @@
 #ifndef EMER_MACHINE_ID_PROVIDER_H
 #define EMER_MACHINE_ID_PROVIDER_H
 
-#include <glib-object.h>
 #include <uuid/uuid.h>
+
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -20,12 +20,13 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include <string.h>
+
+#include <gio/gio.h>
 #include <glib.h>
 #include <glib-object.h>
 #include <glib-unix.h>
-#include <gio/gio.h>
 #include <polkit/polkit.h>
-#include <string.h>
 
 #include "emer-daemon.h"
 #include "emer-event-recorder-server.h"

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -257,11 +257,52 @@ on_name_lost (GDBusConnection *system_bus,
   g_error ("Could not acquire name '%s' on system bus.", name);
 }
 
+static EmerDaemon *
+make_daemon (gint                argc,
+             const gchar * const argv[])
+{
+  gchar *persistent_cache_directory = NULL;
+  GOptionEntry option_entries[] =
+  {
+    { "persistent-cache-directory", 'p', G_OPTION_FLAG_NONE,
+      G_OPTION_ARG_FILENAME, &persistent_cache_directory,
+      "Store persistent cache at path", "path"},
+    { NULL }
+  };
+
+  GOptionContext *option_context =
+    g_option_context_new (NULL /* parameter string */);
+  g_option_context_add_main_entries (option_context, option_entries,
+                                     NULL /* translation domain */);
+
+  GError *error = NULL;
+  gboolean parse_succeeded =
+    g_option_context_parse (option_context, &argc, (gchar ***) &argv, &error);
+  g_option_context_free (option_context);
+
+  if (!parse_succeeded)
+    {
+      g_warning ("Option parsing failed: %s.", error->message);
+      g_error_free (error);
+      return NULL;
+    }
+
+  if (persistent_cache_directory == NULL)
+    return emer_daemon_new (PERSISTENT_CACHE_DIR);
+
+  EmerDaemon *daemon = emer_daemon_new (persistent_cache_directory);
+  g_free (persistent_cache_directory);
+
+  return daemon;
+}
+
 int
 main (int                argc,
       const char * const argv[])
 {
-  EmerDaemon *daemon = emer_daemon_new ();
+  EmerDaemon *daemon = make_daemon (argc, argv);
+  if (daemon == NULL)
+    return EXIT_FAILURE;
 
   GMainLoop *main_loop = g_main_loop_new (NULL, TRUE);
 

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -297,9 +297,9 @@ make_daemon (gint                argc,
   return daemon;
 }
 
-int
-main (int                argc,
-      const char * const argv[])
+gint
+main (gint                argc,
+      const gchar * const argv[])
 {
   EmerDaemon *daemon = make_daemon (argc, argv);
   if (daemon == NULL)

--- a/daemon/emer-network-send-provider.c
+++ b/daemon/emer-network-send-provider.c
@@ -32,11 +32,6 @@ typedef struct EmerNetworkSendProviderPrivate
 
 G_DEFINE_TYPE_WITH_PRIVATE (EmerNetworkSendProvider, emer_network_send_provider, G_TYPE_OBJECT)
 
-/*
- * The filepath to the metadata file containing the network send metadata.
- */
-#define DEFAULT_NETWORK_SEND_FILE_PATH PERSISTENT_CACHE_DIR "network_send_file"
-
 #define NETWORK_SEND_GROUP "network_send_data"
 #define NETWORK_SEND_KEY   "network_requests_sent"
 
@@ -123,7 +118,7 @@ emer_network_send_provider_class_init (EmerNetworkSendProviderClass *klass)
   emer_network_send_provider_props[PROP_PATH] =
     g_param_spec_string ("path", "Path",
                          "The path to the file where the network send data is stored.",
-                         DEFAULT_NETWORK_SEND_FILE_PATH,
+                         NULL,
                          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   object_class->set_property = emer_network_send_provider_set_property;
@@ -143,32 +138,17 @@ emer_network_send_provider_init (EmerNetworkSendProvider *self)
 
 /*
  * emer_network_send_provider_new:
- *
- * Constructs the provider used to obtain and store data regarding "network
- * send" metadata via the default filepath.
- *
- * Returns: (transfer full): A new #EmerNetworkSendProvider.
- * Free with g_object_unref().
- */
-EmerNetworkSendProvider *
-emer_network_send_provider_new (void)
-{
-  return g_object_new (EMER_TYPE_NETWORK_SEND_PROVIDER, NULL);
-}
-
-/*
- * emer_network_send_provider_new_full:
  * @path: path to a file containing network send data; see
  * #EmerNetworkSendProvider:path.
  *
- * Constructs the provider used to obtain and store data regarding "network
- * send" metadata via a given filepath.
+ * Constructs a provider that stores the number of upload attempts in a
+ * file at the given path.
  *
  * Returns: (transfer full): A new #EmerNetworkSendProvider.
  * Free with g_object_unref().
  */
 EmerNetworkSendProvider *
-emer_network_send_provider_new_full (const gchar *path)
+emer_network_send_provider_new (const gchar *path)
 {
   return g_object_new (EMER_TYPE_NETWORK_SEND_PROVIDER,
                        "path", path,

--- a/daemon/emer-network-send-provider.h
+++ b/daemon/emer-network-send-provider.h
@@ -77,9 +77,7 @@ struct _EmerNetworkSendProviderClass
 
 GType                    emer_network_send_provider_get_type              (void) G_GNUC_CONST;
 
-EmerNetworkSendProvider *emer_network_send_provider_new                   (void);
-
-EmerNetworkSendProvider *emer_network_send_provider_new_full              (const gchar             *path);
+EmerNetworkSendProvider *emer_network_send_provider_new                   (const gchar             *path);
 
 gint                     emer_network_send_provider_get_send_number       (EmerNetworkSendProvider *self);
 

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -471,8 +471,8 @@ emer_permissions_provider_new (void)
  *   Free with g_object_unref() when done.
  */
 EmerPermissionsProvider *
-emer_permissions_provider_new_full (const char *permissions_config_file_path,
-                                    const char *ostree_config_file_path)
+emer_permissions_provider_new_full (const gchar *permissions_config_file_path,
+                                    const gchar *ostree_config_file_path)
 {
   return g_object_new (EMER_TYPE_PERMISSIONS_PROVIDER,
                        "config-file-path", permissions_config_file_path,

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -24,8 +24,8 @@
 
 #include <string.h>
 
-#include <glib.h>
 #include <gio/gio.h>
+#include <glib.h>
 #include <ostree-repo.h>
 
 #include "shared/metrics-util.h"

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -866,8 +866,10 @@ emer_persistent_cache_initable_init (GInitable    *initable,
 
   if (g_mkdir_with_parents (priv->cache_directory, 02774) != 0)
     {
-      const gchar *error_string = g_strerror (errno);
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+      gint error_code = errno;
+      GIOErrorEnum gio_error_code = g_io_error_from_errno (error_code);
+      const gchar *error_string = g_strerror (error_code);
+      g_set_error (error, G_IO_ERROR, gio_error_code,
                    "Failed to create directory: %s. Error: %s",
                    priv->cache_directory, error_string);
       return FALSE;

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -37,6 +37,7 @@
 #include "shared/metrics-util.h"
 
 #define VARIANT_FILENAME "variants.dat"
+#define DEFAULT_VERSION_FILENAME "local_version_file"
 
 /* SECTION:emer-persistent-cache.c
  * @title: Persistent Cache
@@ -687,10 +688,9 @@ set_cache_version_provider (EmerPersistentCache      *self,
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  if (cache_version_provider == NULL)
-    priv->cache_version_provider = emer_cache_version_provider_new ();
-  else
-    priv->cache_version_provider = g_object_ref (cache_version_provider);
+  if (cache_version_provider != NULL)
+    g_object_ref (cache_version_provider);
+  priv->cache_version_provider = cache_version_provider;
 }
 
 static void
@@ -714,6 +714,16 @@ emer_persistent_cache_constructed (GObject *object)
 
   priv->boot_metadata_file_path =
     g_build_filename (priv->cache_directory, BOOT_OFFSET_METADATA_FILE, NULL);
+
+  if (priv->cache_version_provider == NULL)
+    {
+      gchar *cache_version_path =
+        g_build_filename (priv->cache_directory, DEFAULT_VERSION_FILENAME,
+                          NULL);
+      priv->cache_version_provider =
+        emer_cache_version_provider_new (cache_version_path);
+      g_free (cache_version_path);
+    }
 
   G_OBJECT_CLASS (emer_persistent_cache_parent_class)->constructed (object);
 }

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -864,7 +864,7 @@ emer_persistent_cache_initable_init (GInitable    *initable,
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  if (g_mkdir_with_parents (priv->cache_directory, 02774) != 0)
+  if (g_mkdir_with_parents (priv->cache_directory, 02775) != 0)
     {
       gint error_code = errno;
       GIOErrorEnum gio_error_code = g_io_error_from_errno (error_code);

--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -23,8 +23,8 @@
 #ifndef EMER_PERSISTENT_CACHE_H
 #define EMER_PERSISTENT_CACHE_H
 
-#include <glib-object.h>
 #include <gio/gio.h>
+#include <glib-object.h>
 
 #include "emer-boot-id-provider.h"
 #include "emer-cache-size-provider.h"

--- a/tests/daemon/mock-cache-version-provider.c
+++ b/tests/daemon/mock-cache-version-provider.c
@@ -6,7 +6,7 @@
 
 typedef struct _EmerCacheVersionProviderPrivate
 {
-  gboolean foo;
+  gint cache_version;
 } EmerCacheVersionProviderPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (EmerCacheVersionProvider,
@@ -35,7 +35,10 @@ gboolean
 emer_cache_version_provider_get_version (EmerCacheVersionProvider *self,
                                          gint                     *version)
 {
-  *version = 0;
+  EmerCacheVersionProviderPrivate *priv =
+    emer_cache_version_provider_get_instance_private (self);
+
+  *version = priv->cache_version;
   return TRUE;
 }
 
@@ -44,5 +47,9 @@ emer_cache_version_provider_set_version (EmerCacheVersionProvider *self,
                                          gint                      new_version,
                                          GError                  **error)
 {
+  EmerCacheVersionProviderPrivate *priv =
+    emer_cache_version_provider_get_instance_private (self);
+
+  priv->cache_version = new_version;
   return TRUE;
 }

--- a/tests/daemon/mock-cache-version-provider.c
+++ b/tests/daemon/mock-cache-version-provider.c
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* Copyright 2014 Endless Mobile, Inc. */
+/* Copyright 2014, 2015 Endless Mobile, Inc. */
 
 #include "emer-cache-version-provider.h"
 
@@ -24,13 +24,7 @@ emer_cache_version_provider_init (EmerCacheVersionProvider *self)
 }
 
 EmerCacheVersionProvider *
-emer_cache_version_provider_new ()
-{
-  return g_object_new (EMER_TYPE_CACHE_VERSION_PROVIDER, NULL);
-}
-
-EmerCacheVersionProvider *
-emer_cache_version_provider_new_full (const gchar *cache_version_file_path)
+emer_cache_version_provider_new (const gchar *path)
 {
   return g_object_new (EMER_TYPE_CACHE_VERSION_PROVIDER, NULL);
 }

--- a/tests/daemon/mock-cache-version-provider.c
+++ b/tests/daemon/mock-cache-version-provider.c
@@ -16,11 +16,13 @@ G_DEFINE_TYPE_WITH_PRIVATE (EmerCacheVersionProvider,
 static void
 emer_cache_version_provider_class_init (EmerCacheVersionProviderClass *klass)
 {
+  /* Nothing to do */
 }
 
 static void
 emer_cache_version_provider_init (EmerCacheVersionProvider *self)
 {
+  /* Nothing to do */
 }
 
 EmerCacheVersionProvider *

--- a/tests/daemon/mock-machine-id-provider.c
+++ b/tests/daemon/mock-machine-id-provider.c
@@ -22,8 +22,9 @@
 
 #include "emer-machine-id-provider.h"
 
-#include <glib.h>
 #include <uuid/uuid.h>
+
+#include <glib.h>
 
 #define MACHINE_ID "387c5206-24b5-4513-a34f-72689d5c0a0e"
 

--- a/tests/daemon/mock-network-send-provider.c
+++ b/tests/daemon/mock-network-send-provider.c
@@ -22,8 +22,8 @@
 
 #include "emer-network-send-provider.h"
 
-#include <glib.h>
 #include <gio/gio.h>
+#include <glib.h>
 
 typedef struct _EmerNetworkSendProviderPrivate
 {

--- a/tests/daemon/mock-network-send-provider.c
+++ b/tests/daemon/mock-network-send-provider.c
@@ -46,15 +46,9 @@ emer_network_send_provider_init (EmerNetworkSendProvider *self)
 /* MOCK PUBLIC API */
 
 EmerNetworkSendProvider *
-emer_network_send_provider_new (void)
+emer_network_send_provider_new (const gchar *path)
 {
   return g_object_new (EMER_TYPE_NETWORK_SEND_PROVIDER, NULL);
-}
-
-EmerNetworkSendProvider *
-emer_network_send_provider_new_full (const char *path)
-{
-  return emer_network_send_provider_new ();
 }
 
 gint

--- a/tests/daemon/mock-permissions-provider.c
+++ b/tests/daemon/mock-permissions-provider.c
@@ -58,8 +58,8 @@ emer_permissions_provider_new (void)
 }
 
 EmerPermissionsProvider *
-emer_permissions_provider_new_full (const char *config_file_path,
-                                    const char *ostree_config_file_path)
+emer_permissions_provider_new_full (const gchar *config_file_path,
+                                    const gchar *ostree_config_file_path)
 {
   return emer_permissions_provider_new ();
 }

--- a/tests/daemon/mock-permissions-provider.c
+++ b/tests/daemon/mock-permissions-provider.c
@@ -23,8 +23,8 @@
 #include "emer-permissions-provider.h"
 #include "mock-permissions-provider.h"
 
-#include <glib.h>
 #include <gio/gio.h>
+#include <glib.h>
 
 typedef struct _EmerPermissionsProviderPrivate
 {

--- a/tests/daemon/mock-permissions-provider.h
+++ b/tests/daemon/mock-permissions-provider.h
@@ -23,9 +23,9 @@
 #ifndef MOCK_PERMISSIONS_PROVIDER_H
 #define MOCK_PERMISSIONS_PROVIDER_H
 
-#include <glib.h>
-
 #include "emer-permissions-provider.h"
+
+#include <glib.h>
 
 G_BEGIN_DECLS
 

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -22,9 +22,10 @@
 
 #include "emer-persistent-cache.h"
 #include "mock-persistent-cache.h"
-#include "shared/metrics-util.h"
 
 #include <glib.h>
+
+#include "shared/metrics-util.h"
 
 typedef struct _EmerPersistentCachePrivate
 {

--- a/tests/daemon/test-boot-id-provider.c
+++ b/tests/daemon/test-boot-id-provider.c
@@ -22,10 +22,11 @@
 
 #include "emer-boot-id-provider.h"
 
+#include <uuid/uuid.h>
+
+#include <gio/gio.h>
 #include <glib.h>
 #include <glib/gstdio.h>
-#include <gio/gio.h>
-#include <uuid/uuid.h>
 
 #define TESTING_FILE_PATH "testing_boot_id_XXXXXX"
 #define FIRST_TESTING_ID  "67ba25f5-b7af-48f9-a746-d1421a7e49de\n"

--- a/tests/daemon/test-boot-id-provider.c
+++ b/tests/daemon/test-boot-id-provider.c
@@ -131,11 +131,11 @@ test_boot_id_provider_caches_id (struct Fixture *fixture,
   g_assert (uuid_compare (testing_id, real_id) != 0);
 }
 
-int
-main (int                argc,
-      const char * const argv[])
+gint
+main (gint                argc,
+      const gchar * const argv[])
 {
-  g_test_init (&argc, (char ***) &argv, NULL);
+  g_test_init (&argc, (gchar ***) &argv, NULL);
 // gboolean is being used as a dummy fixture.
 #define ADD_BOOT_TEST_FUNC(path, func) \
   g_test_add ((path), struct Fixture, NULL, setup, (func), teardown)

--- a/tests/daemon/test-cache-size-provider.c
+++ b/tests/daemon/test-cache-size-provider.c
@@ -120,11 +120,11 @@ test_cache_size_provider_caches_max_cache_size (Fixture      *fixture,
   g_assert_cmpint (second_max_cache_size, ==, FIRST_MAX_CACHE_SIZE);
 }
 
-int
-main (int                argc,
-      const char * const argv[])
+gint
+main (gint                argc,
+      const gchar * const argv[])
 {
-  g_test_init (&argc, (char ***) &argv, NULL);
+  g_test_init (&argc, (gchar ***) &argv, NULL);
 #define ADD_CACHE_SIZE_TEST_FUNC(path, func) \
   g_test_add ((path), Fixture, NULL, setup, (func), teardown)
 

--- a/tests/daemon/test-cache-version-provider.c
+++ b/tests/daemon/test-cache-version-provider.c
@@ -71,7 +71,7 @@ setup (Fixture      *fixture,
   write_testing_cache_keyfile (fixture, STARTING_KEY_FILE);
 
   fixture->version_provider =
-    emer_cache_version_provider_new_full (fixture->tmp_path);
+    emer_cache_version_provider_new (fixture->tmp_path);
 }
 
 static void

--- a/tests/daemon/test-cache-version-provider.c
+++ b/tests/daemon/test-cache-version-provider.c
@@ -147,11 +147,11 @@ test_cache_version_provider_can_set_version (Fixture      *fixture,
   g_assert_cmpint (second_version, ==, write_version);
 }
 
-int
-main (int                argc,
-      const char * const argv[])
+gint
+main (gint                argc,
+      const gchar * const argv[])
 {
-  g_test_init (&argc, (char ***) &argv, NULL);
+  g_test_init (&argc, (gchar ***) &argv, NULL);
 #define ADD_CACHE_VERSION_TEST_FUNC(path, func) \
   g_test_add ((path), Fixture, NULL, setup, (func), teardown)
 

--- a/tests/daemon/test-cache-version-provider.c
+++ b/tests/daemon/test-cache-version-provider.c
@@ -20,9 +20,9 @@
 
 #include "emer-cache-version-provider.h"
 
+#include <gio/gio.h>
 #include <glib.h>
 #include <glib/gstdio.h>
-#include <gio/gio.h>
 
 #define TESTING_FILE_PATH "testing_cache_version_XXXXXX"
 

--- a/tests/daemon/test-circular-file.c
+++ b/tests/daemon/test-circular-file.c
@@ -605,11 +605,11 @@ test_circular_file_shrink (Fixture      *fixture,
   g_object_unref (circular_file_2);
 }
 
-int
-main (int                argc,
-      const char * const argv[])
+gint
+main (gint                argc,
+      const gchar * const argv[])
 {
-  g_test_init (&argc, (char ***) &argv, NULL);
+  g_test_init (&argc, (gchar ***) &argv, NULL);
 
 #define ADD_CIRCULAR_FILE_TEST_FUNC(path, func) \
   g_test_add((path), Fixture, NULL, setup, (func), teardown)

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -1347,11 +1347,11 @@ test_daemon_limits_network_upload_size (Fixture      *fixture,
   wait_for_upload_to_finish (fixture);
 }
 
-int
-main (int                argc,
-      const char * const argv[])
+gint
+main (gint                argc,
+      const gchar * const argv[])
 {
-  g_test_init (&argc, (char ***) &argv, NULL);
+  g_test_init (&argc, (gchar ***) &argv, NULL);
 
 #define ADD_DAEMON_TEST(path, test_func) \
   g_test_add ((path), Fixture, NULL, setup, (test_func), teardown)

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -21,6 +21,21 @@
  */
 
 #include "emer-daemon.h"
+
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <uuid/uuid.h>
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
+#include <glib/gstdio.h>
+#include <libsoup/soup.h>
+
+#include <eosmetrics/eosmetrics.h>
+
 #include "emer-boot-id-provider.h"
 #include "emer-machine-id-provider.h"
 #include "emer-network-send-provider.h"
@@ -29,18 +44,6 @@
 #include "mock-permissions-provider.h"
 #include "mock-persistent-cache.h"
 #include "shared/metrics-util.h"
-
-#include <eosmetrics/eosmetrics.h>
-#include <gio/gio.h>
-#include <glib.h>
-#include <glib-object.h>
-#include <glib/gstdio.h>
-#include <libsoup/soup.h>
-#include <uuid/uuid.h>
-#include <signal.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/prctl.h>
 
 #define MOCK_SERVER_PATH TEST_DIR "daemon/mock-server.py"
 

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -991,7 +991,8 @@ setup (Fixture      *fixture,
   gchar *server_uri = get_server_uri (fixture->mock_server);
 
   fixture->mock_machine_id_provider = emer_machine_id_provider_new ();
-  fixture->mock_network_send_provider = emer_network_send_provider_new ();
+  fixture->mock_network_send_provider =
+    emer_network_send_provider_new (NULL /* path */);
   fixture->mock_permissions_provider = emer_permissions_provider_new ();
   fixture->mock_persistent_cache =
     emer_persistent_cache_new (NULL /* directory */, NULL /* GError */);
@@ -1025,7 +1026,7 @@ static void
 test_daemon_new_succeeds (Fixture      *fixture,
                           gconstpointer unused)
 {
-  EmerDaemon *daemon = emer_daemon_new ();
+  EmerDaemon *daemon = emer_daemon_new (NULL /* persistent cache directory */);
   g_assert_nonnull (daemon);
   g_object_unref (daemon);
 }

--- a/tests/daemon/test-machine-id-provider.c
+++ b/tests/daemon/test-machine-id-provider.c
@@ -114,15 +114,15 @@ test_machine_id_provider_can_get_id (gboolean     *unused,
   g_object_unref (id_provider);
 }
 
-int
-main (int                argc,
-      const char * const argv[])
+gint
+main (gint                argc,
+      const gchar * const argv[])
 {
 // We are using a gboolean as a fixture type, but it will go unused.
 #define ADD_CACHE_TEST_FUNC(path, func) \
   g_test_add((path), gboolean, NULL, setup, (func), teardown)
 
-  g_test_init (&argc, (char ***) &argv, NULL);
+  g_test_init (&argc, (gchar ***) &argv, NULL);
 
   ADD_CACHE_TEST_FUNC ("/machine-id-provider/new-succeeds",
                        test_machine_id_provider_new_succeeds);

--- a/tests/daemon/test-machine-id-provider.c
+++ b/tests/daemon/test-machine-id-provider.c
@@ -22,10 +22,11 @@
 
 #include "emer-machine-id-provider.h"
 
+#include <uuid/uuid.h>
+
+#include <gio/gio.h>
 #include <glib.h>
 #include <glib/gstdio.h>
-#include <gio/gio.h>
-#include <uuid/uuid.h>
 
 #define HYPHENS_IN_ID 4
 

--- a/tests/daemon/test-network-send-provider.c
+++ b/tests/daemon/test-network-send-provider.c
@@ -20,9 +20,9 @@
 
 #include "emer-network-send-provider.h"
 
+#include <gio/gio.h>
 #include <glib.h>
 #include <glib/gstdio.h>
-#include <gio/gio.h>
 
 #define TESTING_FILE_PATH "testing_network_send_XXXXXX"
 

--- a/tests/daemon/test-network-send-provider.c
+++ b/tests/daemon/test-network-send-provider.c
@@ -166,11 +166,11 @@ test_network_send_provider_resets_when_corrupted (Fixture      *fixture,
   g_assert_cmpint (second_send_number, ==, RESET_SEND_NUMBER);
 }
 
-int
-main (int                argc,
-      const char * const argv[])
+gint
+main (gint                argc,
+      const gchar * const argv[])
 {
-  g_test_init (&argc, (char ***) &argv, NULL);
+  g_test_init (&argc, (gchar ***) &argv, NULL);
 #define ADD_CACHE_VERSION_TEST_FUNC(path, func) \
   g_test_add ((path), Fixture, NULL, setup, (func), teardown)
 

--- a/tests/daemon/test-network-send-provider.c
+++ b/tests/daemon/test-network-send-provider.c
@@ -79,7 +79,7 @@ setup (Fixture      *fixture,
   write_testing_keyfile (fixture, STARTING_KEY_FILE);
 
   fixture->network_send_provider =
-    emer_network_send_provider_new_full (fixture->tmp_path);
+    emer_network_send_provider_new (fixture->tmp_path);
 }
 
 static void

--- a/tests/daemon/test-permissions-provider.c
+++ b/tests/daemon/test-permissions-provider.c
@@ -449,11 +449,11 @@ test_permissions_provider_set_daemon_enabled_updates_config_file (Fixture      *
   g_free (contents);
 }
 
-int
-main (int                argc,
-      const char * const argv[])
+gint
+main (gint                argc,
+      const gchar * const argv[])
 {
-  g_test_init (&argc, (char ***) &argv, NULL);
+  g_test_init (&argc, (gchar ***) &argv, NULL);
 
 #define ADD_PERMISSIONS_PROVIDER_TEST(path, file_contents, setup, test_func) \
   g_test_add ((path), Fixture, (file_contents), (setup), (test_func), teardown);

--- a/tests/daemon/test-permissions-provider.c
+++ b/tests/daemon/test-permissions-provider.c
@@ -24,8 +24,8 @@
 
 #include <string.h>
 
-#include <glib.h>
 #include <gio/gio.h>
+#include <glib.h>
 
 #define SIGNAL_TIMEOUT_SEC 5
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -1190,11 +1190,11 @@ test_persistent_cache_get_offset_can_build_boot_metadata_file (gboolean     *unu
   g_object_unref (cache);
 }
 
-int
-main (int                argc,
-      const char * const argv[])
+gint
+main (gint                argc,
+      const gchar * const argv[])
 {
-  g_test_init (&argc, (char ***) &argv, NULL);
+  g_test_init (&argc, (gchar ***) &argv, NULL);
 
 // We are using a gboolean as a fixture type, but it will go unused.
 #define ADD_CACHE_TEST_FUNC(path, func) \

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -140,7 +140,7 @@ make_testing_cache (void)
   EmerBootIdProvider *boot_id_provider =
     emer_boot_id_provider_new_full (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   EmerCacheVersionProvider *cache_version_provider =
-    emer_cache_version_provider_new_full (NULL);
+    emer_cache_version_provider_new (NULL);
   GError *error = NULL;
   g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
                          "Failed to unlink old cache file " TEST_DIRECTORY
@@ -595,7 +595,7 @@ test_persistent_cache_store_when_full (gboolean     *unused,
   EmerBootIdProvider *boot_id_provider =
     emer_boot_id_provider_new_full (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   EmerCacheVersionProvider *cache_version_provider =
-    emer_cache_version_provider_new_full (NULL);
+    emer_cache_version_provider_new (NULL);
   GError *error = NULL;
   g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
                          "Failed to unlink old cache file " TEST_DIRECTORY
@@ -820,7 +820,7 @@ test_persistent_cache_purges_when_out_of_date (gboolean     *unused,
   EmerBootIdProvider *boot_id_provider =
     emer_boot_id_provider_new_full (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   EmerCacheVersionProvider *cache_version_provider =
-    emer_cache_version_provider_new_full (NULL);
+    emer_cache_version_provider_new (NULL);
   GError *error = NULL;
   g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
                          "Failed to unlink old cache file " TEST_DIRECTORY

--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -55,6 +55,12 @@ print_variants_to_file (GVariant   **variants,
       return FALSE;
     }
 
+  if (num_variants == 0)
+    {
+      g_object_unref (file_output_stream);
+      return TRUE;
+    }
+
   GByteArray *byte_array = g_byte_array_new ();
   for (gint i = 0; i < num_variants; i++)
     {


### PR DESCRIPTION
Use the new argument in test-opt-out-integration.py to put the
persistent cache directory in a temporary directory so that
make check no longer assumes make install has been run.

[endlessm/eos-sdk#3151]