### PR TITLE
Create cache size file at runtime.

### DIFF
--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -56,7 +56,6 @@ systembussecuritypolicydir = ${sysconfdir}/dbus-1/system.d
 dist_systembussecuritypolicy_DATA = data/com.endlessm.Metrics.conf
 
 dist_config_DATA = \
-	data/cache-size.conf \
 	data/eos-metrics-permissions.conf \
 	$(NULL)
 

--- a/data/cache-size.conf
+++ b/data/cache-size.conf
@@ -1,2 +1,0 @@
-[persistent_cache_size]
-maximum=10000000


### PR DESCRIPTION
Don't create it on make install since it's needed by one of our tests
and make check shouldn't assume that make install has been run.

[endlessm/eos-sdk#3151]