### PR TITLE
Support persistent cache dir command line arg.

### DIFF
--- a/daemon/emer-cache-version-provider.c
+++ b/daemon/emer-cache-version-provider.c
@@ -32,12 +32,6 @@ typedef struct EmerCacheVersionProviderPrivate
 
 G_DEFINE_TYPE_WITH_PRIVATE (EmerCacheVersionProvider, emer_cache_version_provider, G_TYPE_OBJECT)
 
-/*
- * This is the filepath to the metadata file containing the local network
- * protocol version.
- */
-#define DEFAULT_CACHE_VERSION_FILE_PATH PERSISTENT_CACHE_DIR "local_version_file"
-
 #define CACHE_VERSION_GROUP "cache_version_info"
 #define CACHE_VERSION_KEY   "version"
 
@@ -117,7 +111,7 @@ emer_cache_version_provider_class_init (EmerCacheVersionProviderClass *klass)
   emer_cache_version_provider_props[PROP_PATH] =
     g_param_spec_string ("path", "Path",
                          "The path to the file where the cache version is stored.",
-                         DEFAULT_CACHE_VERSION_FILE_PATH,
+                         NULL,
                          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   object_class->set_property = emer_cache_version_provider_set_property;
@@ -137,34 +131,19 @@ emer_cache_version_provider_init (EmerCacheVersionProvider *self)
 
 /*
  * emer_cache_version_provider_new:
+ * @path: see #EmerCacheVersionProvider:path
  *
- * Constructs the ID provider used to obtain a cache format version
- * via the default filepath.
- *
- * Returns: (transfer full): A new #EmerCacheVersionProvider.
- * Free with g_object_unref().
- */
-EmerCacheVersionProvider *
-emer_cache_version_provider_new (void)
-{
-  return g_object_new (EMER_TYPE_CACHE_VERSION_PROVIDER, NULL);
-}
-
-/*
- * emer_cache_version_provider_new_full:
- * @cache_version_file_path: path to a file; see #EmerCacheVersionProvider:path
- *
- * Constructs the ID provider used to obtain a cache format version
- * via a given filepath.
+ * Constructs a provider that stores the cache format version in a file at the
+ * given path.
  *
  * Returns: (transfer full): A new #EmerCacheVersionProvider.
  * Free with g_object_unref().
  */
 EmerCacheVersionProvider *
-emer_cache_version_provider_new_full (const gchar *cache_version_file_path)
+emer_cache_version_provider_new (const gchar *path)
 {
   return g_object_new (EMER_TYPE_CACHE_VERSION_PROVIDER,
-                       "path", cache_version_file_path,
+                       "path", path,
                        NULL);
 }
 

--- a/daemon/emer-cache-version-provider.h
+++ b/daemon/emer-cache-version-provider.h
@@ -78,9 +78,7 @@ struct _EmerCacheVersionProviderClass
 
 GType                     emer_cache_version_provider_get_type    (void) G_GNUC_CONST;
 
-EmerCacheVersionProvider *emer_cache_version_provider_new         (void);
-
-EmerCacheVersionProvider *emer_cache_version_provider_new_full    (const gchar              *version_file_path);
+EmerCacheVersionProvider *emer_cache_version_provider_new         (const gchar              *path);
 
 gboolean                  emer_cache_version_provider_get_version (EmerCacheVersionProvider *self,
                                                                    gint                     *version);

--- a/daemon/emer-daemon.h
+++ b/daemon/emer-daemon.h
@@ -72,7 +72,7 @@ struct _EmerDaemonClass
 
 GType                    emer_daemon_get_type                 (void) G_GNUC_CONST;
 
-EmerDaemon *             emer_daemon_new                      (void);
+EmerDaemon *             emer_daemon_new                      (const gchar             *persistent_cache_directory);
 
 EmerDaemon *             emer_daemon_new_full                 (GRand                   *rand,
                                                                const gchar             *server_uri,

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -257,11 +257,52 @@ on_name_lost (GDBusConnection *system_bus,
   g_error ("Could not acquire name '%s' on system bus.", name);
 }
 
+static EmerDaemon *
+make_daemon (gint                argc,
+             const gchar * const argv[])
+{
+  gchar *persistent_cache_directory = NULL;
+  GOptionEntry option_entries[] =
+  {
+    { "persistent-cache-directory", 'p', G_OPTION_FLAG_NONE,
+      G_OPTION_ARG_FILENAME, &persistent_cache_directory,
+      "Store persistent cache at path", "path"},
+    { NULL }
+  };
+
+  GOptionContext *option_context =
+    g_option_context_new (NULL /* parameter string */);
+  g_option_context_add_main_entries (option_context, option_entries,
+                                     NULL /* translation domain */);
+
+  GError *error = NULL;
+  gboolean parse_succeeded =
+    g_option_context_parse (option_context, &argc, (gchar ***) &argv, &error);
+  g_option_context_free (option_context);
+
+  if (!parse_succeeded)
+    {
+      g_warning ("Option parsing failed: %s.", error->message);
+      g_error_free (error);
+      return NULL;
+    }
+
+  if (persistent_cache_directory == NULL)
+    return emer_daemon_new (PERSISTENT_CACHE_DIR);
+
+  EmerDaemon *daemon = emer_daemon_new (persistent_cache_directory);
+  g_free (persistent_cache_directory);
+
+  return daemon;
+}
+
 int
 main (int                argc,
       const char * const argv[])
 {
-  EmerDaemon *daemon = emer_daemon_new ();
+  EmerDaemon *daemon = make_daemon (argc, argv);
+  if (daemon == NULL)
+    return EXIT_FAILURE;
 
   GMainLoop *main_loop = g_main_loop_new (NULL, TRUE);
 

--- a/daemon/emer-network-send-provider.c
+++ b/daemon/emer-network-send-provider.c
@@ -32,11 +32,6 @@ typedef struct EmerNetworkSendProviderPrivate
 
 G_DEFINE_TYPE_WITH_PRIVATE (EmerNetworkSendProvider, emer_network_send_provider, G_TYPE_OBJECT)
 
-/*
- * The filepath to the metadata file containing the network send metadata.
- */
-#define DEFAULT_NETWORK_SEND_FILE_PATH PERSISTENT_CACHE_DIR "network_send_file"
-
 #define NETWORK_SEND_GROUP "network_send_data"
 #define NETWORK_SEND_KEY   "network_requests_sent"
 
@@ -123,7 +118,7 @@ emer_network_send_provider_class_init (EmerNetworkSendProviderClass *klass)
   emer_network_send_provider_props[PROP_PATH] =
     g_param_spec_string ("path", "Path",
                          "The path to the file where the network send data is stored.",
-                         DEFAULT_NETWORK_SEND_FILE_PATH,
+                         NULL,
                          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   object_class->set_property = emer_network_send_provider_set_property;
@@ -143,32 +138,17 @@ emer_network_send_provider_init (EmerNetworkSendProvider *self)
 
 /*
  * emer_network_send_provider_new:
- *
- * Constructs the provider used to obtain and store data regarding "network
- * send" metadata via the default filepath.
- *
- * Returns: (transfer full): A new #EmerNetworkSendProvider.
- * Free with g_object_unref().
- */
-EmerNetworkSendProvider *
-emer_network_send_provider_new (void)
-{
-  return g_object_new (EMER_TYPE_NETWORK_SEND_PROVIDER, NULL);
-}
-
-/*
- * emer_network_send_provider_new_full:
  * @path: path to a file containing network send data; see
  * #EmerNetworkSendProvider:path.
  *
- * Constructs the provider used to obtain and store data regarding "network
- * send" metadata via a given filepath.
+ * Constructs a provider that stores the number of upload attempts in a
+ * file at the given path.
  *
  * Returns: (transfer full): A new #EmerNetworkSendProvider.
  * Free with g_object_unref().
  */
 EmerNetworkSendProvider *
-emer_network_send_provider_new_full (const gchar *path)
+emer_network_send_provider_new (const gchar *path)
 {
   return g_object_new (EMER_TYPE_NETWORK_SEND_PROVIDER,
                        "path", path,

--- a/daemon/emer-network-send-provider.h
+++ b/daemon/emer-network-send-provider.h
@@ -77,9 +77,7 @@ struct _EmerNetworkSendProviderClass
 
 GType                    emer_network_send_provider_get_type              (void) G_GNUC_CONST;
 
-EmerNetworkSendProvider *emer_network_send_provider_new                   (void);
-
-EmerNetworkSendProvider *emer_network_send_provider_new_full              (const gchar             *path);
+EmerNetworkSendProvider *emer_network_send_provider_new                   (const gchar             *path);
 
 gint                     emer_network_send_provider_get_send_number       (EmerNetworkSendProvider *self);
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -37,6 +37,7 @@
 #include "shared/metrics-util.h"
 
 #define VARIANT_FILENAME "variants.dat"
+#define DEFAULT_VERSION_FILENAME "local_version_file"
 
 /* SECTION:emer-persistent-cache.c
  * @title: Persistent Cache
@@ -687,10 +688,9 @@ set_cache_version_provider (EmerPersistentCache      *self,
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  if (cache_version_provider == NULL)
-    priv->cache_version_provider = emer_cache_version_provider_new ();
-  else
-    priv->cache_version_provider = g_object_ref (cache_version_provider);
+  if (cache_version_provider != NULL)
+    g_object_ref (cache_version_provider);
+  priv->cache_version_provider = cache_version_provider;
 }
 
 static void
@@ -714,6 +714,16 @@ emer_persistent_cache_constructed (GObject *object)
 
   priv->boot_metadata_file_path =
     g_build_filename (priv->cache_directory, BOOT_OFFSET_METADATA_FILE, NULL);
+
+  if (priv->cache_version_provider == NULL)
+    {
+      gchar *cache_version_path =
+        g_build_filename (priv->cache_directory, DEFAULT_VERSION_FILENAME,
+                          NULL);
+      priv->cache_version_provider =
+        emer_cache_version_provider_new (cache_version_path);
+      g_free (cache_version_path);
+    }
 
   G_OBJECT_CLASS (emer_persistent_cache_parent_class)->constructed (object);
 }

--- a/tests/daemon/mock-cache-version-provider.c
+++ b/tests/daemon/mock-cache-version-provider.c
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* Copyright 2014 Endless Mobile, Inc. */
+/* Copyright 2014, 2015 Endless Mobile, Inc. */
 
 #include "emer-cache-version-provider.h"
 
@@ -24,13 +24,7 @@ emer_cache_version_provider_init (EmerCacheVersionProvider *self)
 }
 
 EmerCacheVersionProvider *
-emer_cache_version_provider_new ()
-{
-  return g_object_new (EMER_TYPE_CACHE_VERSION_PROVIDER, NULL);
-}
-
-EmerCacheVersionProvider *
-emer_cache_version_provider_new_full (const gchar *cache_version_file_path)
+emer_cache_version_provider_new (const gchar *path)
 {
   return g_object_new (EMER_TYPE_CACHE_VERSION_PROVIDER, NULL);
 }

--- a/tests/daemon/mock-network-send-provider.c
+++ b/tests/daemon/mock-network-send-provider.c
@@ -46,15 +46,9 @@ emer_network_send_provider_init (EmerNetworkSendProvider *self)
 /* MOCK PUBLIC API */
 
 EmerNetworkSendProvider *
-emer_network_send_provider_new (void)
+emer_network_send_provider_new (const gchar *path)
 {
   return g_object_new (EMER_TYPE_NETWORK_SEND_PROVIDER, NULL);
-}
-
-EmerNetworkSendProvider *
-emer_network_send_provider_new_full (const char *path)
-{
-  return emer_network_send_provider_new ();
 }
 
 gint

--- a/tests/daemon/test-cache-version-provider.c
+++ b/tests/daemon/test-cache-version-provider.c
@@ -71,7 +71,7 @@ setup (Fixture      *fixture,
   write_testing_cache_keyfile (fixture, STARTING_KEY_FILE);
 
   fixture->version_provider =
-    emer_cache_version_provider_new_full (fixture->tmp_path);
+    emer_cache_version_provider_new (fixture->tmp_path);
 }
 
 static void

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -991,7 +991,8 @@ setup (Fixture      *fixture,
   gchar *server_uri = get_server_uri (fixture->mock_server);
 
   fixture->mock_machine_id_provider = emer_machine_id_provider_new ();
-  fixture->mock_network_send_provider = emer_network_send_provider_new ();
+  fixture->mock_network_send_provider =
+    emer_network_send_provider_new (NULL /* path */);
   fixture->mock_permissions_provider = emer_permissions_provider_new ();
   fixture->mock_persistent_cache =
     emer_persistent_cache_new (NULL /* directory */, NULL /* GError */);
@@ -1025,7 +1026,7 @@ static void
 test_daemon_new_succeeds (Fixture      *fixture,
                           gconstpointer unused)
 {
-  EmerDaemon *daemon = emer_daemon_new ();
+  EmerDaemon *daemon = emer_daemon_new (NULL /* persistent cache directory */);
   g_assert_nonnull (daemon);
   g_object_unref (daemon);
 }

--- a/tests/daemon/test-network-send-provider.c
+++ b/tests/daemon/test-network-send-provider.c
@@ -79,7 +79,7 @@ setup (Fixture      *fixture,
   write_testing_keyfile (fixture, STARTING_KEY_FILE);
 
   fixture->network_send_provider =
-    emer_network_send_provider_new_full (fixture->tmp_path);
+    emer_network_send_provider_new (fixture->tmp_path);
 }
 
 static void

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -140,7 +140,7 @@ make_testing_cache (void)
   EmerBootIdProvider *boot_id_provider =
     emer_boot_id_provider_new_full (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   EmerCacheVersionProvider *cache_version_provider =
-    emer_cache_version_provider_new_full (NULL);
+    emer_cache_version_provider_new (NULL);
   GError *error = NULL;
   g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
                          "Failed to unlink old cache file " TEST_DIRECTORY
@@ -595,7 +595,7 @@ test_persistent_cache_store_when_full (gboolean     *unused,
   EmerBootIdProvider *boot_id_provider =
     emer_boot_id_provider_new_full (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   EmerCacheVersionProvider *cache_version_provider =
-    emer_cache_version_provider_new_full (NULL);
+    emer_cache_version_provider_new (NULL);
   GError *error = NULL;
   g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
                          "Failed to unlink old cache file " TEST_DIRECTORY
@@ -820,7 +820,7 @@ test_persistent_cache_purges_when_out_of_date (gboolean     *unused,
   EmerBootIdProvider *boot_id_provider =
     emer_boot_id_provider_new_full (TEST_DIRECTORY TEST_SYSTEM_BOOT_ID_FILE);
   EmerCacheVersionProvider *cache_version_provider =
-    emer_cache_version_provider_new_full (NULL);
+    emer_cache_version_provider_new (NULL);
   GError *error = NULL;
   g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
                          "Failed to unlink old cache file " TEST_DIRECTORY


### PR DESCRIPTION
Use the new argument in test-opt-out-integration.py to put the
persistent cache directory in a temporary directory so that
make check no longer assumes make install has been run.

[endlessm/eos-sdk#3151]