### PR TITLE
Don't specify Wants=systemd-login.service

### DIFF
--- a/data/eos-metrics-event-recorder.service.in
+++ b/data/eos-metrics-event-recorder.service.in
@@ -1,6 +1,5 @@
 [Unit]
 Description=EndlessOS Metrics Event Recorder Server
-Wants=systemd-logind.service
 
 [Service]
 Environment=DCONF_PROFILE=/dev/null


### PR DESCRIPTION
We already handle both the case when logind is around and when it's not
at startup.

[endlessm/eos-sdk#3531]