### PR TITLE
Remove the shutdown hooks for timestamp updates/cache flushing

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -368,7 +368,7 @@ get_offset_timestamps (EmerDaemon *self,
 
   gint64 boot_offset;
   if (!emer_persistent_cache_get_boot_time_offset (priv->persistent_cache,
-                                                   &boot_offset, FALSE, error))
+                                                   &boot_offset, error))
     return FALSE;
 
   *rel_timestamp_ptr += boot_offset;
@@ -1380,7 +1380,7 @@ emer_daemon_record_singular_event (EmerDaemon *self,
   gint64 boot_offset;
   GError *error = NULL;
   if (!emer_persistent_cache_get_boot_time_offset (priv->persistent_cache,
-                                                   &boot_offset, FALSE, &error))
+                                                   &boot_offset, &error))
     {
       g_warning ("Unable to correct event's relative timestamp. Dropping "
                  "event. Error: %s.", error->message);
@@ -1420,7 +1420,7 @@ emer_daemon_record_aggregate_event (EmerDaemon *self,
   gint64 boot_offset;
   GError *error = NULL;
   if (!emer_persistent_cache_get_boot_time_offset (priv->persistent_cache,
-                                                   &boot_offset, FALSE, &error))
+                                                   &boot_offset, &error))
     {
       g_warning ("Unable to correct event's relative timestamp. Dropping "
                  "event. Error: %s.", error->message);
@@ -1457,7 +1457,7 @@ emer_daemon_record_event_sequence (EmerDaemon *self,
   gint64 boot_offset;
   GError *error = NULL;
   if (!emer_persistent_cache_get_boot_time_offset (priv->persistent_cache,
-                                                   &boot_offset, FALSE, &error))
+                                                   &boot_offset, &error))
     {
       g_warning ("Unable to correct event's relative timestamp. Dropping "
                  "event. Error: %s.", error->message);

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -966,17 +966,13 @@ emer_persistent_cache_cost (GVariant *variant)
 gboolean
 emer_persistent_cache_get_boot_time_offset (EmerPersistentCache *self,
                                             gint64              *offset,
-                                            gboolean             always_update_timestamps,
                                             GError             **error)
 {
   EmerPersistentCachePrivate *priv =
     emer_persistent_cache_get_instance_private (self);
 
-  /* When always_update_timestamps is FALSE, the timestamps won't be written
-   * unless the boot offset in the metadata file is being overwritten.
-   */
   gboolean update_succeeded =
-    update_boot_offset (self, always_update_timestamps, error);
+    update_boot_offset (self, FALSE, error);
   if (!update_succeeded)
     return FALSE;
 

--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -93,7 +93,6 @@ gsize                emer_persistent_cache_cost                 (GVariant       
 
 gboolean             emer_persistent_cache_get_boot_time_offset (EmerPersistentCache      *self,
                                                                  gint64                   *offset,
-                                                                 gboolean                  always_update_timestamps,
                                                                  GError                  **error);
 
 gboolean             emer_persistent_cache_store                (EmerPersistentCache      *self,

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -30,7 +30,6 @@
 typedef struct _EmerPersistentCachePrivate
 {
   GPtrArray *variant_array;
-  gint num_timestamp_updates;
 } EmerPersistentCachePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (EmerPersistentCache, emer_persistent_cache,
@@ -92,16 +91,8 @@ emer_persistent_cache_cost (GVariant *variant)
 gboolean
 emer_persistent_cache_get_boot_time_offset (EmerPersistentCache *self,
                                             gint64              *offset,
-                                            gboolean             always_update_timestamps,
                                             GError             **error)
 {
-  if (always_update_timestamps)
-    {
-      EmerPersistentCachePrivate *priv =
-        emer_persistent_cache_get_instance_private (self);
-      priv->num_timestamp_updates++;
-    }
-
   if (offset != NULL)
     *offset = BOOT_TIME_OFFSET;
   return TRUE;
@@ -185,15 +176,4 @@ emer_persistent_cache_remove (EmerPersistentCache *self,
     g_ptr_array_remove_range (priv->variant_array, 0, token);
 
   return TRUE;
-}
-
-/* API OF MOCK OBJECT */
-
-gint
-mock_persistent_cache_get_num_timestamp_updates (EmerPersistentCache *self)
-{
-  EmerPersistentCachePrivate *priv =
-    emer_persistent_cache_get_instance_private (self);
-
-  return priv->num_timestamp_updates;
 }

--- a/tests/daemon/mock-persistent-cache.h
+++ b/tests/daemon/mock-persistent-cache.h
@@ -32,8 +32,6 @@ G_BEGIN_DECLS
 #define BOOT_TIME_OFFSET G_GINT64_CONSTANT (73)
 #define MAX_NUM_VARIANTS 10
 
-gint mock_persistent_cache_get_num_timestamp_updates (EmerPersistentCache *self);
-
 G_END_DECLS
 
 #endif /* MOCK_PERSISTENT_CACHE_H */

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -48,7 +48,6 @@
 #define MOCK_SERVER_PATH TEST_DIR "daemon/mock-server.py"
 
 #define MEANINGLESS_EVENT "350ac4ff-3026-4c25-9e7e-e8103b4fd5d8"
-#define MEANINGLESS_EVENT_2 "d936cd5c-08de-4d4e-8a87-8df1f4a33cba"
 
 #define USER_ID 4200u
 #define NUM_EVENTS G_GINT64_CONSTANT (101)

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -63,12 +63,6 @@
 
 #define TIMEOUT_SEC 5
 
-#define EXPECTED_INHIBIT_SHUTDOWN_ARGS \
-  "\"shutdown\" " \
-  "\"EndlessOS Event Recorder Daemon\" " \
-  "\"Flushing events to disk\" " \
-  "\"delay\""
-
 typedef struct _Fixture
 {
   EmerDaemon *test_object;
@@ -78,7 +72,6 @@ typedef struct _Fixture
   EmerPersistentCache *mock_persistent_cache;
 
   GSubprocess *mock_server;
-  GSubprocess *logind_mock;
 
   gint64 relative_time;
   gint64 absolute_time;
@@ -130,15 +123,6 @@ terminate_subprocess_and_wait (GSubprocess *subprocess)
   g_object_unref (subprocess);
 }
 
-static void
-start_mock_logind_service (Fixture *fixture)
-{
-  fixture->logind_mock =
-    g_subprocess_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE, NULL, "python3", "-m",
-                      "dbusmock", "--system", "--template", "logind", NULL);
-  g_assert_nonnull (fixture->logind_mock);
-}
-
 static gboolean
 timeout (gpointer unused)
 {
@@ -177,17 +161,6 @@ contains_dbus_call (const gchar *line,
   gchar *given_args_index = strstr (arguments_given, arguments);
   g_free (arguments_given);
   return given_args_index != NULL;
-}
-
-static gboolean
-process_logind_line (GString *line,
-                     gpointer unused)
-{
-  // Ensure that the only null byte in the line is the terminal null byte.
-  g_assert_cmpuint (line->len, ==, strlen (line->str));
-
-  return !contains_dbus_call (line->str, "Inhibit",
-                              EXPECTED_INHIBIT_SHUTDOWN_ARGS);
 }
 
 static gboolean
@@ -432,28 +405,6 @@ read_bytes_from_stdout (GSubprocess           *subprocess,
   g_source_remove (timeout_id);
   g_main_loop_unref (byte_collector.main_loop);
   g_byte_array_unref (byte_collector.byte_array);
-}
-
-static void
-emit_shutdown_signal (gboolean shutdown)
-{
-  GDBusConnection *system_bus = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, NULL);
-  g_assert_nonnull (system_bus);
-
-  GVariantBuilder args_builder;
-  g_variant_builder_init (&args_builder, G_VARIANT_TYPE ("av"));
-  g_variant_builder_add (&args_builder, "v", g_variant_new ("b", shutdown));
-  GVariant *response =
-    g_dbus_connection_call_sync (system_bus, "org.freedesktop.login1",
-                                 "/org/freedesktop/login1",
-                                 "org.freedesktop.DBus.Mock", "EmitSignal",
-                                 g_variant_new ("(sssav)", "",
-                                                "PrepareForShutdown", "b",
-                                                &args_builder),
-                                 NULL, G_DBUS_CALL_FLAGS_NO_AUTO_START,
-                                 TIMEOUT_SEC * 1000,
-                                 NULL, NULL);
-  g_assert_nonnull (response);
 }
 
 static GVariant *
@@ -1015,7 +966,7 @@ static void
 teardown (Fixture      *fixture,
           gconstpointer unused)
 {
-  g_object_unref (fixture->test_object);
+  g_clear_object (&fixture->test_object);
   g_object_unref (fixture->mock_machine_id_provider);
   g_object_unref (fixture->mock_network_send_provider);
   g_object_unref (fixture->mock_permissions_provider);
@@ -1225,48 +1176,13 @@ test_daemon_does_not_record_sequences_when_daemon_disabled (Fixture      *fixtur
 }
 
 static void
-test_daemon_updates_timestamps_on_shutdown (Fixture      *fixture,
-                                            gconstpointer unused)
-{
-  start_mock_logind_service (fixture);
-
-  gint num_timestamp_updates_before =
-    mock_persistent_cache_get_num_timestamp_updates (fixture->mock_persistent_cache);
-
-  read_lines_from_stdout (fixture->logind_mock,
-                          (ProcessLineSourceFunc) process_logind_line,
-                          NULL /* user_data */);
-  emit_shutdown_signal (TRUE);
-
-  // Wait for EmerDaemon to handle the signal.
-  while (g_main_context_pending (NULL))
-    g_main_context_iteration (NULL, TRUE);
-
-  gint num_timestamp_updates_after =
-    mock_persistent_cache_get_num_timestamp_updates (fixture->mock_persistent_cache);
-  g_assert_cmpint (num_timestamp_updates_after, ==, num_timestamp_updates_before + 1);
-
-  terminate_subprocess_and_wait (fixture->logind_mock);
-}
-
-static void
-test_daemon_flushes_to_persistent_cache_on_shutdown (Fixture      *fixture,
+test_daemon_flushes_to_persistent_cache_on_finalize (Fixture      *fixture,
                                                      gconstpointer unused)
 {
-  start_mock_logind_service (fixture);
-
-  read_lines_from_stdout (fixture->logind_mock,
-                          (ProcessLineSourceFunc) process_logind_line,
-                          NULL /* user_data */);
-
   record_singulars (fixture->test_object);
-  emit_shutdown_signal (TRUE);
 
-  /* Wait for daemon to handle the signal. */
-  while (g_main_context_pending (NULL))
-    g_main_context_iteration (NULL, TRUE);
-
-  terminate_subprocess_and_wait (fixture->logind_mock);
+  /* Unref the daemon, causing it to finalize. */
+  g_clear_object (&fixture->test_object);
 
   GVariant **variants;
   gsize num_variants;
@@ -1346,10 +1262,8 @@ main (gint                argc,
                    test_daemon_does_not_record_aggregates_when_daemon_disabled);
   ADD_DAEMON_TEST ("/daemon/does-not-record-sequences-when-daemon-disabled",
                    test_daemon_does_not_record_sequences_when_daemon_disabled);
-  ADD_DAEMON_TEST ("/daemon/updates-timestamps-on-shutdown",
-                   test_daemon_updates_timestamps_on_shutdown);
-  ADD_DAEMON_TEST ("/daemon/flushes-to-persistent-cache-on-shutdown",
-                   test_daemon_flushes_to_persistent_cache_on_shutdown);
+  ADD_DAEMON_TEST ("/daemon/flushes-to-persistent-cache-on-finalize",
+                   test_daemon_flushes_to_persistent_cache_on_finalize);
   ADD_DAEMON_TEST ("/daemon/limits-network-upload-size",
                    test_daemon_limits_network_upload_size);
 

--- a/tests/test-opt-out-integration.py
+++ b/tests/test-opt-out-integration.py
@@ -47,8 +47,7 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
     def setUp(self):
         """Start the event recorder on the mock system bus."""
 
-        # Put polkitd and logind mocks onto the mock system bus
-        (self.login_popen, self.login_obj) = self.spawn_server_template('logind')
+        # Put polkitd mocks onto the mock system bus
         (self.polkit_popen, self.polkit_obj) = self.spawn_server_template('polkitd')
 
         self.persistent_cache_directory = tempfile.mkdtemp()
@@ -67,11 +66,9 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
 
     def tearDown(self):
         self.polkit_popen.terminate()
-        self.login_popen.terminate()
         self.daemon.terminate()
 
         self.polkit_popen.wait()
-        self.login_popen.wait()
         self.assertEquals(self.daemon.wait(), 0)
         shutil.rmtree(self.persistent_cache_directory)
 

--- a/tests/test-opt-out-integration.py
+++ b/tests/test-opt-out-integration.py
@@ -47,7 +47,7 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
     def setUp(self):
         """Start the event recorder on the mock system bus."""
 
-        # Put polkitd mocks onto the mock system bus
+        # Put polkitd mocks onto the mock system bus.
         (self.polkit_popen, self.polkit_obj) = self.spawn_server_template('polkitd')
 
         self.persistent_cache_directory = tempfile.mkdtemp()


### PR DESCRIPTION
Accordingly, the unit tests for these were changed to assert that the
cache is simply flushed on when the daemon is finalized.

[endlessm/eos-sdk#3097]