### PR TITLE
Fix crash at shutdown.

### DIFF
--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -209,6 +209,7 @@ on_bus_acquired (GDBusConnection *system_bus,
                  EmerDaemon      *daemon)
 {
   EmerEventRecorderServer *server = emer_event_recorder_server_skeleton_new ();
+
   g_signal_connect (server, "handle-record-singular-event",
                     G_CALLBACK (on_record_singular_event), daemon);
   g_signal_connect (server, "handle-record-aggregate-event",

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -179,13 +179,11 @@ on_authorize_method_check (GDBusInterfaceSkeleton *interface,
 
   gboolean authorized = polkit_authorization_result_get_is_authorized (result);
   if (!authorized)
-    {
-      g_dbus_method_invocation_return_error (invocation,
-                                             G_DBUS_ERROR,
-                                             G_DBUS_ERROR_AUTH_FAILED,
-                                             "Disabling metrics is only "
-                                             "allowed from system settings");
-    }
+    g_dbus_method_invocation_return_error (invocation,
+                                           G_DBUS_ERROR,
+                                           G_DBUS_ERROR_AUTH_FAILED,
+                                           "Disabling metrics is only "
+                                           "allowed from system settings");
 
   g_object_unref (result);
   return authorized;
@@ -233,10 +231,8 @@ on_bus_acquired (GDBusConnection *system_bus,
                                          system_bus,
                                          "/com/endlessm/Metrics",
                                          &error))
-    {
-      g_error ("Could not export metrics interface on system bus: %s.",
-               error->message);
-    }
+    g_error ("Could not export metrics interface on system bus: %s.",
+             error->message);
 }
 
 /*
@@ -253,9 +249,8 @@ on_name_lost (GDBusConnection *system_bus,
    * acquired.
    */
   if (system_bus == NULL)
-    {
-      g_error ("Could not get connection to system bus.");
-    }
+    g_error ("Could not get connection to system bus.");
+
   g_error ("Could not acquire name '%s' on system bus.", name);
 }
 

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -200,8 +200,8 @@ quit_main_loop (GMainLoop *main_loop)
 
 /*
  * Called when a reference to the system bus is acquired. This is where you are
- * supposed to export your well-known name, confusingly not in name_acquired;
- * that is too late.
+ * supposed to export your well-known name, not in name_acquired; that is too
+ * late.
  */
 static void
 on_bus_acquired (GDBusConnection *system_bus,

--- a/data/eos-metrics-event-recorder.service.in
+++ b/data/eos-metrics-event-recorder.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=EndlessOS Metrics Event Recorder Server
+Requires=dbus.service
+After=dbus.service
 
 [Service]
 Environment=DCONF_PROFILE=/dev/null

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -128,40 +128,6 @@ timeout (gpointer unused)
   g_assert_not_reached ();
 }
 
-/*
- * Looks through the given @line of a mock DBus process' output for a call
- * matching @method_name and containing the string @arguments in its arguments.
- *
- * Returns %TRUE if the call was found in @line and @arguments matched.
- *
- * Returns %FALSE if the call was not found in @line, or the call was found but
- * @arguments was given and did not match.
- */
-static gboolean
-contains_dbus_call (const gchar *line,
-                    const gchar *method_name,
-                    const gchar *arguments)
-{
-  gchar *method_called = NULL, *arguments_given = NULL;
-  if (sscanf (line, "%*f %ms %m[^\n]", &method_called, &arguments_given) != 2)
-    {
-      g_free (method_called);
-      return FALSE;
-    }
-
-  if (strcmp (method_name, method_called) != 0)
-    {
-      g_free (method_called);
-      g_free (arguments_given);
-      return FALSE;
-    }
-  g_free (method_called);
-
-  gchar *given_args_index = strstr (arguments_given, arguments);
-  g_free (arguments_given);
-  return given_args_index != NULL;
-}
-
 static gboolean
 remove_last_character (GString *line,
                        gchar  **stripped_line)

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -474,8 +474,9 @@ assert_variants_equal (GVariant *actual_variant,
   g_variant_unref (expected_variant);
 }
 
-static void assert_machine_id_matches (GVariant              *machine_id_variant,
-                                       EmerMachineIdProvider *machine_id_provider)
+static void
+assert_machine_id_matches (GVariant              *machine_id_variant,
+                           EmerMachineIdProvider *machine_id_provider)
 {
   gsize actual_length;
   const guchar *actual_machine_id =


### PR DESCRIPTION
The metrics instrumentation daemon expects to be able to send messages
to the event recorder daemon as long as the event recorder daemon is
alive. The event recorder daemon is a D-Bus service, so it can only
receive messages while D-Bus is around to deliver them. Therefore,
instruct systemd to start D-Bus before and shut it down after the event
recorder daemon.

[endlessm/eos-sdk#3848]