### PR TITLE
Gzip network requests at compression level 9.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /tests/daemon/test-cache-version-provider
 /tests/daemon/test-circular-file
 /tests/daemon/test-daemon.dbusdaemon
+/tests/daemon/test-gzip
 /tests/daemon/test-machine-id-provider
 /tests/daemon/test-network-send-provider
 /tests/daemon/test-permissions-provider

--- a/daemon/Makefile.am.inc
+++ b/daemon/Makefile.am.inc
@@ -41,6 +41,7 @@ eos_metrics_event_recorder_SOURCES = \
 	daemon/emer-cache-version-provider.c daemon/emer-cache-version-provider.h \
 	daemon/emer-circular-file.c daemon/emer-circular-file.h \
 	daemon/emer-daemon.c daemon/emer-daemon.h \
+	daemon/emer-gzip.c daemon/emer-gzip.h \
 	daemon/emer-machine-id-provider.c daemon/emer-machine-id-provider.h \
 	daemon/emer-network-send-provider.c daemon/emer-network-send-provider.h \
 	daemon/emer-permissions-provider.c daemon/emer-permissions-provider.h \

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -708,6 +708,7 @@ handle_network_monitor_can_reach (GNetworkMonitor *network_monitor,
   gconstpointer serialized_request_body = g_variant_get_data (request_body);
   if (serialized_request_body == NULL)
     {
+      g_variant_unref (request_body);
       g_task_return_new_error (upload_task, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
                                "Could not serialize network request body");
       goto handle_upload_failed;

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1492,11 +1492,11 @@ emer_daemon_record_event_sequence (EmerDaemon *self,
 
 /* emer_daemon_upload_events:
  * @self: the daemon
- * @callback (nullable): the function to call once the upload completes. The
+ * @callback: (nullable): the function to call once the upload completes. The
  * first parameter passed to this callback is self. The second parameter is a
  * GAsyncResult that can be passed to emer_daemon_upload_events_finish to
  * determine whether the upload succeeded. The third parameter is user_data.
- * @user_data (nullable): arbitrary data that is blindly passed through to the
+ * @user_data: (nullable): arbitrary data that is blindly passed through to the
  * callback.
  *
  * The event recorder daemon may have already decided to upload some or all
@@ -1519,7 +1519,7 @@ emer_daemon_upload_events (EmerDaemon         *self,
 /* emer_daemon_upload_events_finish:
  * @self: the daemon
  * @result: a GAsyncResult that encapsulates whether the upload succeeded
- * @error (out) (optional): if the upload failed, error will be set to a GError
+ * @error: (out) (optional): if the upload failed, error will be set to a GError
  * describing what went wrong; otherwise it will be set to NULL. Pass NULL to
  * ignore this value.
  *

--- a/daemon/emer-gzip.c
+++ b/daemon/emer-gzip.c
@@ -1,0 +1,125 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2015 Endless Mobile, Inc. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "emer-gzip.h"
+
+#include <gio/gio.h>
+#include <glib.h>
+
+/* 9 is the highest compression level, meaning it typically achieves the best
+ * compression ratio but takes the longest time to run.
+ */
+#define COMPRESSION_LEVEL 9
+
+/*
+ * SECTION:emer-gzip
+ * @title: gzip
+ * @short_description: Compresses data using the gzip algorithm.
+ *
+ * Provides a simplified interface to GZlibCompressor that only supports
+ * compression level 9, the gzip algorithm, and non-streaming compression.
+ */
+
+/*
+ * emer_gzip_compress:
+ * @input_data: the data to compress.
+ * @input_length: the length of the data to compress in bytes.
+ * @compressed_length: (out): the length of the compressed data.
+ * @error: (out) (optional): if compression failed, error will be set to a GError
+ * describing the failure; otherwise it won't be modified. Pass NULL to ignore
+ * this value.
+ *
+ * Compresses input_data with the gzip algorithm at compression level 9. Returns
+ * NULL and sets error if compression fails. Sets compressed_length to the
+ * length of the compressed data in bytes.
+ *
+ * Returns: the compressed data or NULL if compression fails. Free with g_free.
+ */
+gpointer
+emer_gzip_compress (gconstpointer input_data,
+                    gsize         input_length,
+                    gsize        *compressed_length,
+                    GError      **error)
+{
+  GZlibCompressor *zlib_compressor =
+    g_zlib_compressor_new (G_ZLIB_COMPRESSOR_FORMAT_GZIP, COMPRESSION_LEVEL);
+  GConverter *converter = G_CONVERTER (zlib_compressor);
+
+  gsize allocated_space = input_length + 1;
+  GByteArray *byte_array = g_byte_array_sized_new (allocated_space);
+  gsize total_bytes_read = 0;
+  gsize total_bytes_written = 0;
+  while (TRUE)
+    {
+      gsize bytes_left_in_buffer = allocated_space - total_bytes_written;
+      if (bytes_left_in_buffer == 0)
+        goto expand_byte_array;
+
+      gsize bytes_left_in_input = input_length - total_bytes_read;
+      GConverterFlags conversion_flags = bytes_left_in_input > 0 ?
+        G_CONVERTER_NO_FLAGS : G_CONVERTER_INPUT_AT_END;
+
+      guint8 *curr_output = byte_array->data + total_bytes_written;
+      const guint8 *curr_input =
+        ((const guint8 *) input_data) + total_bytes_read;
+
+      gsize curr_bytes_written, curr_bytes_read;
+      GError *local_error = NULL;
+      GConverterResult conversion_result =
+        g_converter_convert (converter,
+                             curr_input, bytes_left_in_input,
+                             curr_output, bytes_left_in_buffer,
+                             conversion_flags,
+                             &curr_bytes_read, &curr_bytes_written,
+                             &local_error);
+
+      if (conversion_result == G_CONVERTER_ERROR)
+        {
+          if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NO_SPACE))
+            {
+              g_error_free (local_error);
+              goto expand_byte_array;
+            }
+
+          g_object_unref (zlib_compressor);
+          g_byte_array_free (byte_array, TRUE);
+          g_propagate_error (error, local_error);
+          return NULL;
+        }
+
+      total_bytes_read += curr_bytes_read;
+      total_bytes_written += curr_bytes_written;
+
+      if (conversion_result == G_CONVERTER_FINISHED)
+        break;
+
+expand_byte_array:
+      allocated_space *= 2;
+      g_byte_array_set_size (byte_array, allocated_space);
+    }
+
+  g_object_unref (zlib_compressor);
+  gpointer compressed_data = g_memdup (byte_array->data, total_bytes_written);
+  g_byte_array_free (byte_array, TRUE);
+  *compressed_length = total_bytes_written;
+  return compressed_data;
+}

--- a/daemon/emer-gzip.h
+++ b/daemon/emer-gzip.h
@@ -1,0 +1,33 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2015 Endless Mobile, Inc. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EMER_GZIP_H
+#define EMER_GZIP_H
+
+#include <glib.h>
+
+gpointer emer_gzip_compress (gconstpointer input_data,
+                             gsize         input_length,
+                             gsize        *compressed_length,
+                             GError      **error);
+
+#endif /* EMER_GZIP_H */

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -573,7 +573,7 @@ emer_permissions_provider_get_uploading_enabled (EmerPermissionsProvider *self)
  * emer_permissions_provider_get_environment:
  * @self: the permissions provider
  *
- * Returns the current metrics environment.
+ * Reads the current metrics environment off the disk.
  *
  * Returns: the metrics environment string if it exists in the permissions file
  * and is valid. The default value of the environment string is "test".

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -453,7 +453,7 @@ emer_permissions_provider_init (EmerPermissionsProvider *self)
  * events or not.
  *
  * Returns: (transfer full): a new permissions provider.
- *   Free with g_object_unref() when done.
+ * Free with g_object_unref() when done.
  */
 EmerPermissionsProvider *
 emer_permissions_provider_new (void)
@@ -468,7 +468,7 @@ emer_permissions_provider_new (void)
  * OSTree config file path. Use this function only for testing purposes.
  *
  * Returns: (transfer full): a new permissions provider.
- *   Free with g_object_unref() when done.
+ * Free with g_object_unref() when done.
  */
 EmerPermissionsProvider *
 emer_permissions_provider_new_full (const gchar *permissions_config_file_path,
@@ -487,7 +487,7 @@ emer_permissions_provider_new_full (const gchar *permissions_config_file_path,
  * Tells whether the event recorder should record events.
  *
  * Returns: %TRUE if the event recorder is allowed to record events, %FALSE if
- *   the user has opted out or the user's preference is unknown.
+ * the user has opted out or the user's preference is unknown.
  */
 gboolean
 emer_permissions_provider_get_daemon_enabled (EmerPermissionsProvider *self)
@@ -544,7 +544,7 @@ emer_permissions_provider_set_daemon_enabled (EmerPermissionsProvider *self,
  * emer_permissions_provider_get_daemon_enabled().
  *
  * Returns: %TRUE if the event recorder is allowed to upload events or the
- *   user's preference is unknown, %FALSE if the user has opted out.
+ * user's preference is unknown, %FALSE if the user has opted out.
  */
 gboolean
 emer_permissions_provider_get_uploading_enabled (EmerPermissionsProvider *self)

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -593,8 +593,9 @@ emer_permissions_provider_get_environment (EmerPermissionsProvider *self)
     }
 
   /* Check if the environment is set to "production" and if the term "staging"
-  is in the OSTree URL, which indicates that the metrics environment should be
-  set to "dev". */
+   * is in the OSTree URL, which indicates that the metrics environment should
+   * be set to "dev".
+   */
   if (g_strcmp0 (environment, "production") == 0 &&
       strstr (ostree_url, "staging") != NULL)
     {

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -22,6 +22,7 @@ noinst_PROGRAMS += \
 	tests/daemon/test-cache-version-provider \
 	tests/daemon/test-circular-file \
 	tests/daemon/test-daemon.dbusdaemon \
+	tests/daemon/test-gzip \
 	tests/daemon/test-machine-id-provider \
 	tests/daemon/test-network-send-provider \
 	tests/daemon/test-permissions-provider \
@@ -73,6 +74,7 @@ tests_daemon_test_daemon_dbusdaemon_SOURCES = \
 	tests/daemon/test-daemon.c \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
 	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
+	daemon/emer-gzip.c daemon/emer-gzip.h \
 	tests/daemon/mock-machine-id-provider.c daemon/emer-machine-id-provider.h \
 	tests/daemon/mock-network-send-provider.c \
 	daemon/emer-network-send-provider.h \
@@ -84,6 +86,13 @@ tests_daemon_test_daemon_dbusdaemon_SOURCES = \
 	$(NULL)
 tests_daemon_test_daemon_dbusdaemon_CPPFLAGS = $(DAEMON_TEST_FLAGS)
 tests_daemon_test_daemon_dbusdaemon_LDADD = $(DAEMON_TEST_LIBS)
+
+tests_daemon_test_gzip_SOURCES = \
+	daemon/emer-gzip.c daemon/emer-gzip.h \
+	tests/daemon/test-gzip.c \
+	$(NULL)
+tests_daemon_test_gzip_CPPFLAGS = $(DAEMON_TEST_FLAGS)
+tests_daemon_test_gzip_LDADD = $(DAEMON_TEST_LIBS)
 
 tests_daemon_test_machine_id_provider_SOURCES = \
 	daemon/emer-machine-id-provider.c daemon/emer-machine-id-provider.h \
@@ -132,6 +141,7 @@ TESTS = \
 	tests/daemon/test-cache-version-provider \
 	tests/daemon/test-circular-file \
 	tests/daemon/test-daemon.dbusdaemon \
+	tests/daemon/test-gzip \
 	tests/daemon/test-machine-id-provider \
 	tests/daemon/test-network-send-provider \
 	tests/daemon/test-persistent-cache \

--- a/tests/daemon/mock-server.py
+++ b/tests/daemon/mock-server.py
@@ -18,17 +18,24 @@
 # along with eos-event-recorder-daemon.  If not, see
 # <http://www.gnu.org/licenses/>.
 
+import gzip
 import http.server
 import sys
 
 class PrintingHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
     def do_PUT(self):
         print(self.path, flush=True)
+
+        content_encoding = self.headers['Content-Encoding']
+        print(content_encoding, flush=True)
+
         content_length = int(self.headers['Content-Length'])
-        print(content_length, flush=True)
-        request_body = self.rfile.read(content_length)
-        sys.stdout.buffer.write(request_body)
+        compressed_request_body = self.rfile.read(content_length)
+        decompressed_request_body = gzip.decompress(compressed_request_body)
+        print(len(decompressed_request_body), flush=True)
+        sys.stdout.buffer.write(decompressed_request_body)
         sys.stdout.buffer.flush()
+
         status_code_str = sys.stdin.readline()
         status_code = int(status_code_str)
         self.send_response(status_code)

--- a/tests/daemon/test-boot-id-provider.c
+++ b/tests/daemon/test-boot-id-provider.c
@@ -136,7 +136,6 @@ main (gint                argc,
       const gchar * const argv[])
 {
   g_test_init (&argc, (gchar ***) &argv, NULL);
-// gboolean is being used as a dummy fixture.
 #define ADD_BOOT_TEST_FUNC(path, func) \
   g_test_add ((path), struct Fixture, NULL, setup, (func), teardown)
 

--- a/tests/daemon/test-boot-id-provider.c
+++ b/tests/daemon/test-boot-id-provider.c
@@ -53,7 +53,7 @@ struct Fixture
 
 static void
 write_testing_boot_id (struct Fixture *fixture,
-                     const gchar    *testing_id)
+                       const gchar    *testing_id)
 {
   g_assert (g_file_replace_contents (fixture->tmp_file, testing_id, FILE_LENGTH,
                                      NULL, FALSE,

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -793,13 +793,13 @@ handle_upload_finished (EmerDaemon *test_object,
 
 /* Reads a network request from stdout of fixture->mock_server. Assumes the
  * server prints the path to which the request was made on a single line,
- * followed by the length in bytes of the request received on a single line,
- * followed by the request body without a terminal newline. Sets
- * fixture->relative_time and fixture->absolute_time to the relative and
- * absolute times at which this function was called. Sets fixture->request_path
- * to the path to which the request was sent. Calls source_func with a
- * GByteArray containing the request body as the first parameter and the
- * modified fixture as the second parameter.
+ * followed by the content encoding on a single line, followed by the length in
+ * bytes of the request received on a single line, followed by the request body
+ * without a terminal newline. Sets fixture->relative_time and
+ * fixture->absolute_time to the relative and absolute times at which this
+ * function was called. Sets fixture->request_path to the path to which the
+ * request was sent. Calls source_func with a GByteArray containing the request
+ * body as the first parameter and the modified fixture as the second parameter.
  */
 static void
 read_network_request (Fixture               *fixture,
@@ -815,6 +815,12 @@ read_network_request (Fixture               *fixture,
   read_lines_from_stdout (fixture->mock_server,
                           (ProcessLineSourceFunc) remove_last_character,
                           &fixture->request_path);
+
+  gchar *content_encoding;
+  read_lines_from_stdout (fixture->mock_server,
+                          (ProcessLineSourceFunc) remove_last_character,
+                          &content_encoding);
+  g_assert_cmpstr (content_encoding, ==, "gzip");
 
   guint content_length;
   read_lines_from_stdout (fixture->mock_server,

--- a/tests/daemon/test-gzip.c
+++ b/tests/daemon/test-gzip.c
@@ -1,0 +1,160 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2015 Endless Mobile, Inc. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "emer-gzip.h"
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <string.h>
+
+static gpointer
+gzip_decompress (gconstpointer input_data,
+                 gsize         input_length,
+                 gsize        *decompressed_length)
+{
+  GZlibDecompressor *zlib_decompressor =
+    g_zlib_decompressor_new (G_ZLIB_COMPRESSOR_FORMAT_GZIP);
+  GConverter *converter = G_CONVERTER (zlib_decompressor);
+
+  gsize allocated_space = input_length + 1;
+  GByteArray *byte_array = g_byte_array_sized_new (allocated_space);
+  gsize total_bytes_read = 0;
+  gsize total_bytes_written = 0;
+  while (TRUE)
+    {
+      gsize bytes_left_in_buffer = allocated_space - total_bytes_written;
+      if (bytes_left_in_buffer == 0)
+        goto expand_byte_array;
+
+      gsize bytes_left_in_input = input_length - total_bytes_read;
+      GConverterFlags conversion_flags = bytes_left_in_input > 0 ?
+        G_CONVERTER_NO_FLAGS : G_CONVERTER_INPUT_AT_END;
+
+      guint8 *curr_output = byte_array->data + total_bytes_written;
+      const guint8 *curr_input =
+        ((const guint8 *) input_data) + total_bytes_read;
+
+      gsize curr_bytes_written, curr_bytes_read;
+      GError *error = NULL;
+      GConverterResult conversion_result =
+        g_converter_convert (converter,
+                             curr_input, bytes_left_in_input,
+                             curr_output, bytes_left_in_buffer,
+                             conversion_flags,
+                             &curr_bytes_read, &curr_bytes_written,
+                             &error);
+
+      if (conversion_result == G_CONVERTER_ERROR)
+        {
+          g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NO_SPACE);
+          g_error_free (error);
+          goto expand_byte_array;
+        }
+
+      total_bytes_read += curr_bytes_read;
+      total_bytes_written += curr_bytes_written;
+
+      if (conversion_result == G_CONVERTER_FINISHED)
+        break;
+
+expand_byte_array:
+      allocated_space *= 2;
+      g_byte_array_set_size (byte_array, allocated_space);
+    }
+
+  g_object_unref (zlib_decompressor);
+  *decompressed_length = total_bytes_written;
+  return g_byte_array_free (byte_array, FALSE);
+}
+
+static void
+test_gzip_roundtrip (const gchar *input_string)
+{
+  gsize input_length = strlen (input_string);
+  gsize compressed_length;
+  GError *error = NULL;
+  gpointer compressed_string =
+    emer_gzip_compress (input_string, input_length, &compressed_length, &error);
+  g_assert_nonnull (compressed_string);
+  g_assert_no_error (error);
+
+  gsize decompressed_length;
+  gchar *decompressed_string =
+    (gchar *) gzip_decompress (compressed_string, compressed_length,
+                               &decompressed_length);
+  g_free (compressed_string);
+
+  /* TODO: Replace with g_assert_cmpmem once we upgrade to glib >= 2.46. */
+  g_assert_cmpuint (input_length, ==, decompressed_length);
+  for (gsize i = 0; i < input_length; i++)
+    g_assert_cmpint (input_string[i], ==, decompressed_string[i]);
+
+  g_free (decompressed_string);
+}
+
+static void
+test_gzip_compress_on_empty_payload (gboolean     *unused,
+                                     gconstpointer dont_use_me)
+{
+  test_gzip_roundtrip ("");
+}
+
+static void
+test_gzip_compress_on_standard_payload (gboolean     *unused,
+                                        gconstpointer dont_use_me)
+{
+  test_gzip_roundtrip ("How many zips could a gzip zip if a gzip could zip "
+                       "zips? A gzip could zip as many zips as a gzip could "
+                       "zip if a gzip could zip zips.");
+}
+
+static void
+test_gzip_compress_on_incompressible_payload (gboolean     *unused,
+                                              gconstpointer dont_use_me)
+{
+  test_gzip_roundtrip ("ô8üO½#Bé_¯ì.¼NÛ½ÊÜÑ\x9côÆoQÉÐàðÒ^P^W£^XxÝ1Z>^?UYô\\à^V¢"
+                       "zþzµÿ½ö8\x88\x8f´^L\x81^DÕí¹(^@výþoT³Àû#Ùïq\x89°^MSõ"
+                       "\x99\x82müp ¨Ð\x83h\x94)\x88Ó(æ¥Ã'}\x9fæ\x8c^A?OZ\x82#¦"
+                       "\x88Ý\n\x8eWï^Q\x88^NãS%\x9d`¥");
+}
+
+gint
+main (gint                argc,
+      const gchar * const argv[])
+{
+  g_test_init (&argc, (gchar ***) &argv, NULL);
+
+/* We are using a gboolean as a fixture type, but it will go unused. */
+#define ADD_GZIP_TEST_FUNC(path, func) \
+  g_test_add ((path), gboolean, NULL, NULL, (func), NULL)
+
+  ADD_GZIP_TEST_FUNC ("/gzip/compress-on-empty-payload",
+                      test_gzip_compress_on_empty_payload);
+  ADD_GZIP_TEST_FUNC ("/gzip/compress-on-standard-payload",
+                      test_gzip_compress_on_standard_payload);
+  ADD_GZIP_TEST_FUNC ("/gzip/compress-on-incompressible-payload",
+                      test_gzip_compress_on_incompressible_payload);
+
+#undef ADD_GZIP_TEST_FUNC
+
+  return g_test_run ();
+}


### PR DESCRIPTION
Conserve our user's bandwidth. Use the highest compression level because
some of our user's are on metered connections and we would like to save
them money.

[endlessm/eos-sdk#1453]