### PR TITLE
Correct sending of gzipped requests.

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* Copyright 2014, 2015 Endless Mobile, Inc. */
+/* Copyright 2014 - 2016 Endless Mobile, Inc. */
 
 /*
  * This file is part of eos-event-recorder-daemon.
@@ -451,7 +451,7 @@ queue_http_request (NetworkCallbackData *callback_data)
   soup_uri_free (http_request_uri);
 
   soup_message_headers_append (http_message->request_headers,
-                               "Content-Encoding", "gzip");
+                               "X-Endless-Content-Encoding", "gzip");
   soup_message_set_request (http_message, "application/octet-stream",
                             SOUP_MEMORY_TAKE, compressed_request_body,
                             compressed_request_body_length);

--- a/tests/daemon/mock-server.py
+++ b/tests/daemon/mock-server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2015 Endless Mobile, Inc.
+# Copyright 2015, 2016 Endless Mobile, Inc.
 
 # This file is part of eos-event-recorder-daemon.
 #
@@ -26,7 +26,7 @@ class PrintingHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
     def do_PUT(self):
         print(self.path, flush=True)
 
-        content_encoding = self.headers['Content-Encoding']
+        content_encoding = self.headers['X-Endless-Content-Encoding']
         print(content_encoding, flush=True)
 
         content_length = int(self.headers['Content-Length'])


### PR DESCRIPTION
The HTTP header Content-Encoding is only intended for use in responses.
Replace it with a custom header, X-Endless-Content-Encoding, instead.

[endlessm/eos-sdk#1453]