### PR TITLE
Fix several 64-bit build breaks.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce configure
 
-dnl Copyright 2013, 2014, 2015 Endless Mobile, Inc.
+dnl Copyright 2013 - 2016 Endless Mobile, Inc.
 
 dnl This file is part of eos-event-recorder-daemon.
 dnl
@@ -58,7 +58,7 @@ AC_CACHE_SAVE
 # Update these whenever you use a function that requires a certain API version.
 # Keep these lists sorted alphabetically.
 EOS_METRICS_REQUIREMENT="eosmetrics-0 >= 0.2"
-GIO_REQUIREMENT="gio-unix-2.0 >= 2.40"
+GIO_REQUIREMENT="gio-unix-2.0 >= 2.46"
 GOBJECT_REQUIREMENT="gobject-2.0"
 OSTREE_REQUIREMENT="ostree-1 >= 2013.7"
 POLKIT_REQUIREMENT="polkit-gobject-1"

--- a/daemon/emer-boot-id-provider.c
+++ b/daemon/emer-boot-id-provider.c
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* Copyright 2014, 2015 Endless Mobile, Inc. */
+/* Copyright 2014 - 2016 Endless Mobile, Inc. */
 
 /*
  * This file is part of eos-event-recorder-daemon.
@@ -230,8 +230,8 @@ read_boot_id (EmerBootIdProvider *self)
   if (boot_id_length != FILE_LENGTH)
     {
       g_critical ("Boot ID file (%s) contained %" G_GSIZE_FORMAT " bytes, "
-                  "but expected %d bytes.", priv->path, boot_id_length,
-                  FILE_LENGTH);
+                  "but expected %" G_GSIZE_FORMAT " bytes.",
+                  priv->path, boot_id_length, FILE_LENGTH);
       return FALSE;
     }
 

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1379,8 +1379,8 @@ emer_daemon_record_singular_event (EmerDaemon *self,
 
   if (!is_uuid (event_id))
     {
-      g_warning ("Event ID must be a UUID represented as an array of %d "
-                 "bytes. Dropping event.", UUID_LENGTH);
+      g_warning ("Event ID must be a UUID represented as an array of %"
+                 G_GSIZE_FORMAT " bytes. Dropping event.", UUID_LENGTH);
       return;
     }
 
@@ -1419,8 +1419,8 @@ emer_daemon_record_aggregate_event (EmerDaemon *self,
 
   if (!is_uuid (event_id))
     {
-      g_warning ("Event ID must be a UUID represented as an array of %d "
-                 "bytes. Dropping event.", UUID_LENGTH);
+      g_warning ("Event ID must be a UUID represented as an array of %"
+                 G_GSIZE_FORMAT " bytes. Dropping event.", UUID_LENGTH);
       return;
     }
 
@@ -1456,8 +1456,8 @@ emer_daemon_record_event_sequence (EmerDaemon *self,
 
   if (!is_uuid (event_id))
     {
-      g_warning ("Event ID must be a UUID represented as an array of %d "
-                 "bytes. Dropping event.", UUID_LENGTH);
+      g_warning ("Event ID must be a UUID represented as an array of %"
+                 G_GSIZE_FORMAT " bytes. Dropping event.", UUID_LENGTH);
       return;
     }
 

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -252,7 +252,7 @@ read_machine_id (EmerMachineIdProvider *self)
   if (machine_id_sans_hyphens_length != FILE_LENGTH)
     {
       g_critical ("Machine ID file (%s) contained %" G_GSIZE_FORMAT " bytes, "
-                  "but expected %d bytes.",
+                  "but expected %" G_GSIZE_FORMAT " bytes.",
                   priv->path, machine_id_sans_hyphens_length, FILE_LENGTH);
       return FALSE;
     }

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* Copyright 2014, 2015 Endless Mobile, Inc. */
+/* Copyright 2014 - 2016 Endless Mobile, Inc. */
 
 /*
  * This file is part of eos-event-recorder-daemon.
@@ -253,8 +253,7 @@ read_machine_id (EmerMachineIdProvider *self)
     {
       g_critical ("Machine ID file (%s) contained %" G_GSIZE_FORMAT " bytes, "
                   "but expected %d bytes.",
-                  priv->path, machine_id_sans_hyphens_length,
-                  FILE_LENGTH);
+                  priv->path, machine_id_sans_hyphens_length, FILE_LENGTH);
       return FALSE;
     }
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* Copyright 2014, 2015 Endless Mobile, Inc. */
+/* Copyright 2014 - 2016 Endless Mobile, Inc. */
 
 /*
  * This file is part of eos-event-recorder-daemon.
@@ -636,7 +636,7 @@ apply_cache_versioning (EmerPersistentCache *self,
       if (!set_succeeded)
         {
           g_prefix_error (error,
-                          "Failed to update cache version number to %i. ",
+                          "Failed to update cache version number to %d. ",
                           CURRENT_CACHE_VERSION);
           return FALSE;
         }

--- a/tests/daemon/test-gzip.c
+++ b/tests/daemon/test-gzip.c
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* Copyright 2015 Endless Mobile, Inc. */
+/* Copyright 2015, 2016 Endless Mobile, Inc. */
 
 /*
  * This file is part of eos-event-recorder-daemon.
@@ -103,11 +103,8 @@ test_gzip_roundtrip (const gchar *input_string)
                                &decompressed_length);
   g_free (compressed_string);
 
-  /* TODO: Replace with g_assert_cmpmem once we upgrade to glib >= 2.46. */
-  g_assert_cmpuint (input_length, ==, decompressed_length);
-  for (gsize i = 0; i < input_length; i++)
-    g_assert_cmpint (input_string[i], ==, decompressed_string[i]);
-
+  g_assert_cmpmem (input_string, input_length, decompressed_string,
+                   decompressed_length);
   g_free (decompressed_string);
 }
 

--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -116,9 +116,7 @@ main (gint   argc,
   GOptionEntry options[] =
   {
     {
-      // FIXME: Replace 0 with G_OPTION_FLAG_NONE once GLib 2.42 is available on
-      // Endless OS.
-      "persistent-cache-path", 'p', 0 /* G_OPTION_FLAG_NONE */,
+      "persistent-cache-path", 'p', G_OPTION_FLAG_NONE,
       G_OPTION_ARG_FILENAME, &persistent_cache_path,
       "The filepath to the persistent cache to print.",
       NULL /* argument description */

--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* Copyright 2014, 2015 Endless Mobile, Inc. */
+/* Copyright 2014 - 2016 Endless Mobile, Inc. */
 
 /*
  * This file is part of eos-event-recorder-daemon.
@@ -108,9 +108,9 @@ make_persistent_cache (const gchar *directory)
   return persistent_cache;
 }
 
-int
-main (int   argc,
-      char *argv[])
+gint
+main (gint   argc,
+      gchar *argv[])
 {
   gchar *persistent_cache_path = NULL;
   GOptionEntry options[] =


### PR DESCRIPTION
Use G_GSIZE_FORMAT instead of %d for gsize types.

[https://phabricator.endlessm.com/T11126]