### PR TITLE
Fix some 64-bit build failures.

### DIFF
--- a/daemon/emer-boot-id-provider.c
+++ b/daemon/emer-boot-id-provider.c
@@ -230,7 +230,7 @@ read_boot_id (EmerBootIdProvider *self)
   if (boot_id_length != FILE_LENGTH)
     {
       g_critical ("Boot ID file (%s) contained %" G_GSIZE_FORMAT " bytes, "
-                  "but expected %" G_GSIZE_FORMAT " bytes.",
+                  "but expected %d bytes.",
                   priv->path, boot_id_length, FILE_LENGTH);
       return FALSE;
     }

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -252,7 +252,7 @@ read_machine_id (EmerMachineIdProvider *self)
   if (machine_id_sans_hyphens_length != FILE_LENGTH)
     {
       g_critical ("Machine ID file (%s) contained %" G_GSIZE_FORMAT " bytes, "
-                  "but expected %" G_GSIZE_FORMAT " bytes.",
+                  "but expected %d bytes.",
                   priv->path, machine_id_sans_hyphens_length, FILE_LENGTH);
       return FALSE;
     }


### PR DESCRIPTION
Replace incorrect uses of G_GSIZE_FORMAT with %d as FILE_LENGTH is not
of type gsize.

[https://phabricator.endlessm.com/T11126]