### PR TITLE
Gracefully handle invalid/corrupt data in the persistent cache

### DIFF
--- a/daemon/emer-circular-file.c
+++ b/daemon/emer-circular-file.c
@@ -698,6 +698,7 @@ emer_circular_file_read (EmerCircularFile *self,
                          gsize             data_bytes_to_read,
                          gsize            *num_elems,
                          guint64          *token,
+                         gboolean         *has_invalid,
                          GError          **error)
 {
   EmerCircularFilePrivate *priv =
@@ -728,6 +729,8 @@ emer_circular_file_read (EmerCircularFile *self,
   guint64 curr_data_bytes = 0;
   guint64 curr_disk_bytes = 0;
   GInputStream *input_stream = G_INPUT_STREAM (file_input_stream);
+
+  *has_invalid = FALSE;
   while (curr_disk_bytes < priv->size)
     {
       guint64 elem_size;
@@ -744,6 +747,7 @@ emer_circular_file_read (EmerCircularFile *self,
           g_warning ("Discarding invalid data found after byte %" G_GINT64_FORMAT,
                      (priv->head + curr_disk_bytes) % priv->max_size);
           set_metadata (self, curr_disk_bytes, priv->head, error);
+          *has_invalid = TRUE;
           break;
         }
 

--- a/daemon/emer-circular-file.h
+++ b/daemon/emer-circular-file.h
@@ -83,6 +83,7 @@ gboolean          emer_circular_file_read     (EmerCircularFile *self,
                                                gsize             num_bytes,
                                                gsize            *num_elems,
                                                guint64          *token,
+                                               gboolean         *has_invalid,
                                                GError          **error);
 
 gboolean          emer_circular_file_has_more (EmerCircularFile *self,

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -1045,6 +1045,7 @@ emer_persistent_cache_read (EmerPersistentCache *self,
                             gsize                cost,
                             gsize               *num_variants,
                             guint64             *token,
+                            gboolean            *has_invalid,
                             GError             **error)
 {
   EmerPersistentCachePrivate *priv =
@@ -1057,7 +1058,7 @@ emer_persistent_cache_read (EmerPersistentCache *self,
 
   gboolean read_succeeded =
     emer_circular_file_read (priv->variant_file, &elems, cost, &num_elems,
-                             &local_token, error);
+                             &local_token, has_invalid, error);
   if (!read_succeeded)
     return FALSE;
 
@@ -1104,7 +1105,7 @@ emer_persistent_cache_read (EmerPersistentCache *self,
   if (corrupt_data)
     {
       /* Somehow the circular file contains corrupt data, meaning that we
-       * can't trust its contents anymore so we clean up and return an error. */
+       * can't trust its contents at all, so we clean up and return an error. */
       gsize j = i;
 
       while (j < num_elems)

--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -115,6 +115,9 @@ gboolean             emer_persistent_cache_remove               (EmerPersistentC
                                                                  guint64                   token,
                                                                  GError                  **error);
 
+gboolean             emer_persistent_cache_remove_all           (EmerPersistentCache      *self,
+                                                                 GError                  **error);
+
 EmerPersistentCache *emer_persistent_cache_new_full             (const gchar              *directory,
                                                                  EmerCacheSizeProvider    *cache_size_provider,
                                                                  EmerBootIdProvider       *boot_id_provider,

--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -106,6 +106,7 @@ gboolean             emer_persistent_cache_read                 (EmerPersistentC
                                                                  gsize                     cost,
                                                                  gsize                    *num_variants,
                                                                  guint64                  *token,
+                                                                 gboolean                 *has_invalid,
                                                                  GError                  **error);
 
 gboolean             emer_persistent_cache_has_more             (EmerPersistentCache      *self,

--- a/tests/daemon/mock-circular-file.c
+++ b/tests/daemon/mock-circular-file.c
@@ -160,6 +160,7 @@ emer_circular_file_read (EmerCircularFile *self,
                          gsize             num_bytes,
                          gsize            *num_elems,
                          guint64          *token,
+                         gboolean         *has_invalid,
                          GError          **error)
 {
   EmerCircularFilePrivate *priv =
@@ -190,6 +191,7 @@ emer_circular_file_read (EmerCircularFile *self,
   *num_elems = elem_array->len;
   *elems = (GBytes **) g_ptr_array_free (elem_array, FALSE);
   *token = curr_buffer_bytes;
+  *has_invalid = FALSE;
   return TRUE;
 }
 

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -126,6 +126,7 @@ emer_persistent_cache_read (EmerPersistentCache *self,
                             gsize                cost,
                             gsize               *num_variants,
                             guint64             *token,
+                            gboolean            *has_invalid,
                             GError             **error)
 {
   EmerPersistentCachePrivate *priv =
@@ -151,6 +152,7 @@ emer_persistent_cache_read (EmerPersistentCache *self,
     }
 
   *token = curr_num_variants;
+  *has_invalid = FALSE;
   return TRUE;
 }
 

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -177,3 +177,15 @@ emer_persistent_cache_remove (EmerPersistentCache *self,
 
   return TRUE;
 }
+
+gboolean
+emer_persistent_cache_remove_all (EmerPersistentCache *self,
+                                  GError             **error)
+{
+  EmerPersistentCachePrivate *priv =
+    emer_persistent_cache_get_instance_private (self);
+
+  g_ptr_array_remove_range (priv->variant_array, 0, priv->variant_array->len);
+
+  return TRUE;
+}

--- a/tests/daemon/test-circular-file.c
+++ b/tests/daemon/test-circular-file.c
@@ -154,13 +154,15 @@ assert_strings_read (EmerCircularFile    *circular_file,
   guint64 token = total_disk_size + 1;
 
   GError *error = NULL;
+  gboolean has_invalid;
   gboolean read_succeeded =
     emer_circular_file_read (circular_file, &elems, total_elem_size, &num_elems,
-                             &token, &error);
+                             &token, &has_invalid, &error);
 
   g_assert_no_error (error);
   g_assert_true (read_succeeded);
   g_assert_cmpuint (num_elems, ==, num_strings);
+  g_assert_false (has_invalid);
 
   for (gsize i = 0; i < num_elems; i++)
     {
@@ -190,15 +192,17 @@ assert_circular_file_is_empty (EmerCircularFile *circular_file)
   guint64 token = 1;
 
   GError *error = NULL;
+  gboolean has_invalid;
   gboolean read_succeeded =
     emer_circular_file_read (circular_file, &elems, G_MAXSIZE, &num_elems,
-                             &token, &error);
+                             &token, &has_invalid, &error);
 
   g_assert_no_error (error);
   g_assert_true (read_succeeded);
   g_assert_null (elems);
   g_assert_cmpuint (num_elems, ==, 0);
   g_assert_cmpuint (token, ==, 0);
+  g_assert_false (has_invalid);
 }
 
 static void

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -1159,11 +1159,13 @@ test_daemon_flushes_to_persistent_cache_on_finalize (Fixture      *fixture,
   GVariant **variants;
   gsize num_variants;
   guint64 token;
+  gboolean has_invalid;
   gboolean read_succeeded =
     emer_persistent_cache_read (fixture->mock_persistent_cache, &variants,
-                                G_MAXSIZE, &num_variants, &token,
+                                G_MAXSIZE, &num_variants, &token, &has_invalid,
                                 NULL /* GError */);
   g_assert_true (read_succeeded);
+  g_assert_false (has_invalid);
   assert_singulars_match (variants, num_variants);
 }
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -468,15 +468,17 @@ assert_variants_read (EmerPersistentCache *cache,
   guint64 token = total_size_when_stored + 1;
 
   GError *error = NULL;
+  gboolean has_invalid;
   gboolean read_succeeded =
     emer_persistent_cache_read (cache, &variants_read, total_elem_size,
-                                &num_variants_read, &token, &error);
+                                &num_variants_read, &token, &has_invalid, &error);
 
   g_assert_no_error (error);
   g_assert_true (read_succeeded);
   g_assert_cmpuint (num_variants_read, ==, num_variants);
   assert_variants_equal (variants_read, variants, num_variants);
   g_assert_cmpuint (token, ==, total_size_when_stored);
+  g_assert_false (has_invalid);
 
   destroy_variants (variants_read, num_variants);
 
@@ -495,15 +497,17 @@ assert_cache_is_empty (EmerPersistentCache *cache)
   guint64 token = 1;
 
   GError *error = NULL;
+  gboolean has_invalid;
   gboolean read_succeeded =
     emer_persistent_cache_read (cache, &variants, G_MAXSIZE, &num_variants,
-                                &token, &error);
+                                &token, &has_invalid, &error);
 
   g_assert_no_error (error);
   g_assert_true (read_succeeded);
   g_assert_null (variants);
   g_assert_cmpuint (num_variants, ==, 0);
   g_assert_cmpuint (token, ==, 0);
+  g_assert_false (has_invalid);
 }
 
 static void

--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -161,9 +161,10 @@ main (gint   argc,
   GVariant **variants;
   gsize num_variants;
   guint64 token;
+  gboolean has_invalid;
   gboolean read_succeeded =
     emer_persistent_cache_read (persistent_cache, &variants, G_MAXSIZE,
-                                &num_variants, &token, &error);
+                                &num_variants, &token, &has_invalid, &error);
   g_object_unref (persistent_cache);
 
   if (!read_succeeded)


### PR DESCRIPTION
This patch set improves the way we deal with situations where invalid/corrupt data makes it to the persistent cache file in three ways:
  * Discard invalid data found after a valid chunk when reading from the cache, and just report that.
  * Purge the whole persistent cache file in cases where the corruption can't be detected earlier.
  * Send metrics events to the server so that we can track down when these situations happen

Note that is still unclear to me how we actually ended up in this scenario, which is still the big question here, but these changes should at least prevent the daemon from crashing and make it able to keep recording and sending metrics after having detected and deal with these kind of situations.

https://phabricator.endlessm.com/T12739