### PR TITLE
Change default configuration to "collect, don't upload"

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1444,10 +1444,12 @@ emer_daemon_init (EmerDaemon *self)
  * Returns: (transfer full): a new #EmerDaemon with the default configuration.
  */
 EmerDaemon *
-emer_daemon_new (const gchar *persistent_cache_directory)
+emer_daemon_new (const gchar             *persistent_cache_directory,
+                 EmerPermissionsProvider *permissions_provider)
 {
   return g_object_new (EMER_TYPE_DAEMON,
                        "persistent-cache-directory", persistent_cache_directory,
+                       "permissions-provider", permissions_provider,
                        NULL);
 }
 

--- a/daemon/emer-daemon.h
+++ b/daemon/emer-daemon.h
@@ -72,7 +72,8 @@ struct _EmerDaemonClass
 
 GType                    emer_daemon_get_type                 (void) G_GNUC_CONST;
 
-EmerDaemon *             emer_daemon_new                      (const gchar             *persistent_cache_directory);
+EmerDaemon *             emer_daemon_new                      (const gchar             *persistent_cache_directory,
+                                                               EmerPermissionsProvider *permissions_provider);
 
 EmerDaemon *             emer_daemon_new_full                 (GRand                   *rand,
                                                                const gchar             *server_uri,

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -264,11 +264,16 @@ make_daemon (gint                argc,
 {
   g_autofree gchar *persistent_cache_directory = NULL;
   const gchar *persistent_cache_directory_const = PERSISTENT_CACHE_DIR;
+  g_autofree gchar *config_file_path = NULL;
+  g_autoptr(EmerPermissionsProvider) permissions_provider = NULL;
   GOptionEntry option_entries[] =
   {
     { "persistent-cache-directory", 'p', G_OPTION_FLAG_NONE,
       G_OPTION_ARG_FILENAME, &persistent_cache_directory,
       "Store persistent cache at path", "path"},
+    { "config-file-path", 'c', G_OPTION_FLAG_NONE,
+      G_OPTION_ARG_FILENAME, &config_file_path,
+      "Path to permissions config file", "path"},
     { NULL }
   };
 
@@ -292,7 +297,12 @@ make_daemon (gint                argc,
   if (persistent_cache_directory != NULL)
     persistent_cache_directory_const = persistent_cache_directory;
 
-  return emer_daemon_new (persistent_cache_directory_const);
+  if (config_file_path != NULL)
+    permissions_provider =
+      emer_permissions_provider_new_full (config_file_path, NULL);
+
+  return emer_daemon_new (persistent_cache_directory_const,
+                          permissions_provider);
 }
 
 gint

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -93,7 +93,11 @@ on_set_enabled (EmerEventRecorderServer *server,
                 gboolean                 enabled,
                 EmerDaemon              *daemon)
 {
+  EmerPermissionsProvider *permissions =
+    emer_daemon_get_permissions_provider (daemon);
+
   emer_event_recorder_server_set_enabled (server, enabled);
+  emer_permissions_provider_set_uploading_enabled (permissions, enabled);
   emer_event_recorder_server_complete_set_enabled (server, invocation);
   return TRUE;
 }

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -262,7 +262,8 @@ static EmerDaemon *
 make_daemon (gint                argc,
              const gchar * const argv[])
 {
-  gchar *persistent_cache_directory = NULL;
+  g_autofree gchar *persistent_cache_directory = NULL;
+  const gchar *persistent_cache_directory_const = PERSISTENT_CACHE_DIR;
   GOptionEntry option_entries[] =
   {
     { "persistent-cache-directory", 'p', G_OPTION_FLAG_NONE,
@@ -288,13 +289,10 @@ make_daemon (gint                argc,
       return NULL;
     }
 
-  if (persistent_cache_directory == NULL)
-    return emer_daemon_new (PERSISTENT_CACHE_DIR);
+  if (persistent_cache_directory != NULL)
+    persistent_cache_directory_const = persistent_cache_directory;
 
-  EmerDaemon *daemon = emer_daemon_new (persistent_cache_directory);
-  g_free (persistent_cache_directory);
-
-  return daemon;
+  return emer_daemon_new (persistent_cache_directory_const);
 }
 
 gint

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -54,8 +54,8 @@ G_DEFINE_TYPE_WITH_PRIVATE (EmerPermissionsProvider, emer_permissions_provider, 
 
 #define FALLBACK_CONFIG_FILE_DATA \
   "[" DAEMON_GLOBAL_GROUP_NAME "]\n" \
-  DAEMON_ENABLED_KEY_NAME "=false\n" \
-  DAEMON_UPLOADING_ENABLED_KEY_NAME "=true\n" \
+  DAEMON_ENABLED_KEY_NAME "=true\n" \
+  DAEMON_UPLOADING_ENABLED_KEY_NAME "=false\n" \
   DAEMON_ENVIRONMENT_KEY_NAME "=production\n"
 
 enum

--- a/daemon/emer-permissions-provider.h
+++ b/daemon/emer-permissions-provider.h
@@ -62,6 +62,8 @@ struct _EmerPermissionsProviderClass
   GObjectClass parent_class;
 };
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(EmerPermissionsProvider, g_object_unref)
+
 GType                    emer_permissions_provider_get_type              (void) G_GNUC_CONST;
 
 EmerPermissionsProvider *emer_permissions_provider_new                   (void);

--- a/daemon/emer-permissions-provider.h
+++ b/daemon/emer-permissions-provider.h
@@ -76,6 +76,9 @@ void                     emer_permissions_provider_set_daemon_enabled    (EmerPe
 
 gboolean                 emer_permissions_provider_get_uploading_enabled (EmerPermissionsProvider *self);
 
+void                     emer_permissions_provider_set_uploading_enabled (EmerPermissionsProvider *self,
+                                                                          gboolean                 enabled);
+
 gchar                   *emer_permissions_provider_get_environment       (EmerPermissionsProvider *self);
 
 G_END_DECLS

--- a/data/eos-metrics-permissions.conf
+++ b/data/eos-metrics-permissions.conf
@@ -1,4 +1,4 @@
 [global]
-enabled=false
-uploading_enabled=true
+enabled=true
+uploading_enabled=false
 environment=production

--- a/tests/daemon/mock-permissions-provider.c
+++ b/tests/daemon/mock-permissions-provider.c
@@ -108,11 +108,16 @@ emer_permissions_provider_get_environment (EmerPermissionsProvider *self)
 /* Sets the value to return from
  * emer_permissions_provider_get_uploading_enabled(). */
 void
-mock_permissions_provider_set_uploading_enabled (EmerPermissionsProvider *self,
+emer_permissions_provider_set_uploading_enabled (EmerPermissionsProvider *self,
                                                  gboolean                 uploading_enabled)
 {
   EmerPermissionsProviderPrivate *priv =
     emer_permissions_provider_get_instance_private (self);
 
   priv->uploading_enabled = uploading_enabled;
+
+  /* Emit a property notification even though there isn't a property by this
+   * name in this mock object.
+   */
+  g_signal_emit_by_name (self, "notify::uploading-enabled", NULL);
 }

--- a/tests/daemon/mock-permissions-provider.h
+++ b/tests/daemon/mock-permissions-provider.h
@@ -29,9 +29,6 @@
 
 G_BEGIN_DECLS
 
-void mock_permissions_provider_set_uploading_enabled (EmerPermissionsProvider *self,
-                                                      gboolean                 uploading_enabled);
-
 G_END_DECLS
 
 #endif /* MOCK_PERMISSIONS_PROVIDER_H */

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -952,7 +952,8 @@ static void
 test_daemon_new_succeeds (Fixture      *fixture,
                           gconstpointer unused)
 {
-  EmerDaemon *daemon = emer_daemon_new (NULL /* persistent cache directory */);
+  EmerDaemon *daemon = emer_daemon_new (NULL /* persistent cache directory */,
+                                        NULL /* permissions provider */);
   g_assert_nonnull (daemon);
   g_object_unref (daemon);
 }

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -1055,12 +1055,12 @@ static void
 test_daemon_only_reports_singulars_when_uploading_enabled (Fixture      *fixture,
                                                            gconstpointer unused)
 {
-  mock_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
+  emer_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
                                                    FALSE);
   record_singulars (fixture->test_object);
   assert_uploading_disabled (fixture);
 
-  mock_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
+  emer_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
                                                    TRUE);
   read_network_request (fixture,
                         (ProcessBytesSourceFunc) assert_singulars_received);
@@ -1071,12 +1071,12 @@ static void
 test_daemon_only_reports_aggregates_when_uploading_enabled (Fixture      *fixture,
                                                             gconstpointer unused)
 {
-  mock_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
+  emer_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
                                                    FALSE);
   record_aggregates (fixture->test_object);
   assert_uploading_disabled (fixture);
 
-  mock_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
+  emer_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
                                                    TRUE);
   read_network_request (fixture,
                         (ProcessBytesSourceFunc) assert_aggregates_received);
@@ -1087,12 +1087,12 @@ static void
 test_daemon_only_reports_sequences_when_uploading_enabled (Fixture      *fixture,
                                                            gconstpointer unused)
 {
-  mock_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
+  emer_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
                                                    FALSE);
   record_sequence (fixture->test_object);
   assert_uploading_disabled (fixture);
 
-  mock_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
+  emer_permissions_provider_set_uploading_enabled (fixture->mock_permissions_provider,
                                                    TRUE);
   read_network_request (fixture,
                         (ProcessBytesSourceFunc) assert_sequence_received);

--- a/tests/daemon/test-permissions-provider.c
+++ b/tests/daemon/test-permissions-provider.c
@@ -329,7 +329,7 @@ test_permissions_provider_get_daemon_enabled_fallback (Fixture      *fixture,
 {
   gboolean daemon_enabled =
     emer_permissions_provider_get_daemon_enabled (fixture->test_object);
-  g_assert_false (daemon_enabled);
+  g_assert_true (daemon_enabled);
   g_test_assert_expected_messages ();
 }
 
@@ -357,7 +357,7 @@ test_permissions_provider_get_uploading_enabled_fallback (Fixture      *fixture,
 {
   gboolean uploading_enabled =
     emer_permissions_provider_get_uploading_enabled (fixture->test_object);
-  g_assert_true (uploading_enabled);
+  g_assert_false (uploading_enabled);
   g_test_assert_expected_messages ();
 }
 

--- a/tests/daemon/test-permissions-provider.c
+++ b/tests/daemon/test-permissions-provider.c
@@ -93,6 +93,11 @@ typedef struct {
 
   gboolean notify_daemon_called;
   gboolean notify_daemon_called_with;
+
+  gboolean notify_uploading_called;
+  gboolean notify_uploading_called_with;
+
+  guint num_config_file_changes;
 } Fixture;
 
 /* Callback for notify::daemon-enabled that records what it was called with and
@@ -106,6 +111,20 @@ on_notify_daemon_enabled (EmerPermissionsProvider *permissions_provider,
     fixture->notify_daemon_called_with =
       emer_permissions_provider_get_daemon_enabled (permissions_provider);
   fixture->notify_daemon_called = TRUE;
+  g_main_loop_quit (fixture->main_loop);
+}
+
+/* Callback for notify::uploading-enabled that records what it was called with and
+quits the main loop so the test can continue. */
+static void
+on_notify_uploading_enabled (EmerPermissionsProvider *permissions_provider,
+                             GParamSpec              *pspec,
+                             Fixture                 *fixture)
+{
+  if (!fixture->notify_uploading_called)
+    fixture->notify_uploading_called_with =
+      emer_permissions_provider_get_uploading_enabled (permissions_provider);
+  fixture->notify_uploading_called = TRUE;
   g_main_loop_quit (fixture->main_loop);
 }
 
@@ -173,9 +192,12 @@ setup_config_files (Fixture     *fixture,
   g_free (ostree_config_file_path);
 
   fixture->main_loop = g_main_loop_new (NULL, FALSE);
-  fixture->notify_daemon_called = FALSE;
+
   g_signal_connect (fixture->test_object, "notify::daemon-enabled",
                     G_CALLBACK (on_notify_daemon_enabled), fixture);
+  g_signal_connect (fixture->test_object, "notify::uploading-enabled",
+                    G_CALLBACK (on_notify_uploading_enabled), fixture);
+
 
   /* Failsafe: stop waiting for signals in async tests after
      SIGNAL_TIMEOUT_SEC seconds. */
@@ -395,8 +417,13 @@ test_permissions_provider_set_daemon_enabled (Fixture      *fixture,
 {
   g_idle_add ((GSourceFunc) set_daemon_enabled_false_idle, fixture);
   g_main_loop_run (fixture->main_loop);
+
   g_assert_true (fixture->notify_daemon_called);
   g_assert_false (fixture->notify_daemon_called_with);
+  g_assert_false (emer_permissions_provider_get_daemon_enabled (fixture->test_object));
+
+  g_assert_false(fixture->notify_uploading_called);
+  g_assert_true (emer_permissions_provider_get_uploading_enabled (fixture->test_object));
 }
 
 /* Callback for file monitor change, which quits the main loop. */
@@ -409,7 +436,10 @@ on_config_file_changed (GFileMonitor     *monitor,
 {
   if (event_type == G_FILE_MONITOR_EVENT_CREATED ||
       event_type == G_FILE_MONITOR_EVENT_CHANGED)
-    g_main_loop_quit (fixture->main_loop);
+    {
+      fixture->num_config_file_changes++;
+      g_main_loop_quit (fixture->main_loop);
+    }
 }
 
 static gboolean
@@ -430,6 +460,8 @@ test_permissions_provider_set_daemon_enabled_updates_config_file (Fixture      *
 {
   g_assert_true (file_contents_match (fixture->permissions_config_file,
                                       "^enabled=true$"));
+  g_assert_true (file_contents_match (fixture->permissions_config_file,
+                                      "^uploading_enabled=true$"));
 
   g_idle_add ((GSourceFunc) set_daemon_enabled_false_idle, fixture);
 
@@ -445,11 +477,75 @@ test_permissions_provider_set_daemon_enabled_updates_config_file (Fixture      *
   and a "changed" or "created" file monitor event. */
   g_main_loop_run (fixture->main_loop);
   g_main_loop_run (fixture->main_loop);
+  g_assert_cmpuint (fixture->num_config_file_changes, ==, 1);
 
   g_object_unref (monitor);
 
   g_assert_true (file_contents_match (fixture->permissions_config_file,
                                       "^enabled=false$"));
+  g_assert_true (file_contents_match (fixture->permissions_config_file,
+                                      "^uploading_enabled=true$"));
+}
+
+/* This is run in an idle function so that it doesn't quit the main loop before
+the main loop has started. */
+static gboolean
+set_uploading_enabled_false_idle (Fixture *fixture)
+{
+  emer_permissions_provider_set_uploading_enabled (fixture->test_object, FALSE);
+  return G_SOURCE_REMOVE;
+}
+
+static void
+test_permissions_provider_set_uploading_enabled (Fixture      *fixture,
+                                                 gconstpointer unused)
+{
+  g_idle_add ((GSourceFunc) set_uploading_enabled_false_idle, fixture);
+  g_main_loop_run (fixture->main_loop);
+
+  g_assert_false (fixture->notify_daemon_called);
+  g_assert_true (emer_permissions_provider_get_daemon_enabled (fixture->test_object));
+
+  g_assert_true (fixture->notify_uploading_called);
+  g_assert_false (fixture->notify_uploading_called_with);
+  g_assert_false (emer_permissions_provider_get_uploading_enabled (fixture->test_object));
+}
+
+
+static void
+test_permissions_provider_set_uploading_enabled_updates_config_file (Fixture      *fixture,
+                                                                     gconstpointer unused)
+{
+  g_assert_true (file_contents_match (fixture->permissions_config_file,
+                                      "^enabled=true$"));
+  g_assert_true (file_contents_match (fixture->permissions_config_file,
+                                      "^uploading_enabled=true$"));
+
+  g_idle_add ((GSourceFunc) set_uploading_enabled_false_idle, fixture);
+
+  GFileMonitor *monitor =
+    g_file_monitor_file (fixture->permissions_config_file, G_FILE_MONITOR_NONE,
+                         NULL, NULL);
+  g_assert_nonnull (monitor);
+
+  g_signal_connect (monitor, "changed", G_CALLBACK (on_config_file_changed),
+                    fixture);
+
+  /* Run the main loop twice, to wait for two events: the property notification
+  and a "changed" or "created" file monitor event. */
+  g_main_loop_run (fixture->main_loop);
+  g_main_loop_run (fixture->main_loop);
+  g_assert_cmpuint (fixture->num_config_file_changes, ==, 1);
+
+  g_object_unref (monitor);
+
+  g_assert_true (emer_permissions_provider_get_daemon_enabled (fixture->test_object));
+  g_assert_false (emer_permissions_provider_get_uploading_enabled (fixture->test_object));
+
+  g_assert_true (file_contents_match (fixture->permissions_config_file,
+                                      "^enabled=true$"));
+  g_assert_true (file_contents_match (fixture->permissions_config_file,
+                                      "^uploading_enabled=false$"));
 }
 
 gint
@@ -532,6 +628,14 @@ main (gint                argc,
                                  PERMISSIONS_CONFIG_FILE_ENABLED_TEST,
                                  setup_with_config_file,
                                  test_permissions_provider_set_daemon_enabled_updates_config_file);
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/set-uploading-enabled",
+                                 PERMISSIONS_CONFIG_FILE_ENABLED_TEST,
+                                 setup_with_config_file,
+                                 test_permissions_provider_set_uploading_enabled);
+  ADD_PERMISSIONS_PROVIDER_TEST ("/permissions-provider/set-uploading-enabled-updates-config-file",
+                                 PERMISSIONS_CONFIG_FILE_ENABLED_TEST,
+                                 setup_with_config_file,
+                                 test_permissions_provider_set_uploading_enabled_updates_config_file);
 
 #undef ADD_PERMISSIONS_PROVIDER_TEST
 


### PR DESCRIPTION
With the previous defaults, metrics collected during first boot would be dropped, even if the user consented to metrics in the FBE. This is problematic because the boot-time metrics include crucial facts like the OS version are not submitted the first time an Endless OS installation is used. This also prevented us collecting metrics from live sessions, since the "is this a live session?" metric is also reported at boot time, and every boot is the first boot.

This PR changes the default from "don't collect, do upload" to "do collect, don't upload", and amends SetEnabled() to change both flags in unison.

https://phabricator.endlessm.com/T14065