### PR TITLE
T14065: fix unit test races

### DIFF
--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -154,6 +154,7 @@ read_config_file_sync (EmerPermissionsProvider *self)
   if (!load_succeeded)
     {
       load_fallback_data (self);
+      schedule_config_file_update (self);
 
       if (!g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
         g_critical ("Permissions config file '%s' was invalid or could not be "


### PR DESCRIPTION
This avoids a race in the tests by erasing the daemon's permissions file after each time it is read during the opt-in/opt-out test. This way, when it re-appears on disk, we know that the daemon has re-written it after a state change internally.

One change to the daemon itself is necessary to cause it to write it's internal fallback configuration to a file in the case that the permissions file is missing, otherwise it's impossible for the test to check that the daemon has the correct default state initially (the uploading flag is not visible over the D-Bus API).

https://phabricator.endlessm.com/T14065