### PR TITLE
daemon: fix crash when creating EmerDaemon instance

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1230,11 +1230,6 @@ emer_daemon_constructed (GObject *object)
   EmerDaemon *self = EMER_DAEMON (object);
   EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
 
-  gchar *environment =
-    emer_permissions_provider_get_environment (priv->permissions_provider);
-  schedule_upload (self, environment);
-  g_free (environment);
-
   if (priv->persistent_cache == NULL)
     {
       GError *error = NULL;
@@ -1254,6 +1249,11 @@ emer_daemon_constructed (GObject *object)
         emer_network_send_provider_new (network_send_path);
       g_free (network_send_path);
     }
+
+  gchar *environment =
+    emer_permissions_provider_get_environment (priv->permissions_provider);
+  schedule_upload (self, environment);
+  g_free (environment);
 
   G_OBJECT_CLASS (emer_daemon_parent_class)->constructed (object);
 }


### PR DESCRIPTION
Currently, during emer_daemon_constructor(), we first call into
emer_permissions_provider_get_environment() to potentially schedule an
upload of the previously collected metrics, and then we create an
EmerPersistentCache object, when one does not already exist.

However, we previously connected a callback to change notifications of
the 'daemon-enabled' property of EmerPermissionsProvider, which assumes
that a EmerPersistentCache object has already been created. Since
emer_permissions_provider_get_environment() causes that property to be
notified, we would crash.

This commit fixes the crash by moving the EmerPersistentCache creation
before the call to emer_permissions_provider_get_environment().

https://phabricator.endlessm.com/T17341