### PR TITLE
Recover from corrupt cache metadata or config file

### DIFF
--- a/daemon/emer-boot-id-provider.h
+++ b/daemon/emer-boot-id-provider.h
@@ -63,6 +63,8 @@ typedef struct _EmerBootIdProvider EmerBootIdProvider;
  */
 typedef struct _EmerBootIdProviderClass EmerBootIdProviderClass;
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (EmerBootIdProvider, g_object_unref)
+
 struct _EmerBootIdProvider
 {
   /*< private >*/

--- a/daemon/emer-cache-size-provider.h
+++ b/daemon/emer-cache-size-provider.h
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* Copyright 2015 Endless Mobile, Inc. */
+/* Copyright 2015-2017 Endless Mobile, Inc. */
 
 /*
  * This file is part of eos-event-recorder-daemon.
@@ -23,67 +23,11 @@
 #ifndef EMER_CACHE_SIZE_PROVIDER_H
 #define EMER_CACHE_SIZE_PROVIDER_H
 
-#include <glib-object.h>
+#include <glib.h>
 
 G_BEGIN_DECLS
 
-#define EMER_TYPE_CACHE_SIZE_PROVIDER emer_cache_size_provider_get_type()
-
-#define EMER_CACHE_SIZE_PROVIDER(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), \
-  EMER_TYPE_CACHE_SIZE_PROVIDER, EmerCacheSizeProvider))
-
-#define EMER_CACHE_SIZE_PROVIDER_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), \
-  EMER_TYPE_CACHE_SIZE_PROVIDER, EmerCacheSizeProviderClass))
-
-#define EMER_IS_CACHE_SIZE_PROVIDER(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), \
-  EMER_TYPE_CACHE_SIZE_PROVIDER))
-
-#define EMER_IS_CACHE_SIZE_PROVIDER_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), \
-  EMER_TYPE_CACHE_SIZE_PROVIDER))
-
-#define EMER_CACHE_SIZE_PROVIDER_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), \
-  EMER_TYPE_CACHE_SIZE_PROVIDER, EmerCacheSizeProviderClass))
-
-/*
- * EmerCacheSizeProvider:
- *
- * This instance structure contains no public members.
- */
-typedef struct _EmerCacheSizeProvider EmerCacheSizeProvider;
-
-/*
- * EmerCacheSizeProvider:
- *
- * This class structure contains no public members.
- */
-typedef struct _EmerCacheSizeProviderClass EmerCacheSizeProviderClass;
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (EmerCacheSizeProvider, g_object_unref)
-
-struct _EmerCacheSizeProvider
-{
-  /*< private >*/
-  GObject parent;
-};
-
-struct _EmerCacheSizeProviderClass
-{
-  /*< private >*/
-  GObjectClass parent_class;
-};
-
-GType                  emer_cache_size_provider_get_type              (void) G_GNUC_CONST;
-
-EmerCacheSizeProvider *emer_cache_size_provider_new                   (void);
-
-EmerCacheSizeProvider *emer_cache_size_provider_new_full              (const gchar           *path);
-
-guint64                emer_cache_size_provider_get_max_cache_size    (EmerCacheSizeProvider *self);
+guint64                emer_cache_size_provider_get_max_cache_size    (const gchar           *path);
 
 G_END_DECLS
 

--- a/daemon/emer-cache-size-provider.h
+++ b/daemon/emer-cache-size-provider.h
@@ -63,6 +63,8 @@ typedef struct _EmerCacheSizeProvider EmerCacheSizeProvider;
  */
 typedef struct _EmerCacheSizeProviderClass EmerCacheSizeProviderClass;
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (EmerCacheSizeProvider, g_object_unref)
+
 struct _EmerCacheSizeProvider
 {
   /*< private >*/

--- a/daemon/emer-cache-version-provider.h
+++ b/daemon/emer-cache-version-provider.h
@@ -63,6 +63,7 @@ typedef struct _EmerCacheVersionProvider EmerCacheVersionProvider;
  */
 typedef struct _EmerCacheVersionProviderClass EmerCacheVersionProviderClass;
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (EmerCacheVersionProvider, g_object_unref)
 
 struct _EmerCacheVersionProvider
 {

--- a/daemon/emer-circular-file.c
+++ b/daemon/emer-circular-file.c
@@ -477,7 +477,7 @@ emer_circular_file_initable_init (GInitable    *initable,
   g_object_unref (data_file_output_stream);
 
   priv->metadata_key_file = g_key_file_new ();
-  GError *local_error = NULL;
+  g_autoptr(GError) local_error = NULL;
   gboolean load_succeeded =
     g_key_file_load_from_file (priv->metadata_key_file, priv->metadata_filepath,
                                G_KEY_FILE_NONE, &local_error);
@@ -486,7 +486,7 @@ emer_circular_file_initable_init (GInitable    *initable,
       if (!g_error_matches (local_error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
         goto handle_failed_read;
 
-      g_error_free (local_error);
+      g_clear_error (&local_error);
       g_key_file_set_uint64 (priv->metadata_key_file, METADATA_GROUP_NAME,
                              MAX_SIZE_KEY, priv->max_size);
       return set_metadata (self, 0, 0, error);
@@ -530,7 +530,7 @@ emer_circular_file_initable_init (GInitable    *initable,
   return resize (self, prev_max_size, error);
 
 handle_failed_read:
-  g_propagate_error (error, local_error);
+  g_propagate_error (error, g_steal_pointer (&local_error));
   return FALSE;
 }
 

--- a/daemon/emer-circular-file.h
+++ b/daemon/emer-circular-file.h
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* Copyright 2015 Endless Mobile, Inc. */
+/* Copyright 2015-2017 Endless Mobile, Inc. */
 
 /*
  * This file is part of eos-event-recorder-daemon.
@@ -54,6 +54,8 @@ G_BEGIN_DECLS
 
 typedef struct _EmerCircularFile EmerCircularFile;
 typedef struct _EmerCircularFileClass EmerCircularFileClass;
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (EmerCircularFile, g_object_unref)
 
 struct _EmerCircularFile
 {

--- a/daemon/emer-circular-file.h
+++ b/daemon/emer-circular-file.h
@@ -71,6 +71,7 @@ GType             emer_circular_file_get_type (void) G_GNUC_CONST;
 
 EmerCircularFile *emer_circular_file_new      (const gchar      *path,
                                                guint64           max_size,
+                                               gboolean          reinitialize,
                                                GError          **error);
 
 gboolean          emer_circular_file_append   (EmerCircularFile *self,

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1281,6 +1281,26 @@ emer_daemon_constructed (GObject *object)
 }
 
 static void
+emer_daemon_get_property (GObject      *object,
+                          guint         property_id,
+                          GValue       *value,
+                          GParamSpec   *pspec)
+{
+  EmerDaemon *self = EMER_DAEMON (object);
+  EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
+
+  switch (property_id)
+    {
+    case PROP_PERSISTENT_CACHE:
+      g_value_set_object (value, priv->persistent_cache);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    }
+}
+
+static void
 emer_daemon_set_property (GObject      *object,
                           guint         property_id,
                           const GValue *value,
@@ -1371,6 +1391,7 @@ emer_daemon_class_init (EmerDaemonClass *klass)
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
   object_class->constructed = emer_daemon_constructed;
+  object_class->get_property = emer_daemon_get_property;
   object_class->set_property = emer_daemon_set_property;
   object_class->finalize = emer_daemon_finalize;
 
@@ -1491,7 +1512,7 @@ emer_daemon_class_init (EmerDaemonClass *klass)
                          "Object managing persistent storage of events until "
                          "they are uploaded to the metrics servers",
                          EMER_TYPE_PERSISTENT_CACHE,
-                         G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE |
+                         G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE |
                          G_PARAM_STATIC_STRINGS);
 
   /* Blurb string is good enough default documentation for this */

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1259,10 +1259,14 @@ emer_daemon_constructed (GObject *object)
 
   if (priv->persistent_cache == NULL)
     {
+      guint64 max_cache_size =
+        emer_cache_size_provider_get_max_cache_size (NULL);
       g_autoptr(GError) error = NULL;
 
       priv->persistent_cache =
-        emer_persistent_cache_new (priv->persistent_cache_directory, FALSE,
+        emer_persistent_cache_new (priv->persistent_cache_directory,
+                                   max_cache_size,
+                                   FALSE,
                                    &error);
 
       if (priv->persistent_cache == NULL &&
@@ -1278,7 +1282,9 @@ emer_daemon_constructed (GObject *object)
 
           g_message ("Attempting to reinitialize the persistent cache");
           priv->persistent_cache =
-            emer_persistent_cache_new (priv->persistent_cache_directory, TRUE,
+            emer_persistent_cache_new (priv->persistent_cache_directory,
+                                       max_cache_size,
+                                       TRUE,
                                        &error);
         }
 

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -883,7 +883,7 @@ emer_persistent_cache_initable_init (GInitable    *initable,
   guint64 max_cache_size =
     emer_cache_size_provider_get_max_cache_size (priv->cache_size_provider);
   priv->variant_file =
-    emer_circular_file_new (variant_file_path, max_cache_size, error);
+    emer_circular_file_new (variant_file_path, max_cache_size, FALSE, error);
   g_free (variant_file_path);
   if (priv->variant_file == NULL)
     return FALSE;

--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* Copyright 2014, 2015 Endless Mobile, Inc. */
+/* Copyright 2014-2017 Endless Mobile, Inc. */
 
 /*
  * This file is part of eos-event-recorder-daemon.
@@ -87,6 +87,7 @@ struct _EmerPersistentCacheClass
 GType                emer_persistent_cache_get_type             (void) G_GNUC_CONST;
 
 EmerPersistentCache *emer_persistent_cache_new                  (const gchar              *directory,
+                                                                 gboolean                  reinitialize_cache,
                                                                  GError                  **error);
 
 gsize                emer_persistent_cache_cost                 (GVariant                 *self);
@@ -124,6 +125,7 @@ EmerPersistentCache *emer_persistent_cache_new_full             (const gchar    
                                                                  EmerBootIdProvider       *boot_id_provider,
                                                                  EmerCacheVersionProvider *version_provider,
                                                                  guint                     boot_offset_update_interval,
+                                                                 gboolean                  reinitialize_cache,
                                                                  GError                  **error);
 
 G_END_DECLS

--- a/daemon/emer-persistent-cache.h
+++ b/daemon/emer-persistent-cache.h
@@ -87,6 +87,7 @@ struct _EmerPersistentCacheClass
 GType                emer_persistent_cache_get_type             (void) G_GNUC_CONST;
 
 EmerPersistentCache *emer_persistent_cache_new                  (const gchar              *directory,
+                                                                 guint64                   cache_size,
                                                                  gboolean                  reinitialize_cache,
                                                                  GError                  **error);
 
@@ -121,7 +122,7 @@ gboolean             emer_persistent_cache_remove_all           (EmerPersistentC
                                                                  GError                  **error);
 
 EmerPersistentCache *emer_persistent_cache_new_full             (const gchar              *directory,
-                                                                 EmerCacheSizeProvider    *cache_size_provider,
+                                                                 guint64                   cache_size,
                                                                  EmerBootIdProvider       *boot_id_provider,
                                                                  EmerCacheVersionProvider *version_provider,
                                                                  guint                     boot_offset_update_interval,

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -123,7 +123,8 @@ tests_daemon_test_persistent_cache_SOURCES = \
 	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
 	tests/daemon/mock-cache-version-provider.c \
 	daemon/emer-cache-version-provider.h \
-	tests/daemon/mock-circular-file.c daemon/emer-circular-file.h \
+	tests/daemon/mock-circular-file.c tests/daemon/mock-circular-file.h \
+	daemon/emer-circular-file.h \
 	shared/metrics-util.c shared/metrics-util.h \
 	$(NULL)
 tests_daemon_test_persistent_cache_CPPFLAGS = $(DAEMON_TEST_FLAGS)

--- a/tests/daemon/mock-circular-file.c
+++ b/tests/daemon/mock-circular-file.c
@@ -116,6 +116,7 @@ emer_circular_file_class_init (EmerCircularFileClass *klass)
 EmerCircularFile *
 emer_circular_file_new (const gchar *path,
                         guint64      max_size,
+                        gboolean     reinitialize,
                         GError     **error)
 {
   return g_object_new (EMER_TYPE_CIRCULAR_FILE,

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -69,6 +69,7 @@ emer_persistent_cache_class_init (EmerPersistentCacheClass *klass)
 
 EmerPersistentCache *
 emer_persistent_cache_new (const gchar *directory,
+                           guint64      cache_size,
                            gboolean     reinitialize_cache,
                            GError     **error)
 {
@@ -89,7 +90,7 @@ emer_persistent_cache_new (const gchar *directory,
 
 EmerPersistentCache *
 emer_persistent_cache_new_full (const gchar              *directory,
-                                EmerCacheSizeProvider    *cache_size_provider,
+                                guint64                   cache_size,
                                 EmerBootIdProvider       *boot_id_provider,
                                 EmerCacheVersionProvider *version_provider,
                                 guint                     boot_offset_update_interval,

--- a/tests/daemon/mock-persistent-cache.h
+++ b/tests/daemon/mock-persistent-cache.h
@@ -33,6 +33,8 @@ G_BEGIN_DECLS
 #define MAX_NUM_VARIANTS 10
 
 gboolean             mock_persistent_cache_is_empty             (EmerPersistentCache      *self);
+void                 mock_persistent_cache_set_construct_error  (const GError             *error);
+gboolean             mock_persistent_cache_get_reinitialize     (EmerPersistentCache      *self);
 
 G_END_DECLS
 

--- a/tests/daemon/test-cache-size-provider.c
+++ b/tests/daemon/test-cache-size-provider.c
@@ -20,6 +20,7 @@
 
 #include "emer-cache-size-provider.h"
 
+#include <string.h>
 #include <gio/gio.h>
 #include <glib.h>
 #include <glib/gstdio.h>
@@ -27,10 +28,15 @@
 #define CACHE_SIZE_FILE_PATH "cache_size_file_XXXXXX"
 
 #define FIRST_MAX_CACHE_SIZE 40
+#define DEFAULT_MAX_CACHE_SIZE 10000000
 
 #define FIRST_CACHE_SIZE_FILE_CONTENTS \
  "[persistent_cache_size]\n" \
  "maximum=40\n"
+
+#define DEFAULT_CACHE_SIZE_FILE_CONTENTS \
+ "[persistent_cache_size]\n" \
+ "maximum=10000000\n"
 
 // Helper Functions
 
@@ -41,14 +47,15 @@ typedef struct Fixture
 } Fixture;
 
 static void
-write_cache_size_file (Fixture *fixture,
-                       gchar   *key_file_data)
+write_cache_size_file (Fixture     *fixture,
+                       const gchar *key_file_data,
+                       gssize       key_file_size)
 {
   gboolean ret;
   g_autoptr(GError) error = NULL;
 
-  ret = g_file_set_contents (fixture->tmp_path, key_file_data,
-                             -1, &error);
+  ret = g_file_set_contents (fixture->tmp_path, key_file_data, key_file_size,
+                             &error);
   g_assert_no_error (error);
   g_assert_true (ret);
 }
@@ -76,11 +83,131 @@ static void
 test_cache_size_provider_can_get_max_cache_size (Fixture      *fixture,
                                                  gconstpointer unused)
 {
-  write_cache_size_file (fixture, FIRST_CACHE_SIZE_FILE_CONTENTS);
+  write_cache_size_file (fixture, FIRST_CACHE_SIZE_FILE_CONTENTS, -1);
 
   guint64 max_cache_size =
     emer_cache_size_provider_get_max_cache_size (fixture->tmp_path);
   g_assert_cmpint (max_cache_size, ==, FIRST_MAX_CACHE_SIZE);
+}
+
+static void
+assert_file_has_default_contents (Fixture *fixture)
+{
+  gboolean ret;
+  g_autoptr(GError) error = NULL;
+  g_autofree gchar *contents = NULL;
+
+  guint64 max_cache_size =
+    emer_cache_size_provider_get_max_cache_size (fixture->tmp_path);
+  g_assert_cmpint (max_cache_size, ==, DEFAULT_MAX_CACHE_SIZE);
+
+  ret = g_file_get_contents (fixture->tmp_path, &contents, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_true (ret);
+
+  g_assert_cmpstr (contents, ==, DEFAULT_CACHE_SIZE_FILE_CONTENTS);
+
+  /* Re-reading the file should return the same value */
+  max_cache_size =
+    emer_cache_size_provider_get_max_cache_size (fixture->tmp_path);
+  g_assert_cmpint (max_cache_size, ==, DEFAULT_MAX_CACHE_SIZE);
+}
+
+static void
+assert_string_contains (const gchar *haystack,
+                        const gchar *needle)
+{
+  if (strstr (haystack, needle) == NULL)
+    g_error ("\"%s\" not in \"%s\"", needle, haystack);
+}
+
+static void
+test_cache_size_provider_writes_file_if_missing (Fixture      *fixture,
+                                                 gconstpointer unused)
+{
+  gboolean ret;
+  g_autoptr(GError) error = NULL;
+
+  ret = g_file_delete (fixture->tmp_file, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_true (ret);
+
+  assert_file_has_default_contents (fixture);
+}
+
+static void
+test_cache_size_provider_recovers_if_corrupt_empty (Fixture      *fixture,
+                                                    gconstpointer unused)
+{
+  write_cache_size_file (fixture, "", 0);
+  assert_file_has_default_contents (fixture);
+}
+
+static void
+test_cache_size_provider_recovers_if_corrupt_nul (Fixture      *fixture,
+                                                  gconstpointer unused)
+{
+  /* If the target file does not already exist, then g_file_set_contents(), as
+   * used by g_key_file_save_to_file(), followed by a poorly-timed system crash
+   * can leave the target file at the corrent size but full of NUL bytes.
+   *
+   * https://bugzilla.gnome.org/show_bug.cgi?id=790638
+   *
+   * The key file appears to be empty when one tries to read it (since GKeyFile
+   * reads the contents as a NUL-terminated string) so we should recover by
+   * re-initializing it in this case, silently.
+   */
+  g_test_bug ("T19953");
+
+  gssize size = 41;
+  gchar *contents = g_malloc0 (41);
+
+  write_cache_size_file (fixture, contents, size);
+  assert_file_has_default_contents (fixture);
+}
+
+static void
+test_cache_size_provider_recovers_if_corrupt_missing_key (Fixture      *fixture,
+                                                          gconstpointer unused)
+{
+  /* If the file is not logically empty, we still want to fill in the 'maximum'
+   * key, but leave any other fields untouched. (Perhaps the file is destined
+   * for a future version of the daemon which accepts some new field.)
+   */
+  const gchar *contents = "[persistent_cache_size]\nunrelated_key=1";
+
+  write_cache_size_file (fixture, contents, -1);
+
+  guint64 max_cache_size =
+    emer_cache_size_provider_get_max_cache_size (fixture->tmp_path);
+  g_assert_cmpint (max_cache_size, ==, DEFAULT_MAX_CACHE_SIZE);
+
+  gboolean ret;
+  g_autoptr(GError) error = NULL;
+  g_autofree gchar *new_contents = NULL;
+
+  ret = g_file_get_contents (fixture->tmp_path, &new_contents, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_true (ret);
+
+  assert_string_contains (new_contents, "maximum=10000000");
+  assert_string_contains (new_contents, "unrelated_key=1");
+}
+
+static void
+test_cache_size_provider_recovers_if_corrupt_garbage (Fixture      *fixture,
+                                                      gconstpointer unused)
+{
+  /* If the file exists but is malformed, we should log a warning before
+   * reinitialising the file.
+   */
+  const gchar *contents = "i think i'm paranoid";
+
+  write_cache_size_file (fixture, contents, -1);
+
+  g_test_expect_message (NULL, G_LOG_LEVEL_WARNING, "*Key file*i think i'm paranoid*");
+  assert_file_has_default_contents (fixture);
+  g_test_assert_expected_messages ();
 }
 
 gint
@@ -88,11 +215,23 @@ main (gint                argc,
       const gchar * const argv[])
 {
   g_test_init (&argc, (gchar ***) &argv, NULL);
+  g_test_bug_base ("https://phabricator.endlessm.com/");
+
 #define ADD_CACHE_SIZE_TEST_FUNC(path, func) \
   g_test_add ((path), Fixture, NULL, setup, (func), teardown)
 
   ADD_CACHE_SIZE_TEST_FUNC ("/cache-size-provider/can-get-max-cache-size",
                             test_cache_size_provider_can_get_max_cache_size);
+  ADD_CACHE_SIZE_TEST_FUNC ("/cache-size-provider/writes-file-if-missing",
+                            test_cache_size_provider_writes_file_if_missing);
+  ADD_CACHE_SIZE_TEST_FUNC ("/cache-size-provider/recovers-if-corrupt/empty",
+                            test_cache_size_provider_recovers_if_corrupt_empty);
+  ADD_CACHE_SIZE_TEST_FUNC ("/cache-size-provider/recovers-if-corrupt/nul",
+                            test_cache_size_provider_recovers_if_corrupt_nul);
+  ADD_CACHE_SIZE_TEST_FUNC ("/cache-size-provider/recovers-if-corrupt/missing-key",
+                            test_cache_size_provider_recovers_if_corrupt_missing_key);
+  ADD_CACHE_SIZE_TEST_FUNC ("/cache-size-provider/recovers-if-corrupt/garbage",
+                            test_cache_size_provider_recovers_if_corrupt_garbage);
 
 #undef ADD_CACHE_SIZE_TEST_FUNC
 

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -49,6 +49,7 @@
 #define MOCK_SERVER_PATH TEST_DIR "daemon/mock-server.py"
 
 #define MEANINGLESS_EVENT "350ac4ff-3026-4c25-9e7e-e8103b4fd5d8"
+#define CACHE_METADATA_IS_CORRUPT_EVENT_ID "f0e8a206-3bc2-405e-90d0-ef6fe6dd7edc"
 
 #define USER_ID 4200u
 #define NUM_EVENTS G_GINT64_CONSTANT (101)
@@ -376,13 +377,19 @@ read_bytes_from_stdout (GSubprocess           *subprocess,
 }
 
 static GVariant *
-make_event_id_variant (void)
+make_variant_for_event_id (const gchar *event_id)
 {
   uuid_t uuid;
-  g_assert_cmpint (uuid_parse (MEANINGLESS_EVENT, uuid), ==, 0);
+  g_assert_cmpint (uuid_parse (event_id, uuid), ==, 0);
   GVariantBuilder event_id_builder;
   get_uuid_builder (uuid, &event_id_builder);
   return g_variant_builder_end (&event_id_builder);
+}
+
+static GVariant *
+make_event_id_variant (void)
+{
+  return make_variant_for_event_id (MEANINGLESS_EVENT);
 }
 
 static GVariant *
@@ -943,8 +950,8 @@ create_test_object (Fixture *fixture)
 }
 
 static void
-setup (Fixture      *fixture,
-       gconstpointer unused)
+setup_most (Fixture      *fixture,
+            gconstpointer unused)
 {
   // The mock server should be sent SIGTERM when this process exits.
   GSubprocessLauncher *subprocess_launcher =
@@ -966,8 +973,21 @@ setup (Fixture      *fixture,
   fixture->mock_network_send_provider =
     emer_network_send_provider_new (NULL /* path */);
   fixture->mock_permissions_provider = emer_permissions_provider_new ();
+  fixture->mock_persistent_cache = NULL;
+}
+
+static void
+setup (Fixture      *fixture,
+       gconstpointer unused)
+{
+  g_autoptr(GError) error = NULL;
+  setup_most (fixture, unused);
+
   fixture->mock_persistent_cache =
-    emer_persistent_cache_new (NULL /* directory */, NULL /* GError */);
+    emer_persistent_cache_new (NULL /* directory */,
+                               FALSE /* reinitialize_cache */,
+                               &error);
+  g_assert_no_error (error);
 
   create_test_object (fixture);
 }
@@ -1368,6 +1388,96 @@ test_daemon_limits_network_upload_size (Fixture      *fixture,
   wait_for_upload_to_finish (fixture);
 }
 
+/* Asserts that the mock server received a single
+ * CACHE_METADATA_IS_CORRUPT_EVENT_ID event.
+ */
+static void
+assert_corrupt_metadata_event_received (GByteArray *request,
+                                        Fixture    *fixture)
+{
+  GVariantIter *singular_iterator, *aggregate_iterator, *sequence_iterator;
+  get_events_from_request (request, fixture, &singular_iterator,
+                           &aggregate_iterator, &sequence_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (singular_iterator), ==, 1u);
+
+  GVariant *singular = g_variant_iter_next_value (singular_iterator);
+  GVariant *event_id;
+  GVariant *payload;
+
+  /* Can't make any meaningful assertions about the user ID (it's the user
+   * running the test) or the timestamp.
+   */
+  g_variant_get (singular, "(u@ayxmv)",
+                 NULL, &event_id, NULL, &payload);
+
+  GVariant *expected_event_id =
+    make_variant_for_event_id (CACHE_METADATA_IS_CORRUPT_EVENT_ID);
+  assert_variants_equal (event_id, expected_event_id);
+
+  g_assert_null (payload);
+
+  g_variant_iter_free (singular_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (aggregate_iterator), ==, 0u);
+  g_variant_iter_free (aggregate_iterator);
+
+  g_assert_cmpuint (g_variant_iter_n_children (sequence_iterator), ==, 0u);
+  g_variant_iter_free (sequence_iterator);
+}
+
+/* If the first attempt to create the EmerPersistentCache fails with a
+ * G_KEY_FILE_ERROR, the daemon should attempt to reset the cache, and log an
+ * event indicating that the cache metadata was corrupt.
+ */
+static void
+test_daemon_reinitializes_cache_on_key_file_error (Fixture      *fixture,
+                                                   gconstpointer unused)
+{
+  g_autoptr(GError) persistent_cache_error =
+    g_error_new (G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE, "oh no");
+  mock_persistent_cache_set_construct_error (persistent_cache_error);
+
+  g_test_expect_message (NULL, G_LOG_LEVEL_WARNING, "*oh no*");
+  create_test_object (fixture);
+
+  g_object_get (fixture->test_object,
+                "persistent-cache", &fixture->mock_persistent_cache,
+                NULL);
+
+  g_assert_true (mock_persistent_cache_get_reinitialize (fixture->mock_persistent_cache));
+
+  read_network_request (fixture,
+                        (ProcessBytesSourceFunc) assert_corrupt_metadata_event_received);
+  wait_for_upload_to_finish (fixture);
+
+  g_test_assert_expected_messages ();
+}
+
+/* If creating the EmerPersistentCache with an error other than
+ * G_KEY_FILE_ERROR, we expect a crash.
+ */
+static void
+test_daemon_crashes_on_non_key_file_error (Fixture      *fixture,
+                                           gconstpointer unused)
+{
+  if (g_test_subprocess ())
+    {
+      g_autoptr(GError) persistent_cache_error =
+        g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED, "oh no");
+
+      mock_persistent_cache_set_construct_error (persistent_cache_error);
+
+      /* should abort */
+      create_test_object (fixture);
+      return;
+    }
+
+  g_test_trap_subprocess (NULL, 0, 0);
+  g_test_trap_assert_failed ();
+  g_test_trap_assert_stderr ("*oh no*");
+}
+
 gint
 main (gint                argc,
       const gchar * const argv[])
@@ -1415,6 +1525,16 @@ main (gint                argc,
                    test_daemon_limits_network_upload_size);
 
 #undef ADD_DAEMON_TEST
+
+  /* These tests need slightly different set-up */
+  g_test_add ("/daemon/reinitializes-cache-on-key-file-error",
+              Fixture, NULL, setup_most,
+              test_daemon_reinitializes_cache_on_key_file_error,
+              teardown);
+  g_test_add ("/daemon/crashes-on-non-key-file-error",
+              Fixture, NULL, setup_most,
+              test_daemon_crashes_on_non_key_file_error,
+              teardown);
 
   return g_test_run ();
 }

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -485,7 +485,22 @@ assert_variants_equal (GVariant *actual_variant,
                        GVariant *expected_variant)
 {
   g_assert_nonnull (actual_variant);
-  g_assert_true (g_variant_equal (actual_variant, expected_variant));
+
+  if (!g_variant_equal (actual_variant, expected_variant))
+    {
+      /* Assertion failures of the form
+       *   ERROR:../tests/daemon/test-daemon.c:495:assert_variants_equal:
+       *   'g_variant_equal (actual_variant, expected_variant)' should be TRUE
+       * are not very helpful -- you want to see the actual variants!
+       */
+      g_autofree gchar *actual_str = g_variant_print (actual_variant, TRUE);
+      g_autofree gchar *expected_str = g_variant_print (expected_variant, TRUE);
+      g_assert_cmpstr (actual_str, ==, expected_str);
+
+      /* Should not be reached: */
+      g_error ("variants compared non-equal, but their type-annotated "
+               "stringified representations compared equal!");
+    }
 
   g_variant_unref (actual_variant);
   g_variant_unref (expected_variant);

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -983,8 +983,10 @@ setup (Fixture      *fixture,
   g_autoptr(GError) error = NULL;
   setup_most (fixture, unused);
 
+  /* directory and max_cache_size are ignored by mock object. */
   fixture->mock_persistent_cache =
     emer_persistent_cache_new (NULL /* directory */,
+                               10000000, /* max_cache_size */
                                FALSE /* reinitialize_cache */,
                                &error);
   g_assert_no_error (error);

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -117,7 +117,7 @@ terminate_subprocess_and_wait (GSubprocess *subprocess)
    * Make sure it was the SIGTERM that finished the process, and not something
    * else.
    */
-  GError *error = NULL;
+  g_autoptr(GError) error = NULL;
   g_assert_false (g_subprocess_wait_check (subprocess, NULL, &error));
   g_assert_error (error, G_SPAWN_ERROR, G_SPAWN_ERROR_FAILED);
   g_assert_cmpstr (error->message, ==, "Child process killed by signal 15");
@@ -977,12 +977,12 @@ teardown (Fixture      *fixture,
           gconstpointer unused)
 {
   g_clear_object (&fixture->test_object);
-  g_object_unref (fixture->mock_machine_id_provider);
-  g_object_unref (fixture->mock_network_send_provider);
-  g_object_unref (fixture->mock_permissions_provider);
-  g_object_unref (fixture->mock_persistent_cache);
-  terminate_subprocess_and_wait (fixture->mock_server);
-  g_free (fixture->server_uri);
+  g_clear_object (&fixture->mock_machine_id_provider);
+  g_clear_object (&fixture->mock_network_send_provider);
+  g_clear_object (&fixture->mock_permissions_provider);
+  g_clear_object (&fixture->mock_persistent_cache);
+  g_clear_pointer (&fixture->mock_server, terminate_subprocess_and_wait);
+  g_clear_pointer (&fixture->server_uri, g_free);
 }
 
 // Unit Tests next:

--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -96,7 +96,7 @@ make_persistent_cache (const gchar *directory)
 {
   GError *error = NULL;
   EmerPersistentCache *persistent_cache =
-    emer_persistent_cache_new (directory, &error);
+    emer_persistent_cache_new (directory, FALSE, &error);
 
   if (persistent_cache == NULL)
     {

--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "emer-cache-size-provider.h"
 #include "emer-persistent-cache.h"
 #include "shared/metrics-util.h"
 
@@ -95,8 +96,10 @@ static EmerPersistentCache *
 make_persistent_cache (const gchar *directory)
 {
   GError *error = NULL;
+  guint64 max_cache_size =
+    emer_cache_size_provider_get_max_cache_size (NULL);
   EmerPersistentCache *persistent_cache =
-    emer_persistent_cache_new (directory, FALSE, &error);
+    emer_persistent_cache_new (directory, max_cache_size, FALSE, &error);
 
   if (persistent_cache == NULL)
     {


### PR DESCRIPTION
We observed a system where `/etc/metrics/cache-size.conf` and `/var/cache/metrics/variants.dat.metadata` were full of `NUL` bytes, to the length you'd expect if the file were properly written. When it encountered these files, the metrics daemon logged a warning for the first, then logged a fatal error and fell over for the second.

I believe this is due to surprising behaviour of `g_file_set_contents()` when the file to be overwritten does not exist: it does not `fsync()` the temporary file before `close()` and `rename()`. Is this a bug? Maybe. This application appears to be doing everything right (relatively speaking): it creates both files with `g_key_file_save_to_file()` which is meant to be the correct, safe thing to do.

Regardless of the cause, any systems in the wild which have hit this problem now have a broken metrics daemon, so we need to deal with the case where one or both of these keyfiles cannot be parsed. The sensible recovery options seem to me to be:

* `cache-size.conf`: since there's only one value in this file, just re-initialize it.
* `variants.dat.metadata`: without the metadata it's impossible to interpret the contents of `variants.dat`, so again we need to re-initialize the keyfile, which logically discards the contents of `variants.dat`. In this case, we want to log an event so we have some idea how often this happens in the wild.

`EmerCacheSizeProvider` was, to my eyes, really overcomplicated, so I'm afraid I couldn't stop myself replacing it with a single function.

https://phabricator.endlessm.com/T19953