### PR TITLE
Fix build/distcheck; enable more warnings more often

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,7 @@ AM_CFLAGS = @STRICT_CFLAGS@
 # directory when doing 'make distcheck'.
 AM_DISTCHECK_CONFIGURE_FLAGS = \
 	--enable-strict-flags \
-	--with-systemdsystemunitdir=$(libdir)/systemd \
+	--with-systemdsystemunitdir='$${prefix}/lib/systemd/system' \
 	$(NULL)
 if EOS_ENABLE_COVERAGE
 AM_DISTCHECK_CONFIGURE_FLAGS += --enable-coverage --with-coverage-dir=@EOS_COVERAGE_DIR@

--- a/Makefile.am
+++ b/Makefile.am
@@ -30,12 +30,13 @@ ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = README.md
 
 # Compiler flags
-AM_CFLAGS = @STRICT_CFLAGS@
+AM_CFLAGS = @WARN_CFLAGS@
+AM_LDFLAGS = @WARN_LDFLAGS@
 
 # Enable strict compiler flags and install systemd unit files to the specified
 # directory when doing 'make distcheck'.
 AM_DISTCHECK_CONFIGURE_FLAGS = \
-	--enable-strict-flags \
+	--enable-compile-warnings=error \
 	--with-systemdsystemunitdir='$${prefix}/lib/systemd/system' \
 	$(NULL)
 if EOS_ENABLE_COVERAGE
@@ -95,7 +96,7 @@ EOS_COVERAGE_BLACKLIST_PATTERNS =	\
 @EOS_COVERAGE_RULES@
 
 AM_CFLAGS += @EOS_C_COVERAGE_CFLAGS@
-AM_LDFLAGS = @EOS_C_COVERAGE_LDFLAGS@
+AM_LDFLAGS += @EOS_C_COVERAGE_LDFLAGS@
 
 # # # DBUS DAEMON ("EVENT RECORDER SERVER") # # #
 

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,8 @@ AM_SILENT_RULES([yes])
 # Keep Autotools macros local to this source tree
 AC_CONFIG_MACRO_DIR([m4])
 
+AX_IS_RELEASE([git-directory])
+
 AC_CACHE_SAVE
 
 # Variables to define
@@ -93,43 +95,17 @@ AC_ARG_VAR([GDBUS_CODEGEN], [Path to gdbus-codegen])
 
 AC_CACHE_SAVE
 
+
 # Configure options
 # -----------------
-# --enable-strict-flags: Compile with strict compiler flags. Done automatically
-# during 'make distcheck'.
-AC_ARG_ENABLE([strict-flags],
-    [AS_HELP_STRING([--enable-strict-flags=@<:@no/yes/error@:>@],
-        [Use strict compiler flags @<:@default=no@:>@])],
-    [],
-    [enable_strict_flags=no])
-# Emmanuele's list of flags
-STRICT_COMPILER_FLAGS="$STRICT_COMPILER_FLAGS
-    -Wall
-    -Wcast-align
-    -Wuninitialized
-    -Wno-strict-aliasing
-    -Werror=pointer-arith
-    -Werror=missing-declarations
-    -Werror=redundant-decls
-    -Werror=empty-body
-    -Werror=format
-    -Werror=format-security
-    -Werror=format-nonliteral
-    -Werror=init-self"
-AS_CASE([$enable_strict_flags],
-    [yes],
-        [AS_COMPILER_FLAGS([STRICT_CFLAGS], [$STRICT_COMPILER_FLAGS])],
-    [no],
-        [],
-        [error],
-        [
-            STRICT_COMPILER_FLAGS="$STRICT_COMPILER_FLAGS -Werror"
-            AS_COMPILER_FLAGS([STRICT_CFLAGS], [$STRICT_COMPILER_FLAGS])
-        ],
-    [AC_MSG_ERROR([Invalid option for --enable-strict-flags])])
-dnl Strip leading spaces
-STRICT_CFLAGS=${STRICT_CFLAGS#*  }
-AC_SUBST(STRICT_CFLAGS)
+# --enable-compile-warnings. By default, warnings are enabled for all builds,
+# and fatal for builds from Git checkouts. Documentation:
+# https://www.gnu.org/software/autoconf-archive/ax_compiler_flags.html
+#
+# -Wno-declaration-after-statement:
+#   Mixed decls are used a lot and are harmless.
+AX_COMPILER_FLAGS([WARN_CFLAGS], [WARN_LDFLAGS], [], [],
+                  [-Wno-declaration-after-statement])
 
 systemdsystemunitdir="$($PKG_CONFIG systemd --variable=systemdsystemunitdir)"
 dnl Allow overriding systemdsystemunitdir during distcheck in order to trick

--- a/daemon/emer-cache-size-provider.c
+++ b/daemon/emer-cache-size-provider.c
@@ -48,8 +48,7 @@ guint64
 emer_cache_size_provider_get_max_cache_size (const gchar *path)
 {
   g_autoptr(GKeyFile) key_file = g_key_file_new ();
-  guint64 cache_size;
-  gboolean load_succeeded;
+  guint64 cache_size = 0;
   g_autoptr(GError) error = NULL;
 
   if (path == NULL)

--- a/daemon/emer-circular-file.c
+++ b/daemon/emer-circular-file.c
@@ -272,7 +272,7 @@ continue_reading_from_start (EmerCircularFile *self,
 
   GSeekable *seekable = G_SEEKABLE (input_stream);
   goffset curr_position = g_seekable_tell (seekable);
-  if (curr_position != priv->max_size)
+  if (curr_position < 0 || (guint64) curr_position != priv->max_size)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
                    "Circular file has a physical size of %" G_GOFFSET_FORMAT
@@ -567,7 +567,7 @@ emer_circular_file_initable_init (GInitable    *initable,
   if (local_error != NULL)
     goto handle_failed_read;
 
-  if (priv->head < 0 || priv->head >= prev_max_size)
+  if (priv->head < 0 || (guint64) priv->head >= prev_max_size)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "Pointer to "
                    "head of circular file must lie in range [0, %"

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -291,7 +291,7 @@ remove_events (EmerDaemon *self,
   if (num_events == 0)
     return;
 
-  for (gint i = 0; i < num_events; i++)
+  for (gsize i = 0; i < num_events; i++)
     {
       GVariant *curr_variant = g_ptr_array_index (priv->variant_array, i);
       priv->num_bytes_buffered -= emer_persistent_cache_cost (curr_variant);

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -206,8 +206,6 @@ sync_recorder_server_enabled_for_upload (GBinding     *binding,
                                          GValue       *to_value,
                                          gpointer      user_data)
 {
-  EmerEventRecorderServer *server =
-    EMER_EVENT_RECORDER_SERVER (g_binding_get_target (binding));
   EmerPermissionsProvider *permissions =
     EMER_PERMISSIONS_PROVIDER (g_binding_get_source (binding));
 
@@ -226,8 +224,6 @@ sync_recorder_server_enabled_for_daemon (GBinding     *binding,
                                          GValue       *to_value,
                                          gpointer      user_data)
 {
-  EmerEventRecorderServer *server =
-    EMER_EVENT_RECORDER_SERVER (g_binding_get_target (binding));
   EmerPermissionsProvider *permissions =
     EMER_PERMISSIONS_PROVIDER (g_binding_get_source (binding));
 

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -120,7 +120,6 @@ tests_daemon_test_persistent_cache_SOURCES = \
 	tests/daemon/test-persistent-cache.c \
 	daemon/emer-persistent-cache.c daemon/emer-persistent-cache.h \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
-	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
 	tests/daemon/mock-cache-version-provider.c \
 	daemon/emer-cache-version-provider.h \
 	tests/daemon/mock-circular-file.c tests/daemon/mock-circular-file.h \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -73,7 +73,7 @@ tests_daemon_test_daemon_dbusdaemon_SOURCES = \
 	daemon/emer-daemon.c daemon/emer-daemon.h \
 	tests/daemon/test-daemon.c \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
-	daemon/emer-cache-size-provider.c daemon/emer-cache-size-provider.h \
+	tests/daemon/mock-cache-size-provider.c daemon/emer-cache-size-provider.h \
 	daemon/emer-gzip.c daemon/emer-gzip.h \
 	tests/daemon/mock-machine-id-provider.c daemon/emer-machine-id-provider.h \
 	tests/daemon/mock-network-send-provider.c \

--- a/tests/daemon/mock-cache-size-provider.c
+++ b/tests/daemon/mock-cache-size-provider.c
@@ -1,0 +1,40 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2017 Endless Mobile, Inc. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "emer-cache-size-provider.h"
+
+/* This is the default maximum cache size in bytes. */
+#define DEFAULT_MAX_CACHE_SIZE G_GUINT64_CONSTANT (10000000)
+
+guint64
+emer_cache_size_provider_get_max_cache_size (const gchar *path)
+{
+  /* This mock should only be used by test-daemon.c when testing emer-daemon's
+   * logic to construct the persistent cache itself (as used in production). In
+   * that case, the daemon should attempt to load the cache size from the
+   * default path, which is expressed as NULL. Fail any test which accidentally
+   * attempts to use this mock to read a real file.
+   */
+  g_assert_cmpstr (path, ==, NULL);
+
+  return DEFAULT_MAX_CACHE_SIZE;
+}

--- a/tests/daemon/mock-circular-file.c
+++ b/tests/daemon/mock-circular-file.c
@@ -67,8 +67,6 @@ emer_circular_file_set_property (GObject      *object,
                                  GParamSpec   *pspec)
 {
   EmerCircularFile *self = EMER_CIRCULAR_FILE (object);
-  EmerCircularFilePrivate *priv =
-    emer_circular_file_get_instance_private (self);
 
   switch (property_id)
     {
@@ -257,7 +255,7 @@ mock_circular_file_set_construct_error (const GError *error)
 }
 
 gboolean
-mock_circular_file_got_reinitialize ()
+mock_circular_file_got_reinitialize (void)
 {
   return mock_circular_file_reinitialize;
 }

--- a/tests/daemon/mock-circular-file.c
+++ b/tests/daemon/mock-circular-file.c
@@ -20,7 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#include "emer-circular-file.h"
+#include "mock-circular-file.h"
 
 #include <string.h>
 

--- a/tests/daemon/mock-circular-file.h
+++ b/tests/daemon/mock-circular-file.h
@@ -1,0 +1,37 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2017 Endless Mobile, Inc. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MOCK_CIRCULAR_FILE_H
+#define MOCK_CIRCULAR_FILE_H
+
+#include <glib-object.h>
+
+#include "emer-circular-file.h"
+
+G_BEGIN_DECLS
+
+void                 mock_circular_file_set_construct_error     (const GError             *error);
+gboolean             mock_circular_file_got_reinitialize        (void);
+
+G_END_DECLS
+
+#endif /* MOCK_CIRCULAR_FILE_H */

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -97,7 +97,7 @@ emer_persistent_cache_new_full (const gchar              *directory,
                                 gboolean                  reinitialize_cache,
                                 GError                  **error)
 {
-  g_assert_not_reached ();
+  g_return_val_if_reached (NULL);
 }
 
 gsize

--- a/tests/daemon/test-cache-version-provider.c
+++ b/tests/daemon/test-cache-version-provider.c
@@ -46,8 +46,8 @@ typedef struct Fixture
 } Fixture;
 
 static void
-write_testing_cache_keyfile (Fixture *fixture,
-                             gchar   *key_file_data)
+write_testing_cache_keyfile (Fixture     *fixture,
+                             const gchar *key_file_data)
 {
   GError *error = NULL;
   g_key_file_load_from_data (fixture->key_file, key_file_data, -1,

--- a/tests/daemon/test-circular-file.c
+++ b/tests/daemon/test-circular-file.c
@@ -764,7 +764,7 @@ test_circular_file_broken_metadata_file (Fixture      *fixture,
                                           FALSE /* reinitialize */,
                                           &error);
   g_assert_null (circular_file);
-  g_assert_error (error, G_KEY_FILE_ERROR, expected_error_code);
+  g_assert_error (error, G_KEY_FILE_ERROR, (gint) expected_error_code);
   g_clear_error (&error);
 
   /* Re-initializing the file should work, though. */

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -441,7 +441,7 @@ assert_no_data_uploaded (EmerDaemon               *daemon,
 {
   GError *error = NULL;
   g_assert_false (emer_daemon_upload_events_finish (daemon, result, &error));
-  g_assert_error (error, EMER_ERROR, callback_data->error_code);
+  g_assert_error (error, EMER_ERROR, (gint) callback_data->error_code);
   g_error_free (error);
 
   GPollableInputStream *pollable_input_stream =

--- a/tests/daemon/test-machine-id-provider.c
+++ b/tests/daemon/test-machine-id-provider.c
@@ -45,7 +45,7 @@
 // Helper Functiobns
 
 static gboolean
-write_testing_machine_id ()
+write_testing_machine_id (void)
 {
   GFile *file = g_file_new_for_path (TESTING_FILE_PATH);
   gboolean success = g_file_replace_contents (file,

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -180,7 +180,7 @@ set_boot_offset_in_metadata_file (gint64 new_offset)
  * Overwrites the metadata file's boot id with the given boot id.
  */
 static void
-set_boot_id_in_metadata_file (gchar *boot_id)
+set_boot_id_in_metadata_file (const gchar *boot_id)
 {
   GKeyFile *boot_offset_key_file = load_boot_offset_key_file ();
 

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -28,7 +28,6 @@
 #include <eosmetrics/eosmetrics.h>
 
 #include "emer-boot-id-provider.h"
-#include "emer-cache-size-provider.h"
 #include "emer-cache-version-provider.h"
 #include "mock-circular-file.h"
 #include "shared/metrics-util.h"

--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -63,7 +63,7 @@ print_variants_to_file (GVariant   **variants,
     }
 
   GByteArray *byte_array = g_byte_array_new ();
-  for (gint i = 0; i < num_variants; i++)
+  for (gsize i = 0; i < num_variants; i++)
     {
       gchar *variant_str = g_variant_print (variants[i], TRUE);
       gsize variant_str_length = strlen (variant_str);


### PR DESCRIPTION
In #224 I forgot to commit one file, and introduced three test failures when running `make distcheck`. Mea culpa. While fixing these, I fixed an existing error when running `make distcheck` as non-root, enabled many more compiler warnings, and fixed them too.

https://phabricator.endlessm.com/T19953