### PR TITLE
T18983: Followup fixes

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1605,6 +1605,14 @@ emer_daemon_reset_tracking_id (EmerDaemon  *self,
 {
   EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
 
+  /* Clear all events in the persistent cache and in the memory buffers, we
+   * want to start from scratch here with a new machine ID. */
+  g_ptr_array_set_size (priv->variant_array, 0);
+  priv->num_bytes_buffered = 0;
+
+  if (!emer_persistent_cache_remove_all (priv->persistent_cache, error))
+    return FALSE;
+
   return emer_machine_id_provider_reset_tracking_id (priv->machine_id_provider, error);
 }
 

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -1513,6 +1513,28 @@ test_daemon_refresh_and_reload_machine_id (Fixture       *fixture,
   wait_for_upload_to_finish (fixture);
 }
 
+static void
+test_daemon_reload_machine_id_reset_events (Fixture       *fixture,
+                                            gconstpointer  unused)
+{
+  g_autoptr(GError) error = NULL;
+
+  g_assert_no_error (error);
+
+  /* Record a sequence. We will assert later that this did not get received. */
+  record_singulars (fixture->test_object);
+
+  /* Overwrite machine-id */
+  emer_daemon_reset_tracking_id (fixture->test_object, &error);
+  g_assert_no_error (error);
+
+  /* Read network requests, but assert that no events were received, since
+   * the persistent caches and memory buffers should have been emptied. */
+  read_network_request (fixture,
+                        (ProcessBytesSourceFunc) assert_no_events_received);
+  wait_for_upload_to_finish (fixture);
+}
+
 gint
 main (gint                argc,
       const gchar * const argv[])
@@ -1560,6 +1582,8 @@ main (gint                argc,
                    test_daemon_limits_network_upload_size);
   ADD_DAEMON_TEST ("/daemon/refresh-and-reload-machine-id",
                    test_daemon_refresh_and_reload_machine_id);
+  ADD_DAEMON_TEST ("/daemon/clear-events-on-reload-machine-id",
+                   test_daemon_reload_machine_id_reset_events);
 
 #undef ADD_DAEMON_TEST
 

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -1484,14 +1484,7 @@ static void
 test_daemon_refresh_and_reload_machine_id (Fixture       *fixture,
                                            gconstpointer  unused)
 {
-  g_autoptr(GFileIOStream) stream = NULL;
   g_autoptr(GError) error = NULL;
-  g_autoptr(GFile) override_machine_id_file =
-    g_file_new_tmp ("machine-id-override-XXXXXX",
-                    &stream,
-                    &error);
-  g_autofree gchar *override_machine_id_file_path =
-    g_file_get_path (override_machine_id_file);
   uuid_t initial_machine_id;
   uuid_t new_machine_id;
 

--- a/tests/daemon/test-machine-id-provider.c
+++ b/tests/daemon/test-machine-id-provider.c
@@ -22,6 +22,8 @@
 
 #include "emer-machine-id-provider.h"
 
+#include <string.h>
+
 #include <uuid/uuid.h>
 
 #include <gio/gio.h>
@@ -154,6 +156,28 @@ test_machine_id_provider_can_get_id_override (MachineIdTestFixture *fixture,
 }
 
 static void
+test_machine_id_provider_writes_correctly_formed_override_id (MachineIdTestFixture *fixture,
+                                                              gconstpointer         dontuseme)
+{
+  g_autoptr(EmerMachineIdProvider) id_provider =
+    emer_machine_id_provider_new_full (fixture->machine_id_file_path,
+                                       fixture->override_machine_id_file_path);
+  g_autoptr(GError) error = NULL;
+  g_autofree gchar *contents = NULL;
+
+  emer_machine_id_provider_reset_tracking_id (id_provider, &error);
+  g_assert_no_error (error);
+
+  /* Read the override_machine_id_file_path using g_file_get_contents
+   * and check that its size matches what we would normally write to the
+   * file */
+  g_file_get_contents (fixture->override_machine_id_file_path, &contents, NULL, &error);
+  g_assert_no_error (error);
+
+  g_assert_cmpint (strlen (contents), ==, strlen (TESTING_OVERRIDE_ID));
+}
+
+static void
 test_machine_id_provider_can_get_id_override_malformed (MachineIdTestFixture *fixture,
                                                         gconstpointer         dontuseme)
 {
@@ -186,6 +210,8 @@ main (gint                argc,
                        test_machine_id_provider_can_get_id);
   ADD_CACHE_TEST_FUNC ("/machine-id-provider/can-get-id-override",
                        test_machine_id_provider_can_get_id_override);
+  ADD_CACHE_TEST_FUNC ("/machine-id-provider/can-write-correctly-formed-override-id",
+                       test_machine_id_provider_writes_correctly_formed_override_id);
   ADD_CACHE_TEST_FUNC ("/machine-id-provider/can-get-id-override-malformed",
                        test_machine_id_provider_can_get_id_override_malformed);
 


### PR DESCRIPTION
Some follow-up fixes for https://phabricator.endlessm.com/T18983

The override machine ID was not being written out correctly, which means that it could not be parsed and loaded later by the metrics daemon. Also, we should clear out old metrics events associated with the old ID. We cannot guarantee that they will be uploaded, so just throw them away, for now.
  