### PR TITLE
daemon: Send events more aggressively and often

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -67,7 +67,7 @@
  * For QA, the "dev" environment delay is much shorter.
  */
 #define DEV_NETWORK_SEND_INTERVAL (60u * 15u) // Fifteen minutes
-#define PRODUCTION_NETWORK_SEND_INTERVAL (60u * 60u) // One hour
+#define PRODUCTION_NETWORK_SEND_INTERVAL (60u * 30u) // Thirty minutes
 
 #define DEFAULT_NETWORK_SEND_FILENAME "network_send_file"
 


### PR DESCRIPTION
Currently the metrics daemon only tries to send events to the server an
hour after starting up, and every hour after that. This is problematic
for some use cases such as schools in Colombia where they only use the
computers for a 45 minute class period, meaning events never get sent.
This commit changes the daemon to send events on startup and then every
half hour after that.

The daemon uses a GNetworkMonitor instance so even if the network
connection isn't ready immediately when the daemon starts, it should
wait for it to initialize before attempting an upload.

https://phabricator.endlessm.com/T21643