### PR TITLE
debian: Add VERBOSE=1 to get more output from test logs

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -17,7 +17,7 @@ override_dh_auto_configure:
 	dh_auto_configure -- --enable-strict-flags
 
 override_dh_auto_test:
-	dh_auto_test || ( find . -name '*.log' | xargs cat; false )
+	dh_auto_test VERBOSE=1 || ( find . -name '*.log' | xargs cat; false )
 
 # Avoid changing the owner of configuration files and the persistent cache
 # directory to root:root.


### PR DESCRIPTION
Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T26444