### PR TITLE
permissions-provider: Add environment property

### DIFF
--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -326,6 +326,8 @@ on_bus_acquired (GDBusConnection *system_bus,
                                G_BINDING_DEFAULT | G_BINDING_SYNC_CREATE,
                                sync_recorder_server_enabled_for_upload, NULL,
                                daemon, NULL);
+  g_object_bind_property (permissions, "environment", server, "environment",
+                          G_BINDING_DEFAULT | G_BINDING_SYNC_CREATE);
 
   GError *error = NULL;
   if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (server),

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -65,6 +65,7 @@ enum
   PROP_OSTREE_CONFIG_FILE_PATH,
   PROP_DAEMON_ENABLED,
   PROP_UPLOADING_ENABLED,
+  PROP_ENVIRONMENT,
   NPROPS
 };
 
@@ -322,6 +323,10 @@ set_environment (EmerPermissionsProvider *self,
   g_key_file_set_string (priv->permissions, DAEMON_GLOBAL_GROUP_NAME,
                          DAEMON_ENVIRONMENT_KEY_NAME, environment);
 
+  GParamSpec *environment_pspec =
+    emer_permissions_provider_props[PROP_ENVIRONMENT];
+  g_object_notify_by_pspec (G_OBJECT (self), environment_pspec);
+
   schedule_config_file_update (self);
 }
 
@@ -374,6 +379,11 @@ emer_permissions_provider_get_property (GObject    *object,
     case PROP_DAEMON_ENABLED:
       g_value_set_boolean (value,
                            emer_permissions_provider_get_daemon_enabled (self));
+      break;
+
+    case PROP_ENVIRONMENT:
+      g_value_set_string (value,
+                          emer_permissions_provider_get_environment (self));
       break;
 
     case PROP_UPLOADING_ENABLED:
@@ -458,6 +468,11 @@ emer_permissions_provider_class_init (EmerPermissionsProviderClass *klass)
                           "Whether to enable the metrics daemon system-wide",
                           FALSE,
                           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+  emer_permissions_provider_props[PROP_ENVIRONMENT] =
+    g_param_spec_string ("environment", "Environment",
+                         "The metrics environment",
+                         NULL,
+                         G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
   emer_permissions_provider_props[PROP_UPLOADING_ENABLED] =
     g_param_spec_boolean ("uploading-enabled", "Uploading enabled",
                           "Whether to upload events via the network",


### PR DESCRIPTION
Exports the environment as a DBUS property, to be able to differentiate
between development and production images inside flatpak apps.

https://phabricator.endlessm.com/T26548

This PR needs this one to be merged before: https://github.com/endlessm/eos-metrics/pull/40