### PR TITLE
policy: Add action for eos-write-location

### DIFF
--- a/data/com.endlessm.Metrics.policy
+++ b/data/com.endlessm.Metrics.policy
@@ -48,4 +48,15 @@
     </defaults>
   </action>
 
+  <action id="com.endlessm.Metrics.WriteLocation">
+    <description>Write file describing Solutions deployment location</description>
+    <message>Authentication is required to set up metrics</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/lib/gnome-initial-setup/eos-write-location</annotate>
+  </action>
+
 </policyconfig>


### PR DESCRIPTION
This allows eos-write-location to be run without prompting for admin
access. eos-write-location is a downstream script that is part of
gnome-initial-setup, which is used to save information about the Endless
Solutions deployment that a machine belongs to.

https://phabricator.endlessm.com/T27710