### PR TITLE
T29300 Fix polkit auth prompts

### DIFF
--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -219,13 +219,18 @@ on_authorize_method_check (GDBusInterfaceSkeleton *interface,
 
   const gchar *sender_name = g_dbus_method_invocation_get_sender (invocation);
   PolkitSubject *subject = polkit_system_bus_name_new (sender_name);
+  PolkitCheckAuthorizationFlags flags = POLKIT_CHECK_AUTHORIZATION_FLAGS_NONE;
+  GDBusMessage *message = g_dbus_method_invocation_get_message (invocation);
+
+  if (g_dbus_message_get_flags (message) & G_DBUS_MESSAGE_FLAGS_ALLOW_INTERACTIVE_AUTHORIZATION)
+    flags |= POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION;
 
   PolkitAuthorizationResult *result =
     polkit_authority_check_authorization_sync (authority,
                                                subject,
                                                authorized_method->method_full_name,
                                                NULL /*PolkitDetails*/,
-                                               POLKIT_CHECK_AUTHORIZATION_FLAGS_NONE,
+                                               flags,
                                                NULL /*GCancellable*/,
                                                &error);
   g_object_unref (authority);

--- a/data/com.endlessm.Metrics.policy
+++ b/data/com.endlessm.Metrics.policy
@@ -42,9 +42,9 @@
     <description>Reset the tracking ID used by the metrics system</description>
     <annotate key="org.freedesktop.policykit.owner">unix-user:metrics unix-group:metrics</annotate>
     <defaults>
-      <allow_any>no</allow_any>
-      <allow_inactive>no</allow_inactive>
-      <allow_active>no</allow_active>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
     </defaults>
   </action>
 


### PR DESCRIPTION
**This is untested** because I can’t get e-e-r-d to build using `deb-build-snapshot`. Perhaps something to do with its use of autotools and a deprecated dh-compat level (8). I did not have any more time to dig.

This should be a fairly low risk change, easy to review, and easy to QA once it’s been built by OBS.

https://phabricator.endlessm.com/T29300