### PR TITLE
daemon: Add tracking-id-file-path as argument

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1596,11 +1596,13 @@ emer_daemon_init (EmerDaemon *self)
  */
 EmerDaemon *
 emer_daemon_new (const gchar             *persistent_cache_directory,
-                 EmerPermissionsProvider *permissions_provider)
+                 EmerPermissionsProvider *permissions_provider,
+                 EmerMachineIdProvider   *machine_id_provider)
 {
   return g_object_new (EMER_TYPE_DAEMON,
                        "persistent-cache-directory", persistent_cache_directory,
                        "permissions-provider", permissions_provider,
+                       "machine-id-provider", machine_id_provider,
                        NULL);
 }
 

--- a/daemon/emer-daemon.h
+++ b/daemon/emer-daemon.h
@@ -73,7 +73,8 @@ struct _EmerDaemonClass
 GType                    emer_daemon_get_type                 (void) G_GNUC_CONST;
 
 EmerDaemon *             emer_daemon_new                      (const gchar             *persistent_cache_directory,
-                                                               EmerPermissionsProvider *permissions_provider);
+                                                               EmerPermissionsProvider *permissions_provider,
+                                                               EmerMachineIdProvider *machine_id_provider);
 
 EmerDaemon *             emer_daemon_new_full                 (GRand                   *rand,
                                                                const gchar             *server_uri,

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -172,9 +172,10 @@ emer_machine_id_provider_init (EmerMachineIdProvider *self)
  * @tracking_id_path: A location for an tracking id path,
  *                    see #EmerMachineIdProvider:tracking-id-path
  *
- * Testing function for creating a new #EmerMachineIdProvider in the C API.
- * You only need to use this if you are creating a mock ID provider for unit
- * testing.
+ * For special cases which intends to upload metrics data other than the
+ * host machine, or if you are creating a mock ID provider for unit
+ * testing, use this to create the machine ID provider based on the
+ * spcified ID path.
  *
  * For all normal uses, you should use emer_machine_id_provider_new()
  * instead.

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -378,6 +378,8 @@ make_daemon (gint                argc,
   g_autofree gchar *persistent_cache_directory = NULL;
   const gchar *persistent_cache_directory_const = PERSISTENT_CACHE_DIR;
   g_autofree gchar *config_file_path = NULL;
+  g_autoptr(EmerMachineIdProvider) machine_id_prov = NULL;
+  g_autofree gchar *tracking_id_file_path = NULL;
   g_autoptr(EmerPermissionsProvider) permissions_provider = NULL;
   GOptionEntry option_entries[] =
   {
@@ -387,6 +389,9 @@ make_daemon (gint                argc,
     { "config-file-path", 'c', G_OPTION_FLAG_NONE,
       G_OPTION_ARG_FILENAME, &config_file_path,
       "Path to permissions config file", "path"},
+    { "tracking-id-file-path", 't', G_OPTION_FLAG_NONE,
+      G_OPTION_ARG_FILENAME, &tracking_id_file_path,
+      "Path to tracking ID of the machine", "path"},
     { NULL }
   };
 
@@ -414,8 +419,13 @@ make_daemon (gint                argc,
     permissions_provider =
       emer_permissions_provider_new_full (config_file_path, NULL);
 
+  if (tracking_id_file_path != NULL)
+    machine_id_prov =
+      emer_machine_id_provider_new_full(tracking_id_file_path);
+
   return emer_daemon_new (persistent_cache_directory_const,
-                          permissions_provider);
+                          permissions_provider,
+                          machine_id_prov);
 }
 
 gint

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -1014,7 +1014,8 @@ test_daemon_new_succeeds (Fixture      *fixture,
                           gconstpointer unused)
 {
   EmerDaemon *daemon = emer_daemon_new (NULL /* persistent cache directory */,
-                                        NULL /* permissions provider */);
+                                        NULL /* permissions provider */,
+                                        NULL /* machine id provider */);
   g_assert_nonnull (daemon);
   g_object_unref (daemon);
 }


### PR DESCRIPTION
The eos-event-recorder-daemon can specify the tracking-id file path for each collected metrics data.

https://phabricator.endlessm.com/T30475