### PR TITLE
daemon: Fix payload for CACHE_HAS_INVALID_ELEMENTS

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -782,7 +782,7 @@ add_stored_events_to_builders (EmerDaemon        *self,
 
   if (has_invalid)
     {
-      GVariant *payload = g_variant_new ("(tt)", num_variants, token);
+      GVariant *payload = g_variant_new ("(tt)", num_variants, *token);
 
       g_warning ("Invalid data found in the persistent cache: "
                  "%" G_GSIZE_FORMAT " valid records read (%" G_GUINT64_FORMAT " bytes read)",

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -782,7 +782,7 @@ add_stored_events_to_builders (EmerDaemon        *self,
 
   if (has_invalid)
     {
-      GVariant *payload = g_variant_new ("(tt)", num_variants, *token);
+      GVariant *payload = g_variant_new ("(tt)", (guint64) num_variants, *token);
 
       g_warning ("Invalid data found in the persistent cache: "
                  "%" G_GSIZE_FORMAT " valid records read (%" G_GUINT64_FORMAT " bytes read)",


### PR DESCRIPTION
@liZe spotted that we're currently recording the integer value
of the pointer to the token, rather than the token.

https://github.com/endlessm/azafea/pull/121#issuecomment-663129998

I also noticed that on 32-bit systems the first parameter will be 32 bits wide, but g_variant_new() will expect it to be 64 bits wide.

Untested.