### PR TITLE
tools: add eos-metrics-collector for offline metrics collect/upload

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,7 +64,7 @@ noinst_PROGRAMS +=
 noinst_LTLIBRARIES +=
 
 # Binaries that should be installed in libexecdir
-libexec_PROGRAMS = 
+libexec_PROGRAMS =
 
 substitute_libexecdir = sed \
 	-e 's|@libexecdir[@]|$(libexecdir)|g' \
@@ -72,25 +72,25 @@ substitute_libexecdir = sed \
 
 # dbus services
 dbusservicedir = ${datadir}/dbus-1/system-services
-dist_dbusservice_DATA = 
+dist_dbusservice_DATA =
 
 # dbus security policy
 systembussecuritypolicydir = ${sysconfdir}/dbus-1/system.d
-dist_systembussecuritypolicy_DATA = 
+dist_systembussecuritypolicy_DATA =
 
 # policykit
 policydir = ${datadir}/polkit-1/actions
-dist_policy_DATA = 
+dist_policy_DATA =
 
 policyrulesdir = $(datadir)/polkit-1/rules.d
-dist_policyrules_DATA = 
+dist_policyrules_DATA =
 
 persistentcachedir=$(localstatedir)/cache/metrics/
 configdir=$(sysconfdir)/metrics/
 permissions_file=$(configdir)eos-metrics-permissions.conf
 
 # systemd
-systemdsystemunit_DATA = 
+systemdsystemunit_DATA =
 
 # chown and chgrp are not allowed unless you are root or under some specific
 # other conditions that may not be met every time you run 'make'.

--- a/tools/Makefile.am.inc
+++ b/tools/Makefile.am.inc
@@ -44,6 +44,8 @@ tools_print_persistent_cache_SOURCES = \
 tools_print_persistent_cache_CPPFLAGS = $(PERSISTENT_CACHE_TOOL_FLAGS)
 tools_print_persistent_cache_LDADD = $(PERSISTENT_CACHE_TOOL_LIBS)
 
+dist_libexec_SCRIPTS = tools/eos-metrics-collector.exe
+
 dist_bin_SCRIPTS = \
 	tools/eos-enable-metrics-uploading \
 	tools/eos-select-metrics-env \

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -149,11 +149,14 @@ class OfflineMetricsCollector(OfflineMetrics):
         self.target_dir = os.path.join(target_dir, f.read(32))
         f.close()
 
-        if not os.path.exists(self.target_dir):
-            os.mkdir(self.target_dir)
-        else:
-            subprocess.check_output(['rm', '-rf', self.target_dir])
-            os.mkdir(self.target_dir)
+        if os.path.exists(self.target_dir):
+            msg = (
+                f"Looks like metrics data for this machine exists in the "
+                f"target storage device. Please use a different target device "
+                f"or manually remove {self.target_dir}. Aborting."
+            )
+            sys.exit(msg)
+        os.mkdir(self.target_dir)
 
     def copy_metrics_data(self):
         # we can't use shutil.copy here to copy all files in one call because

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -176,9 +176,8 @@ class OfflineMetricsCollector(OfflineMetrics):
 
     def reset_metrics_data(self):
         files = ['variants.dat', 'variants.dat.metadata']
-        for file in files:
-            target_file = os.path.join(self.metrics_cache_dir, file)
-            subprocess.check_output(['sudo', 'rm', '-f', target_file])
+        for f in files:
+            os.remove(os.path.join(self.metrics_cache_dir, f))
 
     def collect_metrics(self):
         unit_was_running = self.metrics_unit('is-active')

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -71,6 +71,9 @@ class OfflineMetrics():
 class OfflineMetricsUploader(OfflineMetrics):
     def __init__(self, storage_root):
         super().__init__(storage_root)
+        self.bin_dir = "/usr/lib/eos-event-recorder-daemon"
+        self.bin_name = "eos-metrics-event-recorder"
+        self.bin_path = os.path.join(self.bin_dir, self.bin_name)
         self.tmpdir = ''
 
     def copy_metrics_data_and_upload(self):
@@ -84,15 +87,25 @@ class OfflineMetricsUploader(OfflineMetrics):
         self.unit_was_running = self.metrics_unit('is-active')
         self.metrics_unit('stop')
 
+        self.tmpdir = tempfile.mkdtemp()
+        shutil.chown(self.tmpdir, user='metrics', group='metrics')
+
         for tracking_id in os.listdir(self.storage_dir):
-            self.tmpdir = tempfile.mkdtemp()
-            machine_dir = os.path.join(self.storage_dir, tracking_id)
-            for f in os.listdir(machine_dir):
-                shutil.copy(os.path.join(machine_dir, f), self.tmpdir)
-            subprocess.check_output(['sudo', 'chown', '-R', 'metrics:metrics', self.tmpdir])
-            persistent_cache_dir_arg = '--persistent-cache-directory=' + self.tmpdir
-            tracking_id_path_arg = '--tracking-id-file-path=' + self.tmpdir + '/tracking-id'
-            self.daemon = subprocess.Popen(['sudo', '-u', 'metrics', '/lib/eos-event-recorder-daemon/eos-metrics-event-recorder', persistent_cache_dir_arg, tracking_id_path_arg], stderr=subprocess.DEVNULL)
+            machine_srcdir = os.path.join(self.storage_dir, tracking_id)
+            machine_dstdir = os.path.join(self.tmpdir, tracking_id)
+
+            os.mkdir(machine_dstdir)
+            shutil.chown(machine_dstdir, user='metrics', group='metrics')
+            for f in os.listdir(machine_srcdir):
+                src = os.path.join(machine_srcdir, f)
+                dst = os.path.join(machine_dstdir, f)
+                shutil.copyfile(src, dst)
+                shutil.chown(dst, user='metrics', group='metrics')
+
+            dir_arg = f"--persistent-cache-directory={machine_dstdir}"
+            id_arg = f"--tracking-id-file-path={machine_dstdir}/tracking-id"
+            daemon = subprocess.Popen(
+                ['sudo', '-u', 'metrics', self.bin_path, dir_arg, id_arg])
 
             timeout = 0
             while timeout < 5:
@@ -111,8 +124,8 @@ class OfflineMetricsUploader(OfflineMetrics):
             else:
                 print("Upload successfully for tracking id " + tracking_id)
 
-            subprocess.check_output(['sudo', 'killall', '/lib/eos-event-recorder-daemon/eos-metrics-event-recorder'])
-            subprocess.check_output(['sudo', 'rm', '-rf', self.tmpdir])
+            daemon.terminate()
+            shutil.rmtree(machine_dstdir)
 
     def __del__(self):
         '''

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -155,22 +155,21 @@ class OfflineMetricsCollector(OfflineMetrics):
             subprocess.check_output(['rm', '-rf', self.target_dir])
             os.mkdir(self.target_dir)
 
-    def copy_tracking_id(self):
+    def copy_metrics_data(self):
         # we can't use shutil.copy here to copy all files in one call because
         # it tries to maintain files' mode, and some files have the sticky bit
         # set, which is not supported by FAT32
+        files = [
+            'boot_offset_metafile', 'local_version_file', 'network_send_file',
+            'variants.dat', 'variants.dat.metadata'
+        ]
+        for f in files:
+            src = os.path.join(self.metrics_cache_dir, f)
+            dst = os.path.join(self.target_dir, f)
+            if os.path.exists(src):
+                shutil.copyfile(src, dst)
         shutil.copyfile(self.metrics_id,
-            os.path.join(self.target_dir, 'tracking-id'))
-
-    def copy_metrics_data(self):
-        # Check whether the network_send_file exists or not
-        if os.path.exists(os.path.join(self.metrics_cache_dir, 'network_send_file')):
-            shutil.copyfile(os.path.join(self.metrics_cache_dir, 'network_send_file'), os.path.join(self.target_dir, 'network_send_file'))
-
-        # Copy mandatory files
-        files = ['boot_offset_metafile', 'local_version_file', 'variants.dat', 'variants.dat.metadata']
-        for file in files:
-            shutil.copyfile(os.path.join(self.metrics_cache_dir, file), os.path.join(self.target_dir, os.path.basename(file)))
+                        os.path.join(self.target_dir, 'tracking-id'))
 
     def reset_metrics_data(self):
         files = ['variants.dat', 'variants.dat.metadata']
@@ -182,7 +181,6 @@ class OfflineMetricsCollector(OfflineMetrics):
         unit_was_running = self.metrics_unit('is-active')
         self.metrics_unit('stop')
         self.create_folder_for_machine()
-        self.copy_tracking_id()
         self.copy_metrics_data()
         self.reset_metrics_data()
         if unit_was_running:

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -36,7 +36,6 @@ class OfflineMetrics():
         self.metrics_config_file = '/etc/metrics/eos-metrics-permissions.conf'
         self.metrics_proc_name = 'eos-metrics-event-recorder'
 
-
     def metrics_proc_exists(self):
         ps = subprocess.Popen("ps ax -o pid= -o args= ", shell=True, stdout=subprocess.PIPE)
         ps_pid = ps.pid
@@ -70,7 +69,7 @@ class OfflineMetricsUploader(OfflineMetrics):
             subprocess.check_output(['/usr/bin/systemctl', 'stop', self.systemd_service])
         srcdir = os.path.join(self.offline_metrics_usbdisk_node, self.offline_metrics_src_dir)
         if not os.path.exists(srcdir):
-            print ('No metrics data in the eos-metrics-data directory')
+            print('No metrics data in the eos-metrics-data directory')
             sys.exit()
         for machine_dir in os.listdir(srcdir):
             self.offline_tmp_metrics_dir = tempfile.mkdtemp()
@@ -92,7 +91,7 @@ class OfflineMetricsUploader(OfflineMetrics):
                 print('Fail to launch eos-metrics-event-recorder')
                 sys.exit()
 
-            upload=subprocess.run(['/usr/bin/eos-upload-metrics'], stdout=subprocess.DEVNULL)
+            upload = subprocess.run(['/usr/bin/eos-upload-metrics'], stdout=subprocess.DEVNULL)
             if (upload.returncode != 0):
                 print('Upload Fail.')
                 sys.exit()
@@ -232,10 +231,10 @@ def main():
                 'machine will be copied to eos-metrics-data directory'
                 'of the removable storage while doing collect. All collected'
                 'data can uploaded to Metrics Server by doing upload'
-                ) 
+                )
     parser.add_argument('action', metavar='ACTION', type=str,
                         help='collect or upload')
-    args=parser.parse_args()
+    args = parser.parse_args()
 
     if args.action == "collect":
         collect(location)
@@ -247,4 +246,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -37,6 +37,10 @@ class OfflineMetrics():
         self.metrics_proc_name = 'eos-metrics-event-recorder'
         self.storage_root = storage_root
         self.storage_metrics_dir = 'eos-metrics-data'
+        if os.path.exists(self.tracking_id_path):
+            self.metrics_id = self.tracking_id_path
+        else:
+            self.metrics_id = self.machine_id_path
 
     def metrics_proc_exists(self):
         ps = subprocess.Popen("ps ax -o pid= -o args= ", shell=True, stdout=subprocess.PIPE)
@@ -141,33 +145,22 @@ class OfflineMetricsCollector(OfflineMetrics):
         if not os.path.exists(target_dir):
             os.mkdir(target_dir)
 
-        if os.path.exists(self.tracking_id_path):
-            f = open(self.tracking_id_path)
-        elif os.path.exists(self.machine_id_path):
-            f = open(self.machine_id_path)
-        else:
-            print('No tracking/machine id file found')
-            sys.exit()
-
+        f = open(self.metrics_id)
         self.target_dir = os.path.join(target_dir, f.read(32))
+        f.close()
+
         if not os.path.exists(self.target_dir):
             os.mkdir(self.target_dir)
         else:
             subprocess.check_output(['rm', '-rf', self.target_dir])
             os.mkdir(self.target_dir)
-        f.close()
 
     def copy_tracking_id(self):
-        if os.path.exists(self.tracking_id_path):
-            # The tracking id file has permission -rwxrwsr-x  which
-            # will raise PermissionError for shutil.copy, use copyfile
-            # instead
-            shutil.copyfile(self.tracking_id_path, os.path.join(self.target_dir, os.path.basename(self.tracking_id_path)))
-        elif os.path.exists(self.machine_id_path):
-            shutil.copyfile(self.machine_id_path, os.path.join(self.target_dir, os.path.basename(self.tracking_id_path)))
-        else:
-            print('No tracking/machine id file found')
-            sys.exit()
+        # we can't use shutil.copy here to copy all files in one call because
+        # it tries to maintain files' mode, and some files have the sticky bit
+        # set, which is not supported by FAT32
+        shutil.copyfile(self.metrics_id,
+            os.path.join(self.target_dir, 'tracking-id'))
 
     def copy_metrics_data(self):
         # Check whether the network_send_file exists or not

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -197,6 +197,32 @@ class OfflineMetricsCollector(OfflineMetrics):
         return size
 
 
+def collect(location):
+    collector = OfflineMetricsCollector(location)
+    if collector.get_usbdisk_free_space() > collector.evaluate_metrics_data_size():
+        collector.collect_metrics()
+        print("Metrics Collect Done")
+    else:
+        print("Insufficient free space for metrics data")
+
+
+def upload(location):
+    eos_version = get_eos_version()
+    if eos_version is None:
+        sys.exit("This program only works on Endless OS, exiting.")
+    if StrictVersion(eos_version) < StrictVersion("3.9.0"):
+        msg = (
+            f"Uploading metrics collected from other machines requires "
+            f"EOS >= 3.9.0, and {eos_version} was detected, exiting."
+        )
+        sys.exit(msg)
+
+    uploader = OfflineMetricsUploader(location)
+    uploader.copy_metrics_data_and_upload()
+    print("All metrics data been successfully uploaded")
+    shutil.rmtree(os.path.join(location, uploader.offline_metrics_src_dir))
+
+
 def main():
     location = os.path.dirname(os.path.realpath(sys.argv[0]))
     parser = argparse.ArgumentParser(
@@ -212,28 +238,9 @@ def main():
     args=parser.parse_args()
 
     if args.action == "collect":
-        print('collect')
-        collector = OfflineMetricsCollector(location)
-        if collector.get_usbdisk_free_space() > collector.evaluate_metrics_data_size():
-            collector.collect_metrics()
-            print("Metrics Collect Done")
-        else:
-            print("Insufficient free space for metrics data")
+        collect(location)
     elif args.action == "upload":
-        eos_version = get_eos_version()
-        if eos_version is None:
-            sys.exit("This program only works on Endless OS, exiting.")
-        if StrictVersion(eos_version) < StrictVersion("3.9.0"):
-            msg = (
-                f"Uploading metrics collected from other machines requires "
-                f"EOS >= 3.9.0, and {eos_version} was detected, exiting."
-            )
-            sys.exit(msg)
-
-        uploader = OfflineMetricsUploader(location)
-        uploader.copy_metrics_data_and_upload()
-        print("All metrics data been successfully uploaded")
-        shutil.rmtree(os.path.join(location, uploader.offline_metrics_src_dir))
+        upload(location)
     else:
         print('Invalid action ' + args.action)
 

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -1,0 +1,230 @@
+#!/usr/bin/python3
+
+import sys
+import os
+import subprocess
+import shutil
+import time
+import tempfile
+import errno
+import re
+import argparse
+from distutils.version import StrictVersion
+
+
+class OfflineMetrics():
+    def __init__(self):
+        self.metrics_cache_dir = '/var/cache/metrics'
+        self.tracking_id_path = '/etc/metrics/tracking-id'
+        self.machine_id_path = '/etc/machine-id'
+        self.systemd_service = 'eos-metrics-event-recorder.service'
+        self.metrics_config_file = '/etc/metrics/eos-metrics-permissions.conf'
+        self.metrics_proc_name = 'eos-metrics-event-recorder'
+        self.eos_version = None
+
+    def get_eos_version(self):
+        f = open("/etc/os-release")
+        for line in f.readlines():
+            if line.startswith("VERSION="):
+                fdot = line.find('=')
+                major = line[fdot+2:-2]
+                self.eos_version = major
+                return str(major)
+
+    def metrics_proc_exists(self):
+        ps = subprocess.Popen("ps ax -o pid= -o args= ", shell=True, stdout=subprocess.PIPE)
+        ps_pid = ps.pid
+        output = ps.stdout.read()
+        ps.stdout.close()
+        ps.wait()
+
+        for line in str(output).split('\n'):
+            res = re.findall("(\d+) (.*)", line)
+            if res:
+                pid = int(res[0][0])
+                if self.metrics_proc_name in res[0][1] and pid != os.getpid() and pid != ps_pid:
+                    return True
+        return False
+
+    def is_metrics_service_active(self):
+        status = os.system('systemctl is-active --quiet ' + self.systemd_service)
+        return (status == 0)
+
+
+class OfflineMetricsUploader(OfflineMetrics):
+
+    def __init__(self, storage_path=None):
+        super().__init__()
+        self.offline_metrics_usbdisk_node = storage_path
+        self.offline_metrics_src_dir = 'eos-metrics-data'
+        self.offline_tmp_metrics_dir = ''
+
+    def copy_metrics_data_and_upload(self):
+        if (self.is_metrics_service_active()):
+            subprocess.check_output(['/usr/bin/systemctl', 'stop', self.systemd_service])
+        srcdir = os.path.join(self.offline_metrics_usbdisk_node, self.offline_metrics_src_dir)
+        if not os.path.exists(srcdir):
+            print ('No metrics data in the eos-metrics-data directory')
+            sys.exit()
+        for machine_dir in os.listdir(srcdir):
+            self.offline_tmp_metrics_dir = tempfile.mkdtemp()
+            machine_path = os.path.join(srcdir, machine_dir)
+            for file in os.listdir(machine_path):
+                shutil.copy(os.path.join(machine_path, file), self.offline_tmp_metrics_dir)
+            subprocess.check_output(['sudo', 'chown', '-R', 'metrics:metrics', self.offline_tmp_metrics_dir])
+            persistent_cache_dir_arg = '--persistent-cache-directory=' + self.offline_tmp_metrics_dir
+            tracking_id_path_arg = '--tracking-id-file-path=' + self.offline_tmp_metrics_dir + '/tracking-id'
+            self.daemon = subprocess.Popen(['sudo', '-u', 'metrics', '/lib/eos-event-recorder-daemon/eos-metrics-event-recorder', persistent_cache_dir_arg, tracking_id_path_arg], stderr=subprocess.DEVNULL)
+
+            timeout = 0
+            while timeout < 5:
+                time.sleep(1)
+                if self.metrics_proc_exists():
+                    break
+                timeout = timeout + 1
+            if timeout >= 5:
+                print('Fail to launch eos-metrics-event-recorder')
+                sys.exit()
+
+            upload=subprocess.run(['/usr/bin/eos-upload-metrics'], stdout=subprocess.DEVNULL)
+            if (upload.returncode != 0):
+                print('Upload Fail.')
+                sys.exit()
+            else:
+                print("Upload successfully for tracking id " + machine_dir)
+
+            subprocess.check_output(['sudo', 'killall', '/lib/eos-event-recorder-daemon/eos-metrics-event-recorder'])
+            subprocess.check_output(['sudo', 'rm', '-rf', self.offline_tmp_metrics_dir])
+
+    def __del__(self):
+        '''
+        Remove temporary cache data, kill the eos-metrics-event-recorder.
+        And restart the service
+        '''
+        if os.path.exists(self.offline_tmp_metrics_dir):
+            subprocess.check_output(['sudo', 'rm', '-rf', self.offline_tmp_metrics_dir])
+        if self.metrics_proc_exists():
+            subprocess.check_output(['sudo', 'killall', '/lib/eos-event-recorder-daemon/eos-metrics-event-recorder'])
+        if (not self.is_metrics_service_active()):
+            subprocess.check_output(['/usr/bin/systemctl', 'start', self.systemd_service])
+
+
+class OfflineMetricsCollector(OfflineMetrics):
+
+    def __init__(self, storage_path=None):
+        super().__init__()
+        self.offline_metrics_usbdisk_node = storage_path
+        self.offline_metrics_dst_dir = 'eos-metrics-data'
+        self.disk_free_space_in_bytes = 0
+        self.offline_machine_data_dir = None
+
+    def get_usbdisk_free_space(self):
+        disk_usage = shutil.disk_usage(self.offline_metrics_usbdisk_node)
+        self.disk_free_space_in_bytes = disk_usage.free
+        return disk_usage.free
+
+    def create_folder_for_machine(self):
+        target_dir = os.path.join(self.offline_metrics_usbdisk_node, self.offline_metrics_dst_dir)
+        if os.path.exists(target_dir) is False:
+            os.mkdir(target_dir)
+
+        if os.path.exists(self.tracking_id_path) is True:
+            f = open(self.tracking_id_path)
+        elif os.path.exists(self.machine_id_path) is True:
+            f = open(self.machine_id_path)
+        else:
+            print('No tracking/machine id file found')
+            sys.exit()
+
+        self.offline_machine_data_dir = os.path.join(target_dir, f.read(32))
+        if os.path.exists(self.offline_machine_data_dir) is False:
+            os.mkdir(self.offline_machine_data_dir)
+        else:
+            subprocess.check_output(['rm', '-rf', self.offline_machine_data_dir])
+            os.mkdir(self.offline_machine_data_dir)
+        f.close()
+
+    def copy_tracking_id(self):
+        if os.path.exists(self.tracking_id_path) is True:
+            # The tracking id file has permission -rwxrwsr-x  which
+            # will raise PermissionError for shutil.copy, use copyfile
+            # instead
+            shutil.copyfile(self.tracking_id_path, os.path.join(self.offline_machine_data_dir, os.path.basename(self.tracking_id_path)))
+        elif os.path.exists(self.machine_id_path) is True:
+            shutil.copyfile(self.machine_id_path, os.path.join(self.offline_machine_data_dir, os.path.basename(self.tracking_id_path)))
+        else:
+            print('No tracking/machine id file found')
+            sys.exit()
+
+    def copy_metrics_data(self):
+        # Check whether the network_send_file exists or not
+        if os.path.exists(os.path.join(self.metrics_cache_dir, 'network_send_file')) is True:
+            shutil.copyfile(os.path.join(self.metrics_cache_dir, 'network_send_file'), os.path.join(self.offline_machine_data_dir, 'network_send_file'))
+
+        # Copy mandatory files
+        files = ['boot_offset_metafile', 'local_version_file', 'variants.dat', 'variants.dat.metadata']
+        for file in files:
+            shutil.copyfile(os.path.join(self.metrics_cache_dir, file), os.path.join(self.offline_machine_data_dir, os.path.basename(file)))
+
+    def reset_metrics_data(self):
+        files = ['variants.dat', 'variants.dat.metadata']
+        for file in files:
+            target_file = os.path.join(self.metrics_cache_dir, file)
+            subprocess.check_output(['sudo', 'rm', '-f', target_file])
+
+    def collect_metrics(self):
+        if (self.is_metrics_service_active()):
+            subprocess.check_output(['/usr/bin/systemctl', 'stop', self.systemd_service])
+        self.create_folder_for_machine()
+        self.copy_tracking_id()
+        self.copy_metrics_data()
+        self.reset_metrics_data()
+        subprocess.check_output(['/usr/bin/systemctl', 'start', self.systemd_service])
+
+    def evaluate_metrics_data_size(self):
+        size = 0
+        size += os.path.getsize(self.metrics_cache_dir)
+        if os.path.exists(self.tracking_id_path):
+            size += os.path.getsize(self.tracking_id_path)
+        if os.path.exists(self.machine_id_path):
+            size += os.path.getsize(self.machine_id_path)
+        return size
+
+
+def main():
+    location = os.path.dirname(os.path.realpath(sys.argv[0]))
+    parser = argparse.ArgumentParser(
+    description='Offline Metrics Collector. There are 2 actions, collect'
+                'and upload. The program is expected to be located in'
+                'a removable storage. The metrics data of the target'
+                'machine will be copied to eos-metrics-data directory'
+                'of the removable storage while doing collect. All collected'
+                'data can uploaded to Metrics Server by doing upload'
+                ) 
+    parser.add_argument('action', metavar='ACTION', type=str,
+                        help='collect or upload')
+    args=parser.parse_args()
+
+    if args.action == "collect":
+        print('collect')
+        collector = OfflineMetricsCollector(location)
+        if collector.get_usbdisk_free_space() > collector.evaluate_metrics_data_size():
+            collector.collect_metrics()
+            print("Metrics Collect Done")
+        else:
+            print("Insufficient free space for metrics data")
+    elif args.action == "upload":
+        uploader = OfflineMetricsUploader(location)
+        if StrictVersion(uploader.get_eos_version()) < StrictVersion("3.9.0"):
+            print("Please run this command on >= EOS 3.9.0")
+        else:
+            uploader.copy_metrics_data_and_upload()
+            print("All metrics data been successfully uploaded")
+            shutil.rmtree(os.path.join(location, uploader.offline_metrics_src_dir))
+    else:
+        print('Invalid action ' + args.action)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -12,6 +12,21 @@ import argparse
 from distutils.version import StrictVersion
 
 
+def get_eos_version():
+    f = open("/etc/os-release")
+
+    for line in f.readlines():
+        key, value = line.split("=")
+        if key == "ID":
+            distro = value.rstrip('\n').strip('"')
+        if key == "VERSION_ID":
+            version = value.rstrip('\n').strip('"')
+
+    if distro == "endless":
+        return version
+    return None
+
+
 class OfflineMetrics():
     def __init__(self):
         self.metrics_cache_dir = '/var/cache/metrics'
@@ -20,16 +35,7 @@ class OfflineMetrics():
         self.systemd_service = 'eos-metrics-event-recorder.service'
         self.metrics_config_file = '/etc/metrics/eos-metrics-permissions.conf'
         self.metrics_proc_name = 'eos-metrics-event-recorder'
-        self.eos_version = None
 
-    def get_eos_version(self):
-        f = open("/etc/os-release")
-        for line in f.readlines():
-            if line.startswith("VERSION="):
-                fdot = line.find('=')
-                major = line[fdot+2:-2]
-                self.eos_version = major
-                return str(major)
 
     def metrics_proc_exists(self):
         ps = subprocess.Popen("ps ax -o pid= -o args= ", shell=True, stdout=subprocess.PIPE)
@@ -214,13 +220,20 @@ def main():
         else:
             print("Insufficient free space for metrics data")
     elif args.action == "upload":
+        eos_version = get_eos_version()
+        if eos_version is None:
+            sys.exit("This program only works on Endless OS, exiting.")
+        if StrictVersion(eos_version) < StrictVersion("3.9.0"):
+            msg = (
+                f"Uploading metrics collected from other machines requires "
+                f"EOS >= 3.9.0, and {eos_version} was detected, exiting."
+            )
+            sys.exit(msg)
+
         uploader = OfflineMetricsUploader(location)
-        if StrictVersion(uploader.get_eos_version()) < StrictVersion("3.9.0"):
-            print("Please run this command on >= EOS 3.9.0")
-        else:
-            uploader.copy_metrics_data_and_upload()
-            print("All metrics data been successfully uploaded")
-            shutil.rmtree(os.path.join(location, uploader.offline_metrics_src_dir))
+        uploader.copy_metrics_data_and_upload()
+        print("All metrics data been successfully uploaded")
+        shutil.rmtree(os.path.join(location, uploader.offline_metrics_src_dir))
     else:
         print('Invalid action ' + args.action)
 

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -36,7 +36,7 @@ class OfflineMetrics():
         self.metrics_config_file = '/etc/metrics/eos-metrics-permissions.conf'
         self.metrics_proc_name = 'eos-metrics-event-recorder'
         self.storage_root = storage_root
-        self.storage_metrics_dir = 'eos-metrics-data'
+        self.storage_dir = os.path.join(self.storage_root, 'eos-metrics-data')
         if os.path.exists(self.tracking_id_path):
             self.metrics_id = self.tracking_id_path
         else:
@@ -71,25 +71,27 @@ class OfflineMetrics():
 class OfflineMetricsUploader(OfflineMetrics):
     def __init__(self, storage_root):
         super().__init__(storage_root)
-        self.offline_tmp_metrics_dir = ''
+        self.tmpdir = ''
 
     def copy_metrics_data_and_upload(self):
-        srcdir = os.path.join(self.storage_root, self.storage_metrics_dir)
-        if not os.path.exists(srcdir):
-            print(f"No metrics data found in {srcdir}, nothing to do.")
+        if not os.path.exists(self.storage_dir):
+            msg = (
+                f"No metrics data found in {self.storage_dir}, nothing to do."
+            )
+            print(msg)
             sys.exit(0)
 
         self.unit_was_running = self.metrics_unit('is-active')
         self.metrics_unit('stop')
 
-        for machine_dir in os.listdir(srcdir):
-            self.offline_tmp_metrics_dir = tempfile.mkdtemp()
-            machine_path = os.path.join(srcdir, machine_dir)
-            for file in os.listdir(machine_path):
-                shutil.copy(os.path.join(machine_path, file), self.offline_tmp_metrics_dir)
-            subprocess.check_output(['sudo', 'chown', '-R', 'metrics:metrics', self.offline_tmp_metrics_dir])
-            persistent_cache_dir_arg = '--persistent-cache-directory=' + self.offline_tmp_metrics_dir
-            tracking_id_path_arg = '--tracking-id-file-path=' + self.offline_tmp_metrics_dir + '/tracking-id'
+        for tracking_id in os.listdir(self.storage_dir):
+            self.tmpdir = tempfile.mkdtemp()
+            machine_dir = os.path.join(self.storage_dir, tracking_id)
+            for f in os.listdir(machine_dir):
+                shutil.copy(os.path.join(machine_dir, f), self.tmpdir)
+            subprocess.check_output(['sudo', 'chown', '-R', 'metrics:metrics', self.tmpdir])
+            persistent_cache_dir_arg = '--persistent-cache-directory=' + self.tmpdir
+            tracking_id_path_arg = '--tracking-id-file-path=' + self.tmpdir + '/tracking-id'
             self.daemon = subprocess.Popen(['sudo', '-u', 'metrics', '/lib/eos-event-recorder-daemon/eos-metrics-event-recorder', persistent_cache_dir_arg, tracking_id_path_arg], stderr=subprocess.DEVNULL)
 
             timeout = 0
@@ -107,18 +109,18 @@ class OfflineMetricsUploader(OfflineMetrics):
                 print('Upload Fail.')
                 sys.exit()
             else:
-                print("Upload successfully for tracking id " + machine_dir)
+                print("Upload successfully for tracking id " + tracking_id)
 
             subprocess.check_output(['sudo', 'killall', '/lib/eos-event-recorder-daemon/eos-metrics-event-recorder'])
-            subprocess.check_output(['sudo', 'rm', '-rf', self.offline_tmp_metrics_dir])
+            subprocess.check_output(['sudo', 'rm', '-rf', self.tmpdir])
 
     def __del__(self):
         '''
         Remove temporary cache data, kill the eos-metrics-event-recorder.
         And restart the service
         '''
-        if os.path.exists(self.offline_tmp_metrics_dir):
-            subprocess.check_output(['sudo', 'rm', '-rf', self.offline_tmp_metrics_dir])
+        if os.path.exists(self.tmpdir):
+            subprocess.check_output(['sudo', 'rm', '-rf', self.tmpdir])
         if self.metrics_proc_exists():
             subprocess.check_output(['sudo', 'killall', '/lib/eos-event-recorder-daemon/eos-metrics-event-recorder'])
         if self.unit_was_running:
@@ -128,7 +130,7 @@ class OfflineMetricsUploader(OfflineMetrics):
 class OfflineMetricsCollector(OfflineMetrics):
     def __init__(self, storage_root):
         super().__init__(storage_root)
-        self.target_dir = None
+        self.machine_dir = None
 
     def get_usbdisk_free_space(self):
         disk_usage = shutil.disk_usage(self.storage_root)
@@ -143,22 +145,21 @@ class OfflineMetricsCollector(OfflineMetrics):
         return size
 
     def create_machine_dir(self):
-        target_dir = os.path.join(self.storage_root, self.storage_metrics_dir)
-        if not os.path.exists(target_dir):
-            os.mkdir(target_dir)
+        if not os.path.exists(self.storage_dir):
+            os.mkdir(self.storage_dir)
 
         f = open(self.metrics_id)
-        self.target_dir = os.path.join(target_dir, f.read(32))
+        self.machine_dir = os.path.join(self.storage_dir, f.read(32))
         f.close()
 
-        if os.path.exists(self.target_dir):
+        if os.path.exists(self.machine_dir):
             msg = (
                 f"Looks like metrics data for this machine exists in the "
                 f"target storage device. Please use a different target device "
-                f"or manually remove {self.target_dir}. Aborting."
+                f"or manually remove {self.machine_dir}. Aborting."
             )
             sys.exit(msg)
-        os.mkdir(self.target_dir)
+        os.mkdir(self.machine_dir)
 
     def copy_metrics_data(self):
         # we can't use shutil.copy here to copy all files in one call because
@@ -170,11 +171,11 @@ class OfflineMetricsCollector(OfflineMetrics):
         ]
         for f in files:
             src = os.path.join(self.metrics_cache_dir, f)
-            dst = os.path.join(self.target_dir, f)
+            dst = os.path.join(self.machine_dir, f)
             if os.path.exists(src):
                 shutil.copyfile(src, dst)
         shutil.copyfile(self.metrics_id,
-                        os.path.join(self.target_dir, 'tracking-id'))
+                        os.path.join(self.machine_dir, 'tracking-id'))
 
     def reset_metrics_data(self):
         files = ['variants.dat', 'variants.dat.metadata']
@@ -218,7 +219,7 @@ def upload(storage_root):
 
     uploader = OfflineMetricsUploader(storage_root)
     uploader.copy_metrics_data_and_upload()
-    shutil.rmtree(os.path.join(storage_root, uploader.storage_metrics_dir))
+    shutil.rmtree(self.storage_dir)
     print("All metrics data uploaded.")
 
 

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
 
 import argparse
+import dbus
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -37,25 +37,19 @@ class OfflineMetrics():
         self.metrics_proc_name = 'eos-metrics-event-recorder'
         self.storage_root = storage_root
         self.storage_dir = os.path.join(self.storage_root, 'eos-metrics-data')
+        self.dbus_name = "com.endlessm.Metrics"
         if os.path.exists(self.tracking_id_path):
             self.metrics_id = self.tracking_id_path
         else:
             self.metrics_id = self.machine_id_path
 
-    def metrics_proc_exists(self):
-        ps = subprocess.Popen("ps ax -o pid= -o args= ", shell=True, stdout=subprocess.PIPE)
-        ps_pid = ps.pid
-        output = ps.stdout.read()
-        ps.stdout.close()
-        ps.wait()
-
-        for line in str(output).split('\n'):
-            res = re.findall("(\d+) (.*)", line)
-            if res:
-                pid = int(res[0][0])
-                if self.metrics_proc_name in res[0][1] and pid != os.getpid() and pid != ps_pid:
-                    return True
-        return False
+    def metrics_pid_is_ready(self, pid):
+        bus = dbus.SystemBus()
+        if not bus.name_has_owner(self.dbus_name):
+            return False
+        proxy = bus.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus")
+        iface = dbus.Interface(proxy, "org.freedesktop.DBus")
+        return (pid == iface.GetConnectionUnixProcessID(self.dbus_name))
 
     def metrics_unit(self, operation):
         # TODO: the metrics daemon is also D-Bus activatable, so on stop we
@@ -119,13 +113,15 @@ class OfflineMetricsUploader(OfflineMetrics):
             self.daemon = subprocess.Popen(
                 ['sudo', '-u', 'metrics', self.bin_path, dir_arg, id_arg])
 
-            timeout = 0
-            while timeout < 5:
+            # NOTE: Ideally we would get rid of this busy waiting here, but we
+            # are already making a bigger design compromise by having to stop
+            # the daemon and restart it with different command line parameters
+            # for each data set, so let's roll with it for now.
+            tries = 5
+            while not self.metrics_pid_is_ready(self.daemon.pid) and tries > 0:
                 time.sleep(1)
-                if self.metrics_proc_exists():
-                    break
-                timeout = timeout + 1
-            if timeout >= 5:
+                tries -= 1
+            if tries == 0:
                 self.cleanup()
                 sys.exit(f'Failed to launch {self.bin_name}, aborting.')
 

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -74,7 +74,19 @@ class OfflineMetricsUploader(OfflineMetrics):
         self.bin_dir = "/usr/lib/eos-event-recorder-daemon"
         self.bin_name = "eos-metrics-event-recorder"
         self.bin_path = os.path.join(self.bin_dir, self.bin_name)
+        self.up_trigger_bin = "eos-upload-metrics"
         self.tmpdir = ''
+        self.daemon = None
+        self.unit_was_running = False
+
+    def cleanup(self):
+        if self.daemon is not None:
+            self.daemon.terminate()
+            self.daemon = None
+        if os.path.exists(self.tmpdir):
+            shutil.rmtree(self.tmpdir)
+        if self.unit_was_running:
+            self.metrics_unit('start')
 
     def copy_metrics_data_and_upload(self):
         if not os.path.exists(self.storage_dir):
@@ -104,7 +116,7 @@ class OfflineMetricsUploader(OfflineMetrics):
 
             dir_arg = f"--persistent-cache-directory={machine_dstdir}"
             id_arg = f"--tracking-id-file-path={machine_dstdir}/tracking-id"
-            daemon = subprocess.Popen(
+            self.daemon = subprocess.Popen(
                 ['sudo', '-u', 'metrics', self.bin_path, dir_arg, id_arg])
 
             timeout = 0
@@ -114,30 +126,24 @@ class OfflineMetricsUploader(OfflineMetrics):
                     break
                 timeout = timeout + 1
             if timeout >= 5:
-                print('Fail to launch eos-metrics-event-recorder')
-                sys.exit()
+                self.cleanup()
+                sys.exit(f'Failed to launch {self.bin_name}, aborting.')
 
-            upload = subprocess.run(['/usr/bin/eos-upload-metrics'], stdout=subprocess.DEVNULL)
-            if (upload.returncode != 0):
-                print('Upload Fail.')
-                sys.exit()
-            else:
-                print("Upload successfully for tracking id " + tracking_id)
+            up_trigger = subprocess.run(self.up_trigger_bin,
+                                        stdout=subprocess.DEVNULL)
+            if up_trigger.returncode != 0:
+                msg = (
+                    f"Failed to upload metrics, {self.up_trigger_bin} failed "
+                    f"with status {up_trigger.returncode}. Aborting."
+                )
+                self.cleanup()
+                sys.exit(msg)
 
-            daemon.terminate()
+            self.daemon.terminate()
+            self.daemon = None
             shutil.rmtree(machine_dstdir)
-
-    def __del__(self):
-        '''
-        Remove temporary cache data, kill the eos-metrics-event-recorder.
-        And restart the service
-        '''
-        if os.path.exists(self.tmpdir):
-            subprocess.check_output(['sudo', 'rm', '-rf', self.tmpdir])
-        if self.metrics_proc_exists():
-            subprocess.check_output(['sudo', 'killall', '/lib/eos-event-recorder-daemon/eos-metrics-event-recorder'])
-        if self.unit_was_running:
-            self.metrics_unit('start')
+            print(f"Successfully uploaded metrics data for {tracking_id}.")
+        self.cleanup()
 
 
 class OfflineMetricsCollector(OfflineMetrics):

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -83,7 +83,12 @@ class OfflineMetricsUploader(OfflineMetrics):
             self.metrics_unit('start')
 
     def upload_metrics(self):
-        if not os.path.exists(self.storage_dir):
+        exists = os.path.exists(self.storage_dir)
+        isdir = os.path.isdir(self.storage_dir)
+        if exists and isdir:
+            isempty = not os.listdir(self.storage_dir)
+
+        if not exists or not isdir or isempty:
             msg = (
                 f"No metrics data found in {self.storage_dir}, nothing to do."
             )

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 import tempfile
+import pwd
 
 from distutils.version import StrictVersion
 
@@ -43,14 +44,6 @@ class OfflineMetrics():
         else:
             self.metrics_id = self.machine_id_path
 
-    def metrics_pid_is_ready(self, pid):
-        bus = dbus.SystemBus()
-        if not bus.name_has_owner(self.dbus_name):
-            return False
-        proxy = bus.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus")
-        iface = dbus.Interface(proxy, "org.freedesktop.DBus")
-        return (pid == iface.GetConnectionUnixProcessID(self.dbus_name))
-
     def metrics_unit(self, operation):
         # TODO: the metrics daemon is also D-Bus activatable, so on stop we
         # should also do something to prevent it being started over D-Bus.
@@ -81,6 +74,44 @@ class OfflineMetricsUploader(OfflineMetrics):
             shutil.rmtree(self.tmpdir)
         if self.unit_was_running:
             self.metrics_unit('start')
+
+    def chusr(self):
+        pwd_entry = pwd.getpwnam('metrics')
+        os.setgid(pwd_entry.pw_gid)
+        os.setuid(pwd_entry.pw_uid)
+
+    def metrics_pid_is_ready(self, pid):
+        bus = dbus.SystemBus()
+        if not bus.name_has_owner(self.dbus_name):
+            return False
+        proxy = bus.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus")
+        iface = dbus.Interface(proxy, "org.freedesktop.DBus")
+        return (pid == iface.GetConnectionUnixProcessID(self.dbus_name))
+
+    def spawn_metrics_daemon(self, path):
+        dir_arg = f"--persistent-cache-directory={path}"
+        id_arg = f"--tracking-id-file-path={path}/tracking-id"
+
+        env = os.environ.copy()
+        env['USER'] = 'metrics'
+        env['LOGNAME'] = 'metrics'
+        env['HOME'] = path
+        daemon = subprocess.Popen(
+            [self.bin_path, dir_arg, id_arg], preexec_fn=self.chusr, env=env)
+
+        # NOTE: Ideally we would get rid of this busy waiting here, but we
+        # are already making a bigger design compromise by having to stop
+        # the daemon and restart it with different command line parameters
+        # for each data set, so let's roll with it for now.
+        tries = 5
+        while not self.metrics_pid_is_ready(daemon.pid) and tries > 0:
+            time.sleep(1)
+            tries -= 1
+        if tries == 0:
+            self.cleanup()
+            sys.exit(f'Failed to launch {self.bin_name}, aborting.')
+
+        return daemon
 
     def upload_metrics(self):
         exists = os.path.exists(self.storage_dir)
@@ -113,22 +144,7 @@ class OfflineMetricsUploader(OfflineMetrics):
                 shutil.copyfile(src, dst)
                 shutil.chown(dst, user='metrics', group='metrics')
 
-            dir_arg = f"--persistent-cache-directory={machine_dstdir}"
-            id_arg = f"--tracking-id-file-path={machine_dstdir}/tracking-id"
-            self.daemon = subprocess.Popen(
-                ['sudo', '-u', 'metrics', self.bin_path, dir_arg, id_arg])
-
-            # NOTE: Ideally we would get rid of this busy waiting here, but we
-            # are already making a bigger design compromise by having to stop
-            # the daemon and restart it with different command line parameters
-            # for each data set, so let's roll with it for now.
-            tries = 5
-            while not self.metrics_pid_is_ready(self.daemon.pid) and tries > 0:
-                time.sleep(1)
-                tries -= 1
-            if tries == 0:
-                self.cleanup()
-                sys.exit(f'Failed to launch {self.bin_name}, aborting.')
+            self.daemon = self.spawn_metrics_daemon(machine_dstdir)
 
             up_trigger = subprocess.run(self.up_trigger_bin,
                                         stdout=subprocess.DEVNULL)

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -88,7 +88,7 @@ class OfflineMetricsUploader(OfflineMetrics):
         if self.unit_was_running:
             self.metrics_unit('start')
 
-    def copy_metrics_data_and_upload(self):
+    def upload_metrics(self):
         if not os.path.exists(self.storage_dir):
             msg = (
                 f"No metrics data found in {self.storage_dir}, nothing to do."
@@ -141,7 +141,7 @@ class OfflineMetricsUploader(OfflineMetrics):
 
             self.daemon.terminate()
             self.daemon = None
-            shutil.rmtree(machine_dstdir)
+            shutil.rmtree(machine_srcdir)
             print(f"Successfully uploaded metrics data for {tracking_id}.")
         self.cleanup()
 
@@ -237,8 +237,7 @@ def upload(storage_root):
         sys.exit(msg)
 
     uploader = OfflineMetricsUploader(storage_root)
-    uploader.copy_metrics_data_and_upload()
-    shutil.rmtree(self.storage_dir)
+    uploader.upload_metrics()
     print("All metrics data uploaded.")
 
 

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -1,14 +1,14 @@
 #!/usr/bin/python3
 
-import sys
+import argparse
 import os
-import subprocess
+import re
 import shutil
+import subprocess
+import sys
 import time
 import tempfile
-import errno
-import re
-import argparse
+
 from distutils.version import StrictVersion
 
 

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -28,13 +28,15 @@ def get_eos_version():
 
 
 class OfflineMetrics():
-    def __init__(self):
+    def __init__(self, storage_root):
         self.metrics_cache_dir = '/var/cache/metrics'
         self.tracking_id_path = '/etc/metrics/tracking-id'
         self.machine_id_path = '/etc/machine-id'
         self.systemd_service = 'eos-metrics-event-recorder.service'
         self.metrics_config_file = '/etc/metrics/eos-metrics-permissions.conf'
         self.metrics_proc_name = 'eos-metrics-event-recorder'
+        self.storage_root = storage_root
+        self.storage_metrics_dir = 'eos-metrics-data'
 
     def metrics_proc_exists(self):
         ps = subprocess.Popen("ps ax -o pid= -o args= ", shell=True, stdout=subprocess.PIPE)
@@ -63,17 +65,14 @@ class OfflineMetrics():
 
 
 class OfflineMetricsUploader(OfflineMetrics):
-
-    def __init__(self, storage_path=None):
-        super().__init__()
-        self.offline_metrics_usbdisk_node = storage_path
-        self.offline_metrics_src_dir = 'eos-metrics-data'
+    def __init__(self, storage_root):
+        super().__init__(storage_root)
         self.offline_tmp_metrics_dir = ''
 
     def copy_metrics_data_and_upload(self):
         self.unit_was_running = self.metrics_unit('is-active')
         self.metrics_unit('stop')
-        srcdir = os.path.join(self.offline_metrics_usbdisk_node, self.offline_metrics_src_dir)
+        srcdir = os.path.join(self.storage_root, self.storage_metrics_dir)
         if not os.path.exists(srcdir):
             print('No metrics data in the eos-metrics-data directory')
             sys.exit()
@@ -121,17 +120,12 @@ class OfflineMetricsUploader(OfflineMetrics):
 
 
 class OfflineMetricsCollector(OfflineMetrics):
-
-    def __init__(self, storage_path=None):
-        super().__init__()
-        self.offline_metrics_usbdisk_node = storage_path
-        self.offline_metrics_dst_dir = 'eos-metrics-data'
-        self.disk_free_space_in_bytes = 0
-        self.offline_machine_data_dir = None
+    def __init__(self, storage_root):
+        super().__init__(storage_root)
+        self.target_dir = None
 
     def get_usbdisk_free_space(self):
-        disk_usage = shutil.disk_usage(self.offline_metrics_usbdisk_node)
-        self.disk_free_space_in_bytes = disk_usage.free
+        disk_usage = shutil.disk_usage(self.storage_root)
         return disk_usage.free
 
     def calculate_metrics_data_size(self):
@@ -143,47 +137,47 @@ class OfflineMetricsCollector(OfflineMetrics):
         return size
 
     def create_folder_for_machine(self):
-        target_dir = os.path.join(self.offline_metrics_usbdisk_node, self.offline_metrics_dst_dir)
-        if os.path.exists(target_dir) is False:
+        target_dir = os.path.join(self.storage_root, self.storage_metrics_dir)
+        if not os.path.exists(target_dir):
             os.mkdir(target_dir)
 
-        if os.path.exists(self.tracking_id_path) is True:
+        if os.path.exists(self.tracking_id_path):
             f = open(self.tracking_id_path)
-        elif os.path.exists(self.machine_id_path) is True:
+        elif os.path.exists(self.machine_id_path):
             f = open(self.machine_id_path)
         else:
             print('No tracking/machine id file found')
             sys.exit()
 
-        self.offline_machine_data_dir = os.path.join(target_dir, f.read(32))
-        if os.path.exists(self.offline_machine_data_dir) is False:
-            os.mkdir(self.offline_machine_data_dir)
+        self.target_dir = os.path.join(target_dir, f.read(32))
+        if not os.path.exists(self.target_dir):
+            os.mkdir(self.target_dir)
         else:
-            subprocess.check_output(['rm', '-rf', self.offline_machine_data_dir])
-            os.mkdir(self.offline_machine_data_dir)
+            subprocess.check_output(['rm', '-rf', self.target_dir])
+            os.mkdir(self.target_dir)
         f.close()
 
     def copy_tracking_id(self):
-        if os.path.exists(self.tracking_id_path) is True:
+        if os.path.exists(self.tracking_id_path):
             # The tracking id file has permission -rwxrwsr-x  which
             # will raise PermissionError for shutil.copy, use copyfile
             # instead
-            shutil.copyfile(self.tracking_id_path, os.path.join(self.offline_machine_data_dir, os.path.basename(self.tracking_id_path)))
-        elif os.path.exists(self.machine_id_path) is True:
-            shutil.copyfile(self.machine_id_path, os.path.join(self.offline_machine_data_dir, os.path.basename(self.tracking_id_path)))
+            shutil.copyfile(self.tracking_id_path, os.path.join(self.target_dir, os.path.basename(self.tracking_id_path)))
+        elif os.path.exists(self.machine_id_path):
+            shutil.copyfile(self.machine_id_path, os.path.join(self.target_dir, os.path.basename(self.tracking_id_path)))
         else:
             print('No tracking/machine id file found')
             sys.exit()
 
     def copy_metrics_data(self):
         # Check whether the network_send_file exists or not
-        if os.path.exists(os.path.join(self.metrics_cache_dir, 'network_send_file')) is True:
-            shutil.copyfile(os.path.join(self.metrics_cache_dir, 'network_send_file'), os.path.join(self.offline_machine_data_dir, 'network_send_file'))
+        if os.path.exists(os.path.join(self.metrics_cache_dir, 'network_send_file')):
+            shutil.copyfile(os.path.join(self.metrics_cache_dir, 'network_send_file'), os.path.join(self.target_dir, 'network_send_file'))
 
         # Copy mandatory files
         files = ['boot_offset_metafile', 'local_version_file', 'variants.dat', 'variants.dat.metadata']
         for file in files:
-            shutil.copyfile(os.path.join(self.metrics_cache_dir, file), os.path.join(self.offline_machine_data_dir, os.path.basename(file)))
+            shutil.copyfile(os.path.join(self.metrics_cache_dir, file), os.path.join(self.target_dir, os.path.basename(file)))
 
     def reset_metrics_data(self):
         files = ['variants.dat', 'variants.dat.metadata']
@@ -202,8 +196,8 @@ class OfflineMetricsCollector(OfflineMetrics):
             self.metrics_unit('start')
 
 
-def collect(location):
-    collector = OfflineMetricsCollector(location)
+def collect(storage_root):
+    collector = OfflineMetricsCollector(storage_root)
     free_space = collector.get_usbdisk_free_space()
     data_size = collector.calculate_metrics_data_size()
     if free_space < data_size:
@@ -216,7 +210,7 @@ def collect(location):
     print(f"Metrics data collected ({data_size} bytes).")
 
 
-def upload(location):
+def upload(storage_root):
     eos_version = get_eos_version()
     if eos_version is None:
         sys.exit("This program only works on Endless OS, exiting.")
@@ -227,9 +221,9 @@ def upload(location):
         )
         sys.exit(msg)
 
-    uploader = OfflineMetricsUploader(location)
+    uploader = OfflineMetricsUploader(storage_root)
     uploader.copy_metrics_data_and_upload()
-    shutil.rmtree(os.path.join(location, uploader.offline_metrics_src_dir))
+    shutil.rmtree(os.path.join(storage_root, uploader.storage_metrics_dir))
     print("All metrics data uploaded.")
 
 
@@ -258,11 +252,11 @@ def main():
                         help='action to be performed (default: %(default)s)')
     args = parser.parse_args()
 
-    location = sys.path[0]
+    storage_root = sys.path[0]
     if args.action == "collect":
-        collect(location)
+        collect(storage_root)
     elif args.action == "upload":
-        upload(location)
+        upload(storage_root)
 
 
 if __name__ == '__main__':

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -74,12 +74,14 @@ class OfflineMetricsUploader(OfflineMetrics):
         self.offline_tmp_metrics_dir = ''
 
     def copy_metrics_data_and_upload(self):
-        self.unit_was_running = self.metrics_unit('is-active')
-        self.metrics_unit('stop')
         srcdir = os.path.join(self.storage_root, self.storage_metrics_dir)
         if not os.path.exists(srcdir):
-            print('No metrics data in the eos-metrics-data directory')
-            sys.exit()
+            print(f"No metrics data found in {srcdir}, nothing to do.")
+            sys.exit(0)
+
+        self.unit_was_running = self.metrics_unit('is-active')
+        self.metrics_unit('stop')
+
         for machine_dir in os.listdir(srcdir):
             self.offline_tmp_metrics_dir = tempfile.mkdtemp()
             machine_path = os.path.join(srcdir, machine_dir)
@@ -140,7 +142,7 @@ class OfflineMetricsCollector(OfflineMetrics):
             size += os.path.getsize(self.machine_id_path)
         return size
 
-    def create_folder_for_machine(self):
+    def create_machine_dir(self):
         target_dir = os.path.join(self.storage_root, self.storage_metrics_dir)
         if not os.path.exists(target_dir):
             os.mkdir(target_dir)
@@ -180,9 +182,9 @@ class OfflineMetricsCollector(OfflineMetrics):
             os.remove(os.path.join(self.metrics_cache_dir, f))
 
     def collect_metrics(self):
+        self.create_machine_dir()
         unit_was_running = self.metrics_unit('is-active')
         self.metrics_unit('stop')
-        self.create_folder_for_machine()
         self.copy_metrics_data()
         self.reset_metrics_data()
         if unit_was_running:

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -128,6 +128,14 @@ class OfflineMetricsCollector(OfflineMetrics):
         self.disk_free_space_in_bytes = disk_usage.free
         return disk_usage.free
 
+    def calculate_metrics_data_size(self):
+        size = os.path.getsize(self.metrics_cache_dir)
+        if os.path.exists(self.tracking_id_path):
+            size += os.path.getsize(self.tracking_id_path)
+        elif os.path.exists(self.machine_id_path):
+            size += os.path.getsize(self.machine_id_path)
+        return size
+
     def create_folder_for_machine(self):
         target_dir = os.path.join(self.offline_metrics_usbdisk_node, self.offline_metrics_dst_dir)
         if os.path.exists(target_dir) is False:
@@ -186,23 +194,19 @@ class OfflineMetricsCollector(OfflineMetrics):
         self.reset_metrics_data()
         subprocess.check_output(['/usr/bin/systemctl', 'start', self.systemd_service])
 
-    def evaluate_metrics_data_size(self):
-        size = 0
-        size += os.path.getsize(self.metrics_cache_dir)
-        if os.path.exists(self.tracking_id_path):
-            size += os.path.getsize(self.tracking_id_path)
-        if os.path.exists(self.machine_id_path):
-            size += os.path.getsize(self.machine_id_path)
-        return size
-
 
 def collect(location):
     collector = OfflineMetricsCollector(location)
-    if collector.get_usbdisk_free_space() > collector.evaluate_metrics_data_size():
-        collector.collect_metrics()
-        print("Metrics Collect Done")
-    else:
-        print("Insufficient free space for metrics data")
+    free_space = collector.get_usbdisk_free_space()
+    data_size = collector.calculate_metrics_data_size()
+    if free_space < data_size:
+        msg = (
+            f"Insufficient free space ({free_space} bytes) for metrics "
+            f"data size ({data_size} bytes), aborting."
+        )
+        sys.exit(msg)
+    collector.collect_metrics()
+    print(f"Metrics data collected ({data_size} bytes).")
 
 
 def upload(location):
@@ -218,8 +222,8 @@ def upload(location):
 
     uploader = OfflineMetricsUploader(location)
     uploader.copy_metrics_data_and_upload()
-    print("All metrics data been successfully uploaded")
     shutil.rmtree(os.path.join(location, uploader.offline_metrics_src_dir))
+    print("All metrics data uploaded.")
 
 
 def main():

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -223,25 +223,35 @@ def upload(location):
 
 
 def main():
-    location = os.path.dirname(os.path.realpath(sys.argv[0]))
+    desc = """
+    Offline Metrics Collector for Endless OS.
+
+    This program is designed to be executed from a removable storage device,
+    like a USB flash drive. It supports two actions, 'collect' and 'upload'.
+
+    The 'collect' action will extract any existing metrics from the system
+    where it is running and copy it to the removable storage device that it is
+    running from.
+
+    The 'upload' action will upload all extracted metrics data located in the
+    removable storage device that it is running from to the Endless' metrics
+    servers."""
+    epil = "The 'upload' action requires Endless OS 3.9.0 or newer."
+
     parser = argparse.ArgumentParser(
-    description='Offline Metrics Collector. There are 2 actions, collect'
-                'and upload. The program is expected to be located in'
-                'a removable storage. The metrics data of the target'
-                'machine will be copied to eos-metrics-data directory'
-                'of the removable storage while doing collect. All collected'
-                'data can uploaded to Metrics Server by doing upload'
-                )
-    parser.add_argument('action', metavar='ACTION', type=str,
-                        help='collect or upload')
+        description=desc, epilog=epil,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument('action', nargs='?', choices=['collect', 'upload'],
+                        default='collect',
+                        help='action to be performed (default: %(default)s)')
     args = parser.parse_args()
 
+    location = sys.path[0]
     if args.action == "collect":
         collect(location)
     elif args.action == "upload":
         upload(location)
-    else:
-        print('Invalid action ' + args.action)
 
 
 if __name__ == '__main__':

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -2,6 +2,7 @@
 
 import argparse
 import dbus
+import errno
 import os
 import shutil
 import subprocess
@@ -258,6 +259,18 @@ def upload(storage_root):
     print("All metrics data uploaded.")
 
 
+def become_root():
+    if os.getuid() == 0:
+        return
+    # sys.executable will be the python interpreter, so we need to manually
+    # resolve our absolute path (sys.argv[0])
+    args = [sys.executable] + [os.path.abspath(sys.argv[0])] + sys.argv[1:]
+    if os.environ.get("DISPLAY"):
+        cmd = 'pkexec'
+    else:
+        cmd = 'sudo'
+    os.execvp(cmd, [cmd] + args)
+
 def main():
     desc = """
     Offline Metrics Collector for Endless OS.
@@ -282,6 +295,8 @@ def main():
                         default='collect',
                         help='action to be performed (default: %(default)s)')
     args = parser.parse_args()
+
+    become_root()
 
     storage_root = sys.path[0]
     if args.action == "collect":

--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -51,9 +51,15 @@ class OfflineMetrics():
                     return True
         return False
 
-    def is_metrics_service_active(self):
-        status = os.system('systemctl is-active --quiet ' + self.systemd_service)
-        return (status == 0)
+    def metrics_unit(self, operation):
+        # TODO: the metrics daemon is also D-Bus activatable, so on stop we
+        # should also do something to prevent it being started over D-Bus.
+        cmd = ['systemctl', operation]
+        if operation == 'is-active':
+            cmd.append('--quiet')
+        cmd.append(self.systemd_service)
+        p = subprocess.run(cmd)
+        return (p.returncode == 0)
 
 
 class OfflineMetricsUploader(OfflineMetrics):
@@ -65,8 +71,8 @@ class OfflineMetricsUploader(OfflineMetrics):
         self.offline_tmp_metrics_dir = ''
 
     def copy_metrics_data_and_upload(self):
-        if (self.is_metrics_service_active()):
-            subprocess.check_output(['/usr/bin/systemctl', 'stop', self.systemd_service])
+        self.unit_was_running = self.metrics_unit('is-active')
+        self.metrics_unit('stop')
         srcdir = os.path.join(self.offline_metrics_usbdisk_node, self.offline_metrics_src_dir)
         if not os.path.exists(srcdir):
             print('No metrics data in the eos-metrics-data directory')
@@ -110,8 +116,8 @@ class OfflineMetricsUploader(OfflineMetrics):
             subprocess.check_output(['sudo', 'rm', '-rf', self.offline_tmp_metrics_dir])
         if self.metrics_proc_exists():
             subprocess.check_output(['sudo', 'killall', '/lib/eos-event-recorder-daemon/eos-metrics-event-recorder'])
-        if (not self.is_metrics_service_active()):
-            subprocess.check_output(['/usr/bin/systemctl', 'start', self.systemd_service])
+        if self.unit_was_running:
+            self.metrics_unit('start')
 
 
 class OfflineMetricsCollector(OfflineMetrics):
@@ -186,13 +192,14 @@ class OfflineMetricsCollector(OfflineMetrics):
             subprocess.check_output(['sudo', 'rm', '-f', target_file])
 
     def collect_metrics(self):
-        if (self.is_metrics_service_active()):
-            subprocess.check_output(['/usr/bin/systemctl', 'stop', self.systemd_service])
+        unit_was_running = self.metrics_unit('is-active')
+        self.metrics_unit('stop')
         self.create_folder_for_machine()
         self.copy_tracking_id()
         self.copy_metrics_data()
         self.reset_metrics_data()
-        subprocess.check_output(['/usr/bin/systemctl', 'start', self.systemd_service])
+        if unit_was_running:
+            self.metrics_unit('start')
 
 
 def collect(location):


### PR DESCRIPTION
The eos-metrics-collector need to have the extension .exe to gurantee
the executable flag persists after copied to FAT32 partition.

It will take 'collect' and 'upload' as argument to do the corresponding
actions.