### PR TITLE
collector: fix the subprocess.run for python 3.4 compatibility

### DIFF
--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -145,7 +145,7 @@ class OfflineMetricsUploader(OfflineMetrics):
 
             self.daemon = self.spawn_metrics_daemon(machine_dstdir)
 
-            returncode = subprocess.run(self.up_trigger_bin, stdout=subprocess.DEVNULL)
+            returncode = subprocess.call(self.up_trigger_bin, stdout=subprocess.DEVNULL)
             if returncode != 0:
                 msg = (
                     "Failed to upload metrics, {} failed with status {}. "


### PR DESCRIPTION
Replace the subprocess.call with .run which is not included in
commit 4a56946432f73a2411edc9e49a31fa0d78d5adea

https://phabricator.endlessm.com/T30974