### PR TITLE
collector: Call systemctl to unmask the service

### DIFF
--- a/tools/eos-metrics-collector.exe
+++ b/tools/eos-metrics-collector.exe
@@ -48,16 +48,9 @@ class OfflineMetrics:
         supported_ops = ["mask", "unmask"]
         if operation not in supported_ops:
             raise ValueError
-        if operation == "mask":
-            cmd = ["systemctl", "mask", "--runtime", "--now", "--quiet"]
-            cmd.append(self.systemd_service)
-            subprocess.call(cmd)
-        else:
-            systemd_runtime_dir = "/run/systemd/system"
-            try:
-                os.remove(os.path.join(systemd_runtime_dir, self.systemd_service))
-            except FileNotFoundError:
-                pass
+        cmd = ["systemctl", operation, "--runtime", "--now", "--quiet"]
+        cmd.append(self.systemd_service)
+        subprocess.call(cmd)
 
 
 class OfflineMetricsUploader(OfflineMetrics):


### PR DESCRIPTION
Previously we were directly removing the link masking the service to
avoid a bug in system 239 [1], which we shipped in EOS 3.5.0 - 3.5.9.

[1] https://github.com/systemd/systemd/issues/9393

By directly removing the link, systemd fails to notice that the unit has
been unmasked, so effectively it remains masked until the next reboot.

What I had failed to noticed is that the bug listed above was actually
fixed downstream by Debian, so we are not affected by it. We can safely
call `systemctl unmask --runtime` on all our versions, so let's just do
that.

https://phabricator.endlessm.com/T30975