### PR TITLE
Allow configuring the default metrics server at build time

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,10 +41,11 @@ AM_CFLAGS = @WARN_CFLAGS@
 AM_LDFLAGS = @WARN_LDFLAGS@
 
 # Enable strict compiler flags and install systemd unit files to the specified
-# directory when doing 'make distcheck'.
+# directory when doing 'make distcheck'. Set a dummy default server URL.
 AM_DISTCHECK_CONFIGURE_FLAGS = \
 	--enable-compile-warnings=error \
 	--with-systemdsystemunitdir='$${prefix}/lib/systemd/system' \
+	--with-default-metrics-server=azafea.example \
 	$(NULL)
 if EOS_ENABLE_COVERAGE
 AM_DISTCHECK_CONFIGURE_FLAGS += --enable-coverage --with-coverage-dir=@EOS_COVERAGE_DIR@

--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,12 @@ AS_IF([test -f $EVENT_RECORDER_SERVER_XML],
     [AC_MSG_RESULT([present])],
     [AC_MSG_ERROR([absent])])
 
+AC_ARG_WITH([default_metrics_server],
+    [AS_HELP_STRING([--with-default-metrics-server=HOSTNAME],[choose default metrics server])],
+    [DEFAULT_METRICS_SERVER="\"$withval\""],
+    [AC_MSG_ERROR([You must specify a default metrics server using --with-default-metrics-server])])
+AC_DEFINE_UNQUOTED([DEFAULT_METRICS_SERVER], [$DEFAULT_METRICS_SERVER], [Default metrics server])
+
 # Required libraries
 # ------------------
 PKG_CHECK_MODULES([EOS_EVENT_RECORDER_DAEMON], [$EMER_REQUIRED_MODULES])

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-daemon.h"
 
 #include <math.h>
@@ -1044,7 +1045,7 @@ dequeue_and_do_upload (EmerDaemon  *self,
     {
       g_free (priv->server_uri);
       priv->server_uri =
-        g_strconcat ("https://", environment, ".metrics.endlessm.com/"
+        g_strconcat ("https://", environment, "." DEFAULT_METRICS_SERVER "/"
                      CLIENT_VERSION_NUMBER "/", NULL);
     }
 


### PR DESCRIPTION
This makes it easy to use eos-event-recorder-daemon with a metrics server other than metrics.endlessm.com.

I'm not sure whether metrics.endlessm.com is really a good default. It might make more sense to force users to explicitly configure the server to use and then update the eos packaging to select metrics.endlessm.com, to ensure nobody accidentally uses the production server.

https://phabricator.endlessm.com/T31278