### PR TITLE
daemon: Teach eos-event-recorder-daemon to upload metrics in new wire format

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -86,7 +86,7 @@ dist_policy_DATA =
 policyrulesdir = $(datadir)/polkit-1/rules.d
 dist_policyrules_DATA =
 
-persistentcachedir=$(localstatedir)/cache/metrics/
+persistentcachedir=$(localstatedir)/cache/metrics/v3
 configdir=$(sysconfdir)/metrics/
 permissions_file=$(configdir)eos-metrics-permissions.conf
 

--- a/daemon/Makefile.am.inc
+++ b/daemon/Makefile.am.inc
@@ -42,6 +42,7 @@ eos_metrics_event_recorder_SOURCES = \
 	daemon/emer-circular-file.c daemon/emer-circular-file.h \
 	daemon/emer-daemon.c daemon/emer-daemon.h \
 	daemon/emer-gzip.c daemon/emer-gzip.h \
+	daemon/emer-image-id-provider.c daemon/emer-image-id-provider.h \
 	daemon/emer-machine-id-provider.c daemon/emer-machine-id-provider.h \
 	daemon/emer-network-send-provider.c daemon/emer-network-send-provider.h \
 	daemon/emer-permissions-provider.c daemon/emer-permissions-provider.h \

--- a/daemon/Makefile.am.inc
+++ b/daemon/Makefile.am.inc
@@ -47,6 +47,7 @@ eos_metrics_event_recorder_SOURCES = \
 	daemon/emer-network-send-provider.c daemon/emer-network-send-provider.h \
 	daemon/emer-permissions-provider.c daemon/emer-permissions-provider.h \
 	daemon/emer-persistent-cache.c daemon/emer-persistent-cache.h \
+	daemon/emer-site-id-provider.c daemon/emer-site-id-provider.h \
 	daemon/emer-types.c daemon/emer-types.h \
 	emer-event-recorder-server.c emer-event-recorder-server.h \
 	$(NULL)

--- a/daemon/emer-boot-id-provider.h
+++ b/daemon/emer-boot-id-provider.h
@@ -86,6 +86,8 @@ EmerBootIdProvider *emer_boot_id_provider_new_full (const gchar        *boot_id_
 gboolean            emer_boot_id_provider_get_id   (EmerBootIdProvider *self,
                                                     guchar              uuid[16]);
 
+guint8              emer_boot_id_provider_get_boot_type (void);
+
 G_END_DECLS
 
 #endif /* EMER_BOOT_ID_PROVIDER_H */

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -78,7 +78,7 @@
 #define EVENT_VALUE_ARRAY_TYPE_STRING "a" EVENT_VALUE_TYPE_STRING
 #define EVENT_VALUE_ARRAY_TYPE G_VARIANT_TYPE (EVENT_VALUE_ARRAY_TYPE_STRING)
 
-#define SINGULAR_TYPE_STRING "(ayxmv)"
+#define SINGULAR_TYPE_STRING "(aysxmv)"
 #define AGGREGATE_TYPE_STRING "(uayxxmv)"
 #define SEQUENCE_TYPE_STRING "(uay" EVENT_VALUE_ARRAY_TYPE_STRING ")"
 
@@ -1680,6 +1680,7 @@ emer_daemon_record_singular_event (EmerDaemon *self,
                                    GVariant   *payload)
 {
   EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
+  g_autofree gchar *os_version = emer_image_id_provider_get_os_version();
 
   if (!priv->recording_enabled)
     return;
@@ -1705,7 +1706,7 @@ emer_daemon_record_singular_event (EmerDaemon *self,
 
   GVariant *nullable_payload = get_nullable_payload (payload, has_payload);
   GVariant *singular =
-    g_variant_new ("(@ayxmv)", event_id, relative_timestamp,
+    g_variant_new ("(@aysxmv)", event_id, os_version, relative_timestamp,
                    nullable_payload);
   buffer_event (self, singular);
 }

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -78,7 +78,7 @@
 #define EVENT_VALUE_ARRAY_TYPE_STRING "a" EVENT_VALUE_TYPE_STRING
 #define EVENT_VALUE_ARRAY_TYPE G_VARIANT_TYPE (EVENT_VALUE_ARRAY_TYPE_STRING)
 
-#define SINGULAR_TYPE_STRING "(uayxmv)"
+#define SINGULAR_TYPE_STRING "(ayxmv)"
 #define AGGREGATE_TYPE_STRING "(uayxxmv)"
 #define SEQUENCE_TYPE_STRING "(uay" EVENT_VALUE_ARRAY_TYPE_STRING ")"
 
@@ -702,7 +702,6 @@ report_invalid_data_in_cache_on_idle (CacheMetricEventData *callback_data)
     }
 
   emer_daemon_record_singular_event (self,
-                                     getuid (),
                                      event_id_variant,
                                      relative_time,
                                      payload != NULL,
@@ -1675,7 +1674,6 @@ emer_daemon_new_full (GRand                   *rand,
 
 void
 emer_daemon_record_singular_event (EmerDaemon *self,
-                                   guint32     user_id,
                                    GVariant   *event_id,
                                    gint64      relative_timestamp,
                                    gboolean    has_payload,
@@ -1707,7 +1705,7 @@ emer_daemon_record_singular_event (EmerDaemon *self,
 
   GVariant *nullable_payload = get_nullable_payload (payload, has_payload);
   GVariant *singular =
-    g_variant_new ("(u@ayxmv)", user_id, event_id, relative_timestamp,
+    g_variant_new ("(@ayxmv)", event_id, relative_timestamp,
                    nullable_payload);
   buffer_event (self, singular);
 }

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -42,6 +42,7 @@
 #include "emer-network-send-provider.h"
 #include "emer-permissions-provider.h"
 #include "emer-persistent-cache.h"
+#include "emer-site-id-provider.h"
 #include "emer-types.h"
 #include "shared/metrics-util.h"
 
@@ -93,10 +94,10 @@
 #define AGGREGATE_ARRAY_TYPE G_VARIANT_TYPE (AGGREGATE_ARRAY_TYPE_STRING)
 #define SEQUENCE_ARRAY_TYPE G_VARIANT_TYPE (SEQUENCE_ARRAY_TYPE_STRING)
 
-#define REQUEST_TYPE_STRING "(xxs" SINGULAR_ARRAY_TYPE_STRING \
+#define REQUEST_TYPE_STRING "(xxs@a{ss}" SINGULAR_ARRAY_TYPE_STRING \
   AGGREGATE_ARRAY_TYPE_STRING SEQUENCE_ARRAY_TYPE_STRING ")"
 
-#define RETRY_TYPE_STRING "(xxs@" SINGULAR_ARRAY_TYPE_STRING "@" \
+#define RETRY_TYPE_STRING "(xxs@a{ss}@" SINGULAR_ARRAY_TYPE_STRING "@" \
   AGGREGATE_ARRAY_TYPE_STRING "@" SEQUENCE_ARRAY_TYPE_STRING ")"
 
 /* This limit only applies to timer-driven uploads, not explicitly
@@ -430,10 +431,10 @@ get_updated_request_body (EmerDaemon *self,
                           GError    **error)
 {
   g_autofree gchar *image_version;
-  GVariant *singulars, *aggregates, *sequences;
+  GVariant *site_id, *singulars, *aggregates, *sequences;
   g_variant_get (request_body, RETRY_TYPE_STRING,
                  NULL /* relative time */, NULL /* absolute time */,
-                 &image_version, &singulars, &aggregates, &sequences);
+                 &image_version, &site_id, &singulars, &aggregates, &sequences);
 
   // Wait until the last possible moment to get the time of the network request
   // so that it can be used to measure network latency.
@@ -450,7 +451,7 @@ get_updated_request_body (EmerDaemon *self,
   return g_variant_new (RETRY_TYPE_STRING,
                         little_endian_relative_timestamp,
                         little_endian_absolute_timestamp,
-                        image_version, singulars, aggregates, sequences);
+                        image_version, site_id, singulars, aggregates, sequences);
 }
 
 static void
@@ -847,6 +848,7 @@ create_request_body (EmerDaemon *self,
   g_variant_builder_init (&sequences, SEQUENCE_ARRAY_TYPE);
 
   g_autofree gchar *image_version = emer_image_id_provider_get_version ();
+  GVariant *site_id = emer_site_id_provider_get_id ();
 
   gsize num_bytes_read;
   gboolean add_from_buffer =
@@ -874,7 +876,7 @@ create_request_body (EmerDaemon *self,
 
   GVariant *request_body =
     g_variant_new (REQUEST_TYPE_STRING, relative_timestamp, absolute_timestamp,
-                   image_version, &singulars, &aggregates, &sequences);
+                   image_version, site_id, &singulars, &aggregates, &sequences);
 
   g_variant_ref_sink (request_body);
   GVariant *little_endian_request_body =

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -79,7 +79,7 @@
 #define EVENT_VALUE_ARRAY_TYPE G_VARIANT_TYPE (EVENT_VALUE_ARRAY_TYPE_STRING)
 
 #define SINGULAR_TYPE_STRING "(aysxmv)"
-#define AGGREGATE_TYPE_STRING "(uayxxmv)"
+#define AGGREGATE_TYPE_STRING "(ayssxmv)"
 #define SEQUENCE_TYPE_STRING "(uay" EVENT_VALUE_ARRAY_TYPE_STRING ")"
 
 #define SINGULAR_TYPE G_VARIANT_TYPE (SINGULAR_TYPE_STRING)
@@ -1713,35 +1713,6 @@ emer_daemon_record_aggregate_event (EmerDaemon *self,
                                     gboolean    has_payload,
                                     GVariant   *payload)
 {
-  EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
-
-  if (!priv->recording_enabled)
-    return;
-
-  if (!is_uuid (event_id))
-    {
-      g_warning ("Event ID must be a UUID represented as an array of %"
-                 G_GSIZE_FORMAT " bytes. Dropping event.", UUID_LENGTH);
-      return;
-    }
-
-  gint64 boot_offset;
-  GError *error = NULL;
-  if (!emer_persistent_cache_get_boot_time_offset (priv->persistent_cache,
-                                                   &boot_offset, &error))
-    {
-      g_warning ("Unable to correct event's relative timestamp. Dropping "
-                 "event. Error: %s.", error->message);
-      g_error_free (error);
-      return;
-    }
-  relative_timestamp += boot_offset;
-
-  GVariant *nullable_payload = get_nullable_payload (payload, has_payload);
-  GVariant *aggregate =
-    g_variant_new ("(u@ayxxmv)", user_id, event_id, num_events,
-                   relative_timestamp, nullable_payload);
-  buffer_event (self, aggregate);
 }
 
 void

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -49,7 +49,7 @@
 /*
  * The version of this client's network protocol.
  */
-#define CLIENT_VERSION_NUMBER "2"
+#define CLIENT_VERSION_NUMBER "3"
 
 /*
  * The minimum number of seconds to wait before attempting the first retry of a

--- a/daemon/emer-daemon.h
+++ b/daemon/emer-daemon.h
@@ -86,7 +86,6 @@ EmerDaemon *             emer_daemon_new_full                 (GRand            
                                                                gulong                   max_bytes_buffered);
 
 void                     emer_daemon_record_singular_event    (EmerDaemon              *self,
-                                                               guint32                  user_id,
                                                                GVariant                *event_id,
                                                                gint64                   relative_timestamp,
                                                                gboolean                 has_payload,

--- a/daemon/emer-image-id-provider.c
+++ b/daemon/emer-image-id-provider.c
@@ -95,3 +95,16 @@ emer_image_id_provider_get_version (void)
 
   return image_version;
 }
+
+/*
+ * emer_image_id_provider_get_os_version:
+ *
+ * Retrieves the OS version string from system.
+ *
+ * Returns: a string of the OS version.
+ */
+gchar *
+emer_image_id_provider_get_os_version(void)
+{
+  return g_get_os_info(G_OS_INFO_KEY_VERSION);
+}

--- a/daemon/emer-image-id-provider.c
+++ b/daemon/emer-image-id-provider.c
@@ -1,0 +1,97 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2021 Endless OS Foundation LLC. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "emer-image-id-provider.h"
+#include <glib.h>
+#include <sys/xattr.h>
+
+/*
+ * This is a string such as "eos-eos3.1-amd64-amd64.170115-071322.base" which is
+ * saved in an attribute on the root filesystem by the image builder, and allows
+ * us to tell the channel that the OS was installed by (eg download, OEM
+ * pre-install, Endless hardware, USB stick, etc) and which version was
+ * installed. The payload is a single string containing this image ID,
+ * if present.
+ */
+
+#define EOS_IMAGE_VERSION_EVENT "6b1c1cfc-bc36-438c-0647-dacd5878f2b3"
+
+#define EOS_IMAGE_VERSION_XATTR "user.eos-image-version"
+#define EOS_IMAGE_VERSION_PATH "/sysroot"
+#define EOS_IMAGE_VERSION_ALT_PATH "/"
+
+static gchar *
+get_image_version_for_path (const gchar *path)
+{
+  ssize_t xattr_size;
+  g_autofree gchar *image_version = NULL;
+
+  xattr_size = getxattr (path, EOS_IMAGE_VERSION_XATTR, NULL, 0);
+
+  if (xattr_size < 0 || xattr_size > SSIZE_MAX - 1)
+    return NULL;
+
+  image_version = g_malloc0 (xattr_size + 1);
+
+  xattr_size = getxattr (path, EOS_IMAGE_VERSION_XATTR,
+                         image_version, xattr_size);
+
+  /* this check is primarily for ERANGE, in case the attribute size has
+   * changed from the first call to this one */
+  if (xattr_size < 0)
+    {
+      g_warning ("Error when getting 'eos-image-version' from %s: %s", path,
+                 strerror (errno));
+      return NULL;
+    }
+
+  /* shouldn't happen, but if the filesystem is modified or corrupted, we
+   * don't want to cause assertion errors / D-Bus disconnects with invalid
+   * UTF-8 strings */
+  if (!g_utf8_validate (image_version, xattr_size, NULL))
+    {
+      g_warning ("Invalid UTF-8 when getting 'eos-image-version' from %s",
+                 path);
+      return NULL;
+    }
+
+  return g_steal_pointer (&image_version);
+}
+
+/*
+ * emer_image_id_provider_get_version:
+ *
+ * Retrieves the image version string saved by the image builder from the root
+ * filesystem.
+ *
+ * Returns: a string of the image version.
+ */
+gchar *
+emer_image_id_provider_get_version (void)
+{
+  gchar *image_version = get_image_version_for_path (EOS_IMAGE_VERSION_PATH);
+
+  if (image_version == NULL)
+    image_version = get_image_version_for_path (EOS_IMAGE_VERSION_ALT_PATH);
+
+  return image_version;
+}

--- a/daemon/emer-image-id-provider.h
+++ b/daemon/emer-image-id-provider.h
@@ -1,0 +1,34 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2021 Endless OS Foundation LLC. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EMER_IMAGE_ID_PROVIDER_H
+#define EMER_IMAGE_ID_PROVIDER_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+gchar *emer_image_id_provider_get_version (void);
+
+G_END_DECLS
+
+#endif /* EMER_IMAGE_ID_PROVIDER_H */

--- a/daemon/emer-image-id-provider.h
+++ b/daemon/emer-image-id-provider.h
@@ -29,6 +29,8 @@ G_BEGIN_DECLS
 
 gchar *emer_image_id_provider_get_version (void);
 
+gchar *emer_image_id_provider_get_os_version(void);
+
 G_END_DECLS
 
 #endif /* EMER_IMAGE_ID_PROVIDER_H */

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -48,8 +48,8 @@ on_record_singular_event (EmerEventRecorderServer *server,
                           GVariant                *payload,
                           EmerDaemon              *daemon)
 {
-  emer_daemon_record_singular_event (daemon, user_id, event_id,
-                                     relative_timestamp, has_payload, payload);
+  emer_daemon_record_singular_event (daemon, event_id, relative_timestamp,
+                                     has_payload, payload);
   emer_event_recorder_server_complete_record_singular_event (server,
                                                              invocation);
   return TRUE;

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -80,7 +80,7 @@ G_DEFINE_TYPE_WITH_CODE (EmerPersistentCache, emer_persistent_cache, G_TYPE_OBJE
  * they will be removed, and the file in which the version number is stored
  * will be updated.
  */
-#define CURRENT_CACHE_VERSION 4
+#define CURRENT_CACHE_VERSION 5
 
 /*
  * The expected size in bytes of the file located at SYSTEM_BOOT_ID_FILE.

--- a/daemon/emer-site-id-provider.c
+++ b/daemon/emer-site-id-provider.c
@@ -1,0 +1,86 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2021 Endless OS Foundation LLC. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "emer-site-id-provider.h"
+#include <glib.h>
+
+/*
+ * Recorded from location.conf. The auxiliary payload is a dictionary of string
+ * keys (such as facility, city and state) to the values provided in the
+ * location.conf file. The intention is to allow an operator to provide an
+ * optional human-readable label for the location of the system, which can be
+ * used when preparing reports or visualisations of the metrics data.
+ */
+
+#define LOCATION_CONF_FILE SYSCONFDIR "/metrics/location.conf"
+#define LOCATION_LABEL_GROUP "Label"
+
+static GVariant *
+emer_read_location_label (GKeyFile *kf)
+{
+  g_auto (GStrv) keys = g_key_file_get_keys (kf, LOCATION_LABEL_GROUP, NULL, NULL);
+  if (keys == NULL || *keys == NULL)
+    return NULL;
+
+  g_auto (GVariantBuilder) builder = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_ARRAY);
+  gboolean seen_nonempty_value = FALSE;
+  for (GStrv cur = keys; *cur != NULL; cur++)
+    {
+      const gchar *key = *cur;
+      g_autofree gchar *val = g_key_file_get_string (kf, LOCATION_LABEL_GROUP, key, NULL);
+
+      if (val == NULL || *val == '\0')
+        continue;
+
+      seen_nonempty_value = TRUE;
+      g_variant_builder_add (&builder, "{ss}", key, val);
+    }
+
+  if (!seen_nonempty_value)
+    return NULL;
+
+  return g_variant_builder_end (&builder);
+}
+
+/*
+ * emer_site_id_provider_get_id:
+ *
+ * Retrieves the site information provided by Metrics.
+ *
+ * Returns: a pointer of GVariant saving the site information in an array of
+ * dictionary format.
+ */
+GVariant *
+emer_site_id_provider_get_id (void)
+{
+  g_autoptr (GError) err = NULL;
+  g_autoptr (GKeyFile) kf = g_key_file_new ();
+
+  if (!g_key_file_load_from_file (kf, LOCATION_CONF_FILE, G_KEY_FILE_NONE, &err))
+    {
+      g_warning ("Failed to load " LOCATION_CONF_FILE ", unable to record location label: %s",
+                 err->message);
+      return NULL;
+    }
+
+  return emer_read_location_label(kf);
+}

--- a/daemon/emer-site-id-provider.h
+++ b/daemon/emer-site-id-provider.h
@@ -1,0 +1,34 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2021 Endless OS Foundation LLC. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EMER_SITE_ID_PROVIDER_H
+#define EMER_SITE_ID_PROVIDER_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+GVariant *emer_site_id_provider_get_id (void);
+
+G_END_DECLS
+
+#endif /* EMER_SITE_ID_PROVIDER_H */

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -72,6 +72,7 @@ tests_daemon_test_daemon_dbusdaemon_SOURCES = \
 	daemon/emer-boot-id-provider.c daemon/emer-boot-id-provider.h \
 	tests/daemon/mock-cache-size-provider.c daemon/emer-cache-size-provider.h \
 	daemon/emer-gzip.c daemon/emer-gzip.h \
+	tests/daemon/mock-image-id-provider.c tests/daemon/mock-image-id-provider.h \
 	tests/daemon/mock-machine-id-provider.c daemon/emer-machine-id-provider.h \
 	tests/daemon/mock-network-send-provider.c \
 	daemon/emer-network-send-provider.h \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -80,6 +80,7 @@ tests_daemon_test_daemon_dbusdaemon_SOURCES = \
 	tests/daemon/mock-permissions-provider.h \
 	daemon/emer-permissions-provider.h \
 	tests/daemon/mock-persistent-cache.c tests/daemon/mock-persistent-cache.h \
+	tests/daemon/mock-site-id-provider.c daemon/emer-site-id-provider.h \
 	daemon/emer-types.c daemon/emer-types.h \
 	$(NULL)
 tests_daemon_test_daemon_dbusdaemon_CPPFLAGS = $(DAEMON_TEST_FLAGS)

--- a/tests/daemon/mock-image-id-provider.c
+++ b/tests/daemon/mock-image-id-provider.c
@@ -38,3 +38,9 @@ emer_image_id_provider_get_version (void)
 {
   return g_strdup (IMAGE_VERSION);
 }
+
+gchar *
+emer_image_id_provider_get_os_version(void)
+{
+  return g_strdup (OS_VERSION);
+}

--- a/tests/daemon/mock-image-id-provider.c
+++ b/tests/daemon/mock-image-id-provider.c
@@ -1,0 +1,40 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2021 Endless OS Foundation LLC. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "mock-image-id-provider.h"
+#include <glib.h>
+#include <string.h>
+
+/*
+ * Recorded once at startup to report the image ID. This is a string such as
+ * "eos-eos3.1-amd64-amd64.170115-071322.base" which is saved in an attribute
+ * on the root filesystem by the image builder, and allows us to tell the
+ * channel that the OS was installed by (eg download, OEM pre-install, Endless
+ * hardware, USB stick, etc) and which version was installed. The payload
+ * is a single string containing this image ID, if present.
+ */
+
+gchar *
+emer_image_id_provider_get_version (void)
+{
+  return g_strdup (IMAGE_VERSION);
+}

--- a/tests/daemon/mock-image-id-provider.h
+++ b/tests/daemon/mock-image-id-provider.h
@@ -28,8 +28,11 @@
 G_BEGIN_DECLS
 
 #define IMAGE_VERSION	"eos-eos3.1-amd64-amd64.170115-071322.base"
+#define OS_VERSION	"3.1.0"
 
 gchar *emer_image_id_provider_get_version (void);
+
+gchar *emer_image_id_provider_get_os_version(void);
 
 G_END_DECLS
 

--- a/tests/daemon/mock-image-id-provider.h
+++ b/tests/daemon/mock-image-id-provider.h
@@ -1,0 +1,36 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2021 Endless OS Foundation LLC. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EMER_IMAGE_ID_PROVIDER_H
+#define EMER_IMAGE_ID_PROVIDER_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define IMAGE_VERSION	"eos-eos3.1-amd64-amd64.170115-071322.base"
+
+gchar *emer_image_id_provider_get_version (void);
+
+G_END_DECLS
+
+#endif /* EMER_IMAGE_ID_PROVIDER_H */

--- a/tests/daemon/mock-site-id-provider.c
+++ b/tests/daemon/mock-site-id-provider.c
@@ -1,0 +1,41 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2021 Endless OS Foundation LLC. */
+
+/*
+ * This file is part of eos-event-recorder-daemon.
+ *
+ * eos-event-recorder-daemon is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-event-recorder-daemon is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-event-recorder-daemon.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "emer-site-id-provider.h"
+#include <glib.h>
+
+static GVariant *
+emer_read_location_label (void)
+{
+  g_auto (GVariantBuilder) builder = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_ARRAY);
+
+  g_variant_builder_add (&builder, "{ss}", "id", "myid");
+  g_variant_builder_add (&builder, "{ss}", "country", "Earth");
+
+  return g_variant_builder_end (&builder);
+}
+
+GVariant *
+emer_site_id_provider_get_id (void)
+{
+  return emer_read_location_label();
+}

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -42,6 +42,7 @@
 #include "emer-permissions-provider.h"
 #include "emer-persistent-cache.h"
 #include "emer-types.h"
+#include "mock-image-id-provider.h"
 #include "mock-permissions-provider.h"
 #include "mock-persistent-cache.h"
 #include "shared/metrics-util.h"
@@ -663,7 +664,7 @@ get_events_from_request (GByteArray    *request,
   g_free (expected_request_path);
 
   const GVariantType *REQUEST_FORMAT =
-    G_VARIANT_TYPE ("(xxa(uayxmv)a(uayxxmv)a(uaya(xmv)))");
+    G_VARIANT_TYPE ("(xxsa(uayxmv)a(uayxxmv)a(uaya(xmv)))");
   GVariant *request_variant =
     g_variant_new_from_bytes (REQUEST_FORMAT, request_bytes, FALSE);
 
@@ -677,16 +678,19 @@ get_events_from_request (GByteArray    *request,
   g_variant_unref (request_variant);
 
   gint64 client_relative_time, client_absolute_time;
+  const gchar *image_version;
   g_variant_get (native_endian_request,
-                 "(xxa(uayxmv)a(uayxxmv)a(uaya(xmv)))",
-                 &client_relative_time, &client_absolute_time,
-		 singular_iterator, aggregate_iterator, sequence_iterator);
+                 "(xx&sa(uayxmv)a(uayxxmv)a(uaya(xmv)))",
+                 &client_relative_time, &client_absolute_time, &image_version,
+                 singular_iterator, aggregate_iterator, sequence_iterator);
 
   g_assert_cmpint (client_relative_time, >=, fixture->relative_time);
   g_assert_cmpint (client_relative_time, <=, curr_relative_time);
 
   g_assert_cmpint (client_absolute_time, >=, fixture->absolute_time);
   g_assert_cmpint (client_absolute_time, <=, curr_absolute_time);
+
+  g_assert_cmpstr (image_version, ==, IMAGE_VERSION);
 
   g_variant_unref (native_endian_request);
 }

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -530,10 +530,8 @@ static void
 assert_aggregate_matches_variant (GVariant *actual_variant,
                                   GVariant *expected_auxiliary_payload)
 {
-  GVariant *expected_variant =
-    g_variant_new ("(u@ayxxmv)", USER_ID, make_event_id_variant (),
-                   NUM_EVENTS, OFFSET_TIMESTAMP, expected_auxiliary_payload);
-  assert_variants_equal (actual_variant, expected_variant);
+  /* Not defined yet */
+  g_assert_null (NULL);
 }
 
 static void
@@ -639,7 +637,7 @@ get_events_from_request (GByteArray    *request,
   g_free (expected_request_path);
 
   const GVariantType *REQUEST_FORMAT =
-    G_VARIANT_TYPE ("(xxsa{ss}ya(aysxmv)a(uayxxmv))");
+    G_VARIANT_TYPE ("(xxsa{ss}ya(aysxmv)a(ayssxmv))");
   GVariant *request_variant =
     g_variant_new_from_bytes (REQUEST_FORMAT, request_bytes, FALSE);
 
@@ -657,7 +655,7 @@ get_events_from_request (GByteArray    *request,
   GVariant *site_id;
   guint8 boot_type;
   g_variant_get (native_endian_request,
-                 "(xx&s@a{ss}ya(aysxmv)a(uayxxmv))",
+                 "(xx&s@a{ss}ya(aysxmv)a(ayssxmv))",
                  &client_relative_time, &client_absolute_time, &image_version,
                  &site_id, &boot_type, singular_iterator, aggregate_iterator);
 
@@ -744,11 +742,17 @@ assert_aggregates_received (GByteArray *request,
   g_assert_cmpuint (g_variant_iter_n_children (singular_iterator), ==, 0u);
   g_variant_iter_free (singular_iterator);
 
-  g_assert_cmpuint (g_variant_iter_n_children (aggregate_iterator), ==, 2u);
-  assert_aggregate_matches_next_value (aggregate_iterator,
-                                       NULL /* auxiliary_payload */);
-  assert_aggregate_matches_next_value (aggregate_iterator,
+  /* The aggregate event has not defined yet. So, the array is empty right now.
+   * Will restore/re-define the test plan here in the future.
+   */
+  g_assert_cmpuint (g_variant_iter_n_children (aggregate_iterator), ==, 0u);
+  if (g_variant_iter_n_children (aggregate_iterator) > 0)
+    {
+      assert_aggregate_matches_next_value (aggregate_iterator,
+                                           NULL /* auxiliary_payload */);
+      assert_aggregate_matches_next_value (aggregate_iterator,
                                        make_auxiliary_payload ());
+    }
   g_variant_iter_free (aggregate_iterator);
 }
 

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -664,7 +664,7 @@ get_events_from_request (GByteArray    *request,
   g_free (expected_request_path);
 
   const GVariantType *REQUEST_FORMAT =
-    G_VARIANT_TYPE ("(xxsa(uayxmv)a(uayxxmv)a(uaya(xmv)))");
+    G_VARIANT_TYPE ("(xxsa{ss}a(uayxmv)a(uayxxmv)a(uaya(xmv)))");
   GVariant *request_variant =
     g_variant_new_from_bytes (REQUEST_FORMAT, request_bytes, FALSE);
 
@@ -679,10 +679,11 @@ get_events_from_request (GByteArray    *request,
 
   gint64 client_relative_time, client_absolute_time;
   const gchar *image_version;
+  GVariant *site_id;
   g_variant_get (native_endian_request,
-                 "(xx&sa(uayxmv)a(uayxxmv)a(uaya(xmv)))",
+                 "(xx&s@a{ss}a(uayxmv)a(uayxxmv)a(uaya(xmv)))",
                  &client_relative_time, &client_absolute_time, &image_version,
-                 singular_iterator, aggregate_iterator, sequence_iterator);
+                 &site_id, singular_iterator, aggregate_iterator, sequence_iterator);
 
   g_assert_cmpint (client_relative_time, >=, fixture->relative_time);
   g_assert_cmpint (client_relative_time, <=, curr_relative_time);
@@ -691,6 +692,14 @@ get_events_from_request (GByteArray    *request,
   g_assert_cmpint (client_absolute_time, <=, curr_absolute_time);
 
   g_assert_cmpstr (image_version, ==, IMAGE_VERSION);
+
+  const gchar *site_value;
+  g_assert_cmpint (g_variant_n_children (site_id), ==, 2);
+  g_variant_lookup (site_id, "id", "&s", &site_value);
+  g_assert_cmpstr (site_value, ==, "myid");
+  g_variant_lookup (site_id, "country", "&s", &site_value);
+  g_assert_cmpstr (site_value, ==, "Earth");
+  g_variant_unref (site_id);
 
   g_variant_unref (native_endian_request);
 }

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -631,7 +631,7 @@ get_events_from_request (GByteArray    *request,
 
   gchar *checksum =
     g_compute_checksum_for_bytes (G_CHECKSUM_SHA512, request_bytes);
-  gchar *expected_request_path = g_build_filename ("/2/", checksum, NULL);
+  gchar *expected_request_path = g_build_filename ("/3/", checksum, NULL);
   g_free (checksum);
   g_assert_cmpstr (fixture->request_path, ==, expected_request_path);
   g_free (expected_request_path);

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -664,7 +664,7 @@ get_events_from_request (GByteArray    *request,
   g_free (expected_request_path);
 
   const GVariantType *REQUEST_FORMAT =
-    G_VARIANT_TYPE ("(xxsa{ss}a(uayxmv)a(uayxxmv)a(uaya(xmv)))");
+    G_VARIANT_TYPE ("(xxsa{ss}ya(uayxmv)a(uayxxmv)a(uaya(xmv)))");
   GVariant *request_variant =
     g_variant_new_from_bytes (REQUEST_FORMAT, request_bytes, FALSE);
 
@@ -680,10 +680,11 @@ get_events_from_request (GByteArray    *request,
   gint64 client_relative_time, client_absolute_time;
   const gchar *image_version;
   GVariant *site_id;
+  guint8 boot_type;
   g_variant_get (native_endian_request,
-                 "(xx&s@a{ss}a(uayxmv)a(uayxxmv)a(uaya(xmv)))",
+                 "(xx&s@a{ss}ya(uayxmv)a(uayxxmv)a(uaya(xmv)))",
                  &client_relative_time, &client_absolute_time, &image_version,
-                 &site_id, singular_iterator, aggregate_iterator, sequence_iterator);
+                 &site_id, &boot_type, singular_iterator, aggregate_iterator, sequence_iterator);
 
   g_assert_cmpint (client_relative_time, >=, fixture->relative_time);
   g_assert_cmpint (client_relative_time, <=, curr_relative_time);


### PR DESCRIPTION
* Remove the machine ID and send number from the payload
* Add the image ID and dictionary of location site ID data to the payload
* Add the boot type to the payload
* Remove the unix user ID field from each singular event payload
* Add current OS version into singular event payload
* Empty the array of aggregate events and update its string format
* Drop sequence events' actions by making it as no-operation

https://phabricator.endlessm.com/T32144