### PR TITLE
daemon: Stop creating tracking-id

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1502,23 +1502,6 @@ emer_daemon_get_tracking_id (EmerDaemon *self)
   return NULL;
 }
 
-gboolean
-emer_daemon_reset_tracking_id (EmerDaemon  *self,
-                               GError     **error)
-{
-  EmerDaemonPrivate *priv = emer_daemon_get_instance_private (self);
-
-  /* Clear all events in the persistent cache and in the memory buffers, we
-   * want to start from scratch here with a new machine ID. */
-  g_ptr_array_set_size (priv->variant_array, 0);
-  priv->num_bytes_buffered = 0;
-
-  if (!emer_persistent_cache_remove_all (priv->persistent_cache, error))
-    return FALSE;
-
-  return emer_machine_id_provider_reset_tracking_id (priv->machine_id_provider, error);
-}
-
 /*
  * emer_daemon_new_full:
  * @rand: (allow-none): random number generator to use for randomized

--- a/daemon/emer-daemon.h
+++ b/daemon/emer-daemon.h
@@ -111,8 +111,6 @@ void                     emer_daemon_upload_events            (EmerDaemon       
 gboolean                 emer_daemon_upload_events_finish     (EmerDaemon              *self,
                                                                GAsyncResult            *result,
                                                                GError                 **error);
-gboolean                 emer_daemon_reset_tracking_id        (EmerDaemon              *self,
-                                                               GError                 **error);
 gchar *                  emer_daemon_get_tracking_id          (EmerDaemon              *self);
 
 EmerPermissionsProvider *emer_daemon_get_permissions_provider (EmerDaemon              *self);

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -311,24 +311,9 @@ read_machine_id (EmerMachineIdProvider *self, gchar **machine_id_hex)
     {
       if (g_error_matches (local_error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
         {
-          g_debug ("Tracking id file %s does not exist hence creating one.",
+          g_debug ("Tracking id file %s does not exist.",
                    priv->tracking_id_path);
           g_clear_error (&local_error);
-
-          if (!write_tracking_id_file (priv->tracking_id_path, &local_error))
-            {
-              g_message ("Failed to initialize tracking ID at %s: %s.",
-                         priv->tracking_id_path,
-                         local_error->message);
-              return FALSE;
-            }
-	  else if (!read_one_machine_id (priv->tracking_id_path, machine_id_hex, id, &local_error))
-            {
-              g_message ("Failed to read tracking id %s: %s",
-                         priv->tracking_id_path,
-                         local_error->message);
-              return FALSE;
-            }
         }
       else if (g_error_matches (local_error,
                                 EMER_ERROR,
@@ -337,14 +322,13 @@ read_machine_id (EmerMachineIdProvider *self, gchar **machine_id_hex)
           g_message ("Failed to read tracking id %s: %s",
                      priv->tracking_id_path,
                      local_error->message);
-          return FALSE;
         }
       else
         {
           g_message ("Error occured while reading tracking id at %s: %s",
                      priv->tracking_id_path, local_error->message);
-          return FALSE;
         }
+      return FALSE;
     }
 
   uuid_copy (priv->id, id);

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -288,11 +288,6 @@ on_bus_acquired (GDBusConnection *system_bus,
 {
   EmerDaemon *daemon = EMER_DAEMON (user_data);
   EmerEventRecorderServer *server = emer_event_recorder_server_skeleton_new ();
-  g_autofree gchar *tracking_id = NULL;
-
-  tracking_id = emer_daemon_get_tracking_id (daemon);
-  emer_event_recorder_server_set_tracking_id (server,
-                                              tracking_id != NULL ? tracking_id : "");
 
   g_signal_connect (server, "handle-record-singular-event",
                     G_CALLBACK (on_record_singular_event), daemon);

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -102,28 +102,6 @@ on_set_enabled (EmerEventRecorderServer *server,
   return TRUE;
 }
 
-static gboolean
-on_reset_tracking_id (EmerEventRecorderServer *server,
-                      GDBusMethodInvocation   *invocation,
-                      EmerDaemon              *daemon)
-{
-  g_autoptr(GError) error = NULL;
-  g_autofree gchar *tracking_id = NULL;
-
-  if (!emer_daemon_reset_tracking_id (daemon, &error))
-    {
-      g_dbus_method_invocation_return_gerror (invocation, error);
-      return TRUE;
-    }
-
-  tracking_id = emer_daemon_get_tracking_id (daemon);
-  emer_event_recorder_server_set_tracking_id (server,
-                                              tracking_id != NULL ? tracking_id : "");
-
-  emer_event_recorder_server_complete_reset_tracking_id (server, invocation);
-  return TRUE;
-}
-
 static void
 handle_upload_finished (EmerDaemon       *daemon,
                         GAsyncResult     *result,
@@ -326,8 +304,6 @@ on_bus_acquired (GDBusConnection *system_bus,
                     G_CALLBACK (on_set_enabled), daemon);
   g_signal_connect (server, "handle-upload-events",
                     G_CALLBACK (on_upload_events), daemon);
-  g_signal_connect (server, "handle-reset-tracking-id",
-                    G_CALLBACK (on_reset_tracking_id), daemon);
   g_signal_connect (server, "g-authorize-method",
                     G_CALLBACK (on_authorize_method_check), daemon);
 

--- a/tests/daemon/test-machine-id-provider.c
+++ b/tests/daemon/test-machine-id-provider.c
@@ -116,30 +116,19 @@ teardown (MachineIdTestFixture *fixture,
 // Testing Cases
 
 static void
-test_machine_id_provider_create_tracking_id_if_unavailable (MachineIdTestFixture *fixture,
-                                                            gconstpointer         tdata)
+test_machine_id_provider_have_no_tracking_id_if_unavailable (MachineIdTestFixture *fixture,
+                                                             gconstpointer         tdata)
 {
-  g_autoptr(GError) error = NULL;
-  g_autofree gchar *contents = NULL;
-
   g_assert_false (g_file_test (fixture->tracking_id_file_path, G_FILE_TEST_EXISTS));
 
   g_autoptr(EmerMachineIdProvider) id_provider =
     emer_machine_id_provider_new_full (fixture->tracking_id_file_path);
 
   uuid_t id;
-  // id_provider_get_id will write a new tracking ID, if no ID is found.
-  g_assert (emer_machine_id_provider_get_id (id_provider, NULL, id));
+  // id_provider_get_id will "not" write a new tracking ID, if no ID is found.
+  g_assert_false (emer_machine_id_provider_get_id (id_provider, NULL, id));
 
-  g_assert (g_file_test (fixture->tracking_id_file_path, G_FILE_TEST_EXISTS));
-
-  /* Read the tracking_id_file_path using g_file_get_contents
-   * and check that its size matches what we would normally write to the
-   * file */
-  g_file_get_contents (fixture->tracking_id_file_path, &contents, NULL, &error);
-  g_assert_no_error (error);
-
-  g_assert_cmpint (strlen (contents), ==, strlen (TESTING_TRACKING_ID));
+  g_assert_false (g_file_test (fixture->tracking_id_file_path, G_FILE_TEST_EXISTS));
 }
 
 static void
@@ -242,7 +231,7 @@ main (gint                argc,
                        test_machine_id_provider_read_malformed_tracking_id,
                        WRITE_TRACKING_ID_FILE);
   ADD_CACHE_TEST_FUNC ("/machine-id-provider/create-tracking-id-if-unavailable",
-                       test_machine_id_provider_create_tracking_id_if_unavailable,
+                       test_machine_id_provider_have_no_tracking_id_if_unavailable,
                        DONT_WRITE_TRACKING_ID_FILE);
 #undef ADD_CACHE_TEST_FUNC
   return g_test_run ();


### PR DESCRIPTION
According to new metrics protocol, tracking-id is not used any more.
However, to solve the problem of uploading buffered events from older
EOS version like 3.9 and earlier, we should keep some features of
machine-id-provider, but do not create tracking-id file if it does not
exsits.

https://phabricator.endlessm.com/T32454