### PR TITLE
Tell gdbus-codegen to generate more autocleanups

### DIFF
--- a/daemon/Makefile.am.inc
+++ b/daemon/Makefile.am.inc
@@ -30,6 +30,7 @@ $(daemon_dbus_sources): $(EVENT_RECORDER_SERVER_XML)
 	$(AM_V_GEN)$(GDBUS_CODEGEN) --generate-c-code $(daemon_dbus_name) \
 		--c-namespace Emer \
 		--interface-prefix com.endlessm.Metrics. \
+		--c-generate-autocleanup all \
 		$<
 
 CLEANFILES += $(daemon_dbus_sources)


### PR DESCRIPTION
eos-metrics itself was adjusted to do this, but this daemon only uses
the XML from eos-metrics, and generates its own code.

Without this, g_autoptr(EmtrAggregateTimer) cannot be used.

https://phabricator.endlessm.com/T32203
