### PR TITLE
aggregate-timer-impl: Convert counter to seconds

### DIFF
--- a/daemon/emer-aggregate-timer-impl.c
+++ b/daemon/emer-aggregate-timer-impl.c
@@ -112,12 +112,15 @@ emer_aggregate_timer_impl_store (EmerAggregateTimerImpl  *self,
                                  gint64                   monotonic_time_us,
                                  GError                 **error)
 {
-  gint64 counter;
+  guint32 counter;
+  gint64 difference;
 
   g_return_val_if_fail (EMER_IS_AGGREGATE_TIMER_IMPL (self), FALSE);
   g_return_val_if_fail (date != NULL && *date != '\0', FALSE);
 
-  counter = monotonic_time_us - self->start_monotonic_us;
+  difference = monotonic_time_us - self->start_monotonic_us;
+  counter = CLAMP (difference / G_USEC_PER_SEC, 0, G_MAXUINT32);
+
   return emer_aggregate_tally_store_event (self->tally,
                                            self->unix_user_id,
                                            self->event_id,
@@ -147,11 +150,13 @@ emer_aggregate_timer_impl_stop (EmerAggregateTimerImpl  *self,
   g_autoptr(GError) local_error = NULL;
   g_autofree gchar *month_date = NULL;
   g_autofree gchar *date = NULL;
-  gint64 counter;
+  guint32 counter;
+  gint64 difference;
 
   g_return_val_if_fail (EMER_IS_AGGREGATE_TIMER_IMPL (self), FALSE);
 
-  counter = monotonic_time_us - self->start_monotonic_us;
+  difference = monotonic_time_us - self->start_monotonic_us;
+  counter = CLAMP (difference / G_USEC_PER_SEC, 0, G_MAXUINT32);
 
   date = g_date_time_format (datetime, "%Y-%m-%d");
   emer_aggregate_tally_store_event (self->tally,


### PR DESCRIPTION
EmerAggregateTimerImpl tracks the amount of passed time
using the monotonic clock, which gives us a time counter
in μs. However, our plumbing expects the counter to be
in seconds.

Convert the ellapsed aggregate time from μs to seconds
before storing and sending it.

https://phabricator.endlessm.com/T32203