### PR TITLE
Refcount timers

### DIFF
--- a/daemon/emer-aggregate-timer-impl.c
+++ b/daemon/emer-aggregate-timer-impl.c
@@ -114,7 +114,8 @@ emer_aggregate_timer_impl_new (EmerAggregateTally *tally,
   if (payload)
     g_variant_take_ref (payload);
 
-  cache_key = g_variant_new ("(u@ayvmv)",
+  cache_key = g_variant_new ("(su@ayvmv)",
+                             sender_name,
                              unix_user_id,
                              event_id,
                              aggregate_key,

--- a/daemon/emer-aggregate-timer-impl.c
+++ b/daemon/emer-aggregate-timer-impl.c
@@ -42,6 +42,8 @@ struct _EmerAggregateTimerImpl
   GVariant *payload; /* owned */
   gchar *cache_key_string; /* owned */
   gchar *sender_name; /* owned */
+
+  guint32 run_count;
 };
 
 G_DEFINE_TYPE (EmerAggregateTimerImpl, emer_aggregate_timer_impl, G_TYPE_OBJECT)
@@ -129,6 +131,7 @@ emer_aggregate_timer_impl_new (EmerAggregateTally *tally,
                                                    event_id,
                                                    aggregate_key,
                                                    payload);
+  self->run_count = 1;
 
   return self;
 }
@@ -269,4 +272,22 @@ emer_aggregate_timer_impl_compose_hash_string (const gchar *sender_name,
                              payload ? g_variant_take_ref (payload) : NULL);
 
   return g_variant_print (cache_key, TRUE);
+}
+
+void
+emer_aggregate_timer_impl_push_run_count (EmerAggregateTimerImpl *self)
+{
+  g_return_if_fail (EMER_IS_AGGREGATE_TIMER_IMPL (self));
+
+  self->run_count++;
+}
+
+gboolean
+emer_aggregate_timer_impl_pop_run_count (EmerAggregateTimerImpl *self)
+{
+  g_return_val_if_fail (EMER_IS_AGGREGATE_TIMER_IMPL (self), FALSE);
+
+  self->run_count--;
+
+  return self->run_count == 0;
 }

--- a/daemon/emer-aggregate-timer-impl.c
+++ b/daemon/emer-aggregate-timer-impl.c
@@ -237,30 +237,19 @@ emer_aggregate_timer_impl_stop (EmerAggregateTimerImpl  *self,
 }
 
 const gchar *
+emer_aggregate_timer_impl_get_cache_key (EmerAggregateTimerImpl *self)
+{
+  g_return_val_if_fail (EMER_IS_AGGREGATE_TIMER_IMPL (self), NULL);
+
+  return self->cache_key_string;
+}
+
+const gchar *
 emer_aggregate_timer_impl_get_sender_name (EmerAggregateTimerImpl *self)
 {
   g_return_val_if_fail (EMER_IS_AGGREGATE_TIMER_IMPL (self), NULL);
 
   return self->sender_name;
-}
-
-guint
-emer_aggregate_timer_impl_hash (gconstpointer timer_impl)
-{
-  const EmerAggregateTimerImpl *self = EMER_AGGREGATE_TIMER_IMPL ((gpointer)timer_impl);
-
-  return g_str_hash (self->cache_key_string);
-}
-
-gboolean
-emer_aggregate_timer_impl_equal (gconstpointer a,
-                                 gconstpointer b)
-{
-  const EmerAggregateTimerImpl *timer_impl_a = EMER_AGGREGATE_TIMER_IMPL ((gpointer)a);
-  const EmerAggregateTimerImpl *timer_impl_b = EMER_AGGREGATE_TIMER_IMPL ((gpointer)b);
-
-  return g_str_equal (timer_impl_a->cache_key_string,
-                      timer_impl_b->cache_key_string);
 }
 
 gchar *

--- a/daemon/emer-aggregate-timer-impl.h
+++ b/daemon/emer-aggregate-timer-impl.h
@@ -65,4 +65,11 @@ guint emer_aggregate_timer_impl_hash (gconstpointer timer_impl);
 gboolean emer_aggregate_timer_impl_equal (gconstpointer a,
                                           gconstpointer b);
 
+gchar *
+emer_aggregate_timer_impl_compose_hash_string (const gchar *sender_name,
+                                               guint32      unix_user_id,
+                                               GVariant    *event_id,
+                                               GVariant    *aggregate_key,
+                                               GVariant    *payload);
+
 G_END_DECLS

--- a/daemon/emer-aggregate-timer-impl.h
+++ b/daemon/emer-aggregate-timer-impl.h
@@ -70,4 +70,8 @@ emer_aggregate_timer_impl_compose_hash_string (const gchar *sender_name,
                                                GVariant    *aggregate_key,
                                                GVariant    *payload);
 
+void emer_aggregate_timer_impl_push_run_count (EmerAggregateTimerImpl *self);
+
+gboolean emer_aggregate_timer_impl_pop_run_count (EmerAggregateTimerImpl *self);
+
 G_END_DECLS

--- a/daemon/emer-aggregate-timer-impl.h
+++ b/daemon/emer-aggregate-timer-impl.h
@@ -57,13 +57,11 @@ gboolean emer_aggregate_timer_impl_stop (EmerAggregateTimerImpl  *self,
                                          GDateTime               *datetime,
                                          gint64                   monotonic_time_us,
                                          GError                 **error);
+const gchar *
+emer_aggregate_timer_impl_get_cache_key (EmerAggregateTimerImpl *self);
 
 const gchar *
 emer_aggregate_timer_impl_get_sender_name (EmerAggregateTimerImpl *self);
-
-guint emer_aggregate_timer_impl_hash (gconstpointer timer_impl);
-gboolean emer_aggregate_timer_impl_equal (gconstpointer a,
-                                          gconstpointer b);
 
 gchar *
 emer_aggregate_timer_impl_compose_hash_string (const gchar *sender_name,

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -2020,6 +2020,14 @@ emer_daemon_start_aggregate_timer (EmerDaemon       *self,
       return FALSE;
     }
 
+  nullable_payload = get_nullable_payload (payload, has_payload);
+  timer_hash_string =
+    emer_aggregate_timer_impl_compose_hash_string (sender_name,
+                                                   unix_user_id,
+                                                   event_id,
+                                                   aggregate_key,
+                                                   nullable_payload);
+
   timer_object_path = g_strdup_printf ("/com/endlessm/Metrics/AggregateTimer%lu",
                                        timer_id);
 
@@ -2037,7 +2045,6 @@ emer_daemon_start_aggregate_timer (EmerDaemon       *self,
   // Only increment on success, otherwise we waste ids for nothing
   timer_id++;
 
-  nullable_payload = get_nullable_payload (payload, has_payload);
   timer_impl = emer_aggregate_timer_impl_new (priv->aggregate_tally,
                                               g_object_ref (timer),
                                               sender_name,
@@ -2050,13 +2057,6 @@ emer_daemon_start_aggregate_timer (EmerDaemon       *self,
                           "daemon",
                           g_object_ref (self),
                           g_object_unref);
-
-  timer_hash_string =
-    emer_aggregate_timer_impl_compose_hash_string (sender_name,
-                                                   unix_user_id,
-                                                   event_id,
-                                                   aggregate_key,
-                                                   nullable_payload);
 
   if (g_hash_table_contains (priv->aggregate_timers, timer_hash_string))
     {

--- a/daemon/emer-daemon.h
+++ b/daemon/emer-daemon.h
@@ -117,13 +117,14 @@ gchar *                  emer_daemon_get_tracking_id          (EmerDaemon       
 EmerPermissionsProvider *emer_daemon_get_permissions_provider (EmerDaemon              *self);
 
 gboolean                 emer_daemon_start_aggregate_timer    (EmerDaemon              *self,
-                                                               EmerAggregateTimer      *timer,
+                                                               GDBusConnection         *connection,
                                                                const gchar             *sender_name,
                                                                guint32                  unix_user_id,
                                                                GVariant                *event_id,
                                                                GVariant                *aggregate_key,
                                                                gboolean                 has_payload,
                                                                GVariant                *payload,
+                                                               gchar                  **out_timer_object_path,
                                                                GError                 **error);
 
 G_END_DECLS


### PR DESCRIPTION
Quoting the last commit

```
Instead of failing straight away when there's a running
timer, increase its run-count; and decrease it whenever
StopTimer() is called. When the run count reaches zero,
that's when the timer object is unexported and we save
the aggregated timer into the tally.
```

https://phabricator.endlessm.com/T32671