### PR TITLE
eos-enable-metrics-uploading: Fix sed invocation

### DIFF
--- a/tools/eos-enable-metrics-uploading.in
+++ b/tools/eos-enable-metrics-uploading.in
@@ -35,4 +35,4 @@ case "$1" in
         exit 2
 esac
 
-sed --in-place="s/\(uploading_enabled *= *\).*/\1"$UPLOADING_ENABLED"/" @permissions_file@
+sed --in-place -e "s/\(uploading_enabled *= *\).*/\1"$UPLOADING_ENABLED"/" @permissions_file@


### PR DESCRIPTION
The argument to --in-place is the SUFFIX to use when creating a backup
of each input file. The first positional argument is the script to
execute if no other script has been specified with -e or -f.

So the effect of the previous script was to

- Execute @permissions_file@ (i.e. /etc/metrics/eos-metrics-permissions.conf) as a sed script
- Apply it to standard input (since no other input is specified)
- Back up the 0 input files with the suffix 's/\(uploading_enabled ...'

Fix this by passing the input script with '-e' and not specifying a
SUFFIX for in-place editing.
