### PR TITLE
print-persistent-cache: Show message on success

### DIFF
--- a/tools/print-persistent-cache.c
+++ b/tools/print-persistent-cache.c
@@ -180,6 +180,8 @@ main (gint   argc,
 
   gboolean print_succeeded =
     print_variants_to_file (variants, num_variants, OUTPUT_FILE);
+  if (print_succeeded)
+    g_message ("Saved persistent cache contents to %s", OUTPUT_FILE);
   destroy_variants (variants, num_variants);
 
   return print_succeeded ? EXIT_SUCCESS : EXIT_FAILURE;


### PR DESCRIPTION
I was baffled because it did not, in fact, print the persistent cache as
the name suggested. In fact it saves it to a file.
