### PR TITLE
Define GLib API level macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,9 @@ EMER_SHARED_REQUIRED_MODULES="$GIO_REQUIREMENT \
 AC_SUBST(EMER_REQUIRED_MODULES)
 AC_SUBST(EMER_SHARED_REQUIRED_MODULES)
 
+AC_DEFINE([GLIB_VERSION_MIN_REQUIRED], [GLIB_VERSION_2_64], [Require at least this GLib version])
+AC_DEFINE([GLIB_VERSION_MAX_ALLOWED], [GLIB_VERSION_2_64], [Prevent using GLib API newer than this version])
+
 # Required build tools
 # --------------------
 # Make sure we can create directory hierarchies

--- a/daemon/eins-boottime-source.c
+++ b/daemon/eins-boottime-source.c
@@ -17,6 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "eins-boottime-source.h"
 
 #include <errno.h>

--- a/daemon/emer-aggregate-tally.c
+++ b/daemon/emer-aggregate-tally.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-aggregate-tally.h"
 #include "shared/metrics-util.h"
 

--- a/daemon/emer-aggregate-timer-impl.c
+++ b/daemon/emer-aggregate-timer-impl.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-aggregate-timer-impl.h"
 #include "emer-aggregate-tally.h"
 #include "shared/metrics-util.h"

--- a/daemon/emer-boot-id-provider.c
+++ b/daemon/emer-boot-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-boot-id-provider.h"
 
 #include <string.h>

--- a/daemon/emer-cache-size-provider.c
+++ b/daemon/emer-cache-size-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-cache-size-provider.h"
 
 /*

--- a/daemon/emer-cache-version-provider.c
+++ b/daemon/emer-cache-version-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-cache-version-provider.h"
 
 typedef struct EmerCacheVersionProviderPrivate

--- a/daemon/emer-circular-file.c
+++ b/daemon/emer-circular-file.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-circular-file.h"
 
 #include <gio/gio.h>

--- a/daemon/emer-gzip.c
+++ b/daemon/emer-gzip.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-gzip.h"
 
 #include <gio/gio.h>

--- a/daemon/emer-image-id-provider.c
+++ b/daemon/emer-image-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-image-id-provider.h"
 #include <glib.h>
 #include <sys/xattr.h>

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-machine-id-provider.h"
 #include "emer-types.h"
 

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include <string.h>
 
 #include <gio/gio.h>

--- a/daemon/emer-network-send-provider.c
+++ b/daemon/emer-network-send-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-network-send-provider.h"
 
 typedef struct EmerNetworkSendProviderPrivate

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-permissions-provider.h"
 
 #include <string.h>

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-persistent-cache.h"
 
 #include <errno.h>

--- a/daemon/emer-site-id-provider.c
+++ b/daemon/emer-site-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-site-id-provider.h"
 #include <glib.h>
 

--- a/daemon/emer-types.c
+++ b/daemon/emer-types.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-types.h"
 
 #include <gio/gio.h>

--- a/shared/metrics-util.c
+++ b/shared/metrics-util.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "metrics-util.h"
 
 #include <byteswap.h>

--- a/tests/daemon/mock-cache-size-provider.c
+++ b/tests/daemon/mock-cache-size-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-cache-size-provider.h"
 
 /* This is the default maximum cache size in bytes. */

--- a/tests/daemon/mock-circular-file.c
+++ b/tests/daemon/mock-circular-file.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "mock-circular-file.h"
 
 #include <string.h>

--- a/tests/daemon/mock-image-id-provider.c
+++ b/tests/daemon/mock-image-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "mock-image-id-provider.h"
 #include <glib.h>
 #include <string.h>

--- a/tests/daemon/mock-machine-id-provider.c
+++ b/tests/daemon/mock-machine-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-machine-id-provider.h"
 
 #include <uuid/uuid.h>

--- a/tests/daemon/mock-permissions-provider.c
+++ b/tests/daemon/mock-permissions-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-permissions-provider.h"
 #include "mock-permissions-provider.h"
 

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-persistent-cache.h"
 #include "mock-persistent-cache.h"
 

--- a/tests/daemon/mock-site-id-provider.c
+++ b/tests/daemon/mock-site-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-site-id-provider.h"
 #include <glib.h>
 

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-aggregate-tally.h"
 
 #include "shared/metrics-util.h"

--- a/tests/daemon/test-boot-id-provider.c
+++ b/tests/daemon/test-boot-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-boot-id-provider.h"
 
 #include <uuid/uuid.h>

--- a/tests/daemon/test-cache-size-provider.c
+++ b/tests/daemon/test-cache-size-provider.c
@@ -18,6 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-cache-size-provider.h"
 
 #include <string.h>

--- a/tests/daemon/test-cache-version-provider.c
+++ b/tests/daemon/test-cache-version-provider.c
@@ -18,6 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-cache-version-provider.h"
 
 #include <gio/gio.h>

--- a/tests/daemon/test-circular-file.c
+++ b/tests/daemon/test-circular-file.c
@@ -18,6 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-circular-file.h"
 
 #include <string.h>

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-daemon.h"
 
 #include <signal.h>

--- a/tests/daemon/test-gzip.c
+++ b/tests/daemon/test-gzip.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-gzip.h"
 
 #include <gio/gio.h>

--- a/tests/daemon/test-machine-id-provider.c
+++ b/tests/daemon/test-machine-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-machine-id-provider.h"
 
 #include <string.h>

--- a/tests/daemon/test-network-send-provider.c
+++ b/tests/daemon/test-network-send-provider.c
@@ -18,6 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-network-send-provider.h"
 
 #include <gio/gio.h>

--- a/tests/daemon/test-permissions-provider.c
+++ b/tests/daemon/test-permissions-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-permissions-provider.h"
 
 #include <string.h>

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -18,6 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-persistent-cache.h"
 
 #include <string.h>


### PR DESCRIPTION
Endless OS master now has GLib 2.70. Endless OS 4 has 2.66. Some
functions were deprecated between those two versions:

- g_memdup() is deprecated in favour of g_memdup2()
- g_binding_get_source() is deprecated in favour of
  g_binding_dup_source()

This project builds with fatal warnings by default. As a result this
project no longer builds on Endless OS master.

Because we still have outstanding work to land on the eos4 branch,
rather than fixing these warnings and bumping the minimum GLib version,
instead use GLIB_VERSION_MAX_ALLOWED to suppress these warnings (and
prevent inadvertantly using newer API). In future we can bump this and
fix the warnings.

https://phabricator.endlessm.com/T32967
