### PR TITLE
configure: Don't require --with-default-metrics-server

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,11 +41,10 @@ AM_CFLAGS = @WARN_CFLAGS@
 AM_LDFLAGS = @WARN_LDFLAGS@
 
 # Enable strict compiler flags and install systemd unit files to the specified
-# directory when doing 'make distcheck'. Set a dummy default server URL.
+# directory when doing 'make distcheck'.
 AM_DISTCHECK_CONFIGURE_FLAGS = \
 	--enable-compile-warnings=error \
 	--with-systemdsystemunitdir='$${prefix}/lib/systemd/system' \
-	--with-default-metrics-server=azafea.example \
 	$(NULL)
 if EOS_ENABLE_COVERAGE
 AM_DISTCHECK_CONFIGURE_FLAGS += --enable-coverage --with-coverage-dir=@EOS_COVERAGE_DIR@

--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,9 @@ EMER_SHARED_REQUIRED_MODULES="$GIO_REQUIREMENT \
 AC_SUBST(EMER_REQUIRED_MODULES)
 AC_SUBST(EMER_SHARED_REQUIRED_MODULES)
 
+AC_DEFINE([GLIB_VERSION_MIN_REQUIRED], [GLIB_VERSION_2_64], [Require at least this GLib version])
+AC_DEFINE([GLIB_VERSION_MAX_ALLOWED], [GLIB_VERSION_2_64], [Prevent using GLib API newer than this version])
+
 # Required build tools
 # --------------------
 # Make sure we can create directory hierarchies

--- a/configure.ac
+++ b/configure.ac
@@ -139,7 +139,8 @@ AS_IF([test -f $EVENT_RECORDER_SERVER_XML],
 AC_ARG_WITH([default_metrics_server],
     [AS_HELP_STRING([--with-default-metrics-server=HOSTNAME],[choose default metrics server])],
     [DEFAULT_METRICS_SERVER="\"$withval\""],
-    [AC_MSG_ERROR([You must specify a default metrics server using --with-default-metrics-server])])
+    [DEFAULT_METRICS_SERVER="\"azafea.example\""
+     AC_MSG_WARN([You should specify a default metrics server using --with-default-metrics-server])])
 AC_DEFINE_UNQUOTED([DEFAULT_METRICS_SERVER], [$DEFAULT_METRICS_SERVER], [Default metrics server])
 
 # Required libraries

--- a/daemon/eins-boottime-source.c
+++ b/daemon/eins-boottime-source.c
@@ -17,6 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "eins-boottime-source.h"
 
 #include <errno.h>

--- a/daemon/emer-aggregate-tally.c
+++ b/daemon/emer-aggregate-tally.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-aggregate-tally.h"
 #include "shared/metrics-util.h"
 

--- a/daemon/emer-aggregate-timer-impl.c
+++ b/daemon/emer-aggregate-timer-impl.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-aggregate-timer-impl.h"
 #include "emer-aggregate-tally.h"
 #include "shared/metrics-util.h"

--- a/daemon/emer-boot-id-provider.c
+++ b/daemon/emer-boot-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-boot-id-provider.h"
 
 #include <string.h>

--- a/daemon/emer-cache-size-provider.c
+++ b/daemon/emer-cache-size-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-cache-size-provider.h"
 
 /*

--- a/daemon/emer-cache-version-provider.c
+++ b/daemon/emer-cache-version-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-cache-version-provider.h"
 
 typedef struct EmerCacheVersionProviderPrivate

--- a/daemon/emer-circular-file.c
+++ b/daemon/emer-circular-file.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-circular-file.h"
 
 #include <gio/gio.h>

--- a/daemon/emer-gzip.c
+++ b/daemon/emer-gzip.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-gzip.h"
 
 #include <gio/gio.h>

--- a/daemon/emer-image-id-provider.c
+++ b/daemon/emer-image-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-image-id-provider.h"
 #include <glib.h>
 #include <sys/xattr.h>

--- a/daemon/emer-machine-id-provider.c
+++ b/daemon/emer-machine-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-machine-id-provider.h"
 #include "emer-types.h"
 

--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include <string.h>
 
 #include <gio/gio.h>

--- a/daemon/emer-network-send-provider.c
+++ b/daemon/emer-network-send-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-network-send-provider.h"
 
 typedef struct EmerNetworkSendProviderPrivate

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-permissions-provider.h"
 
 #include <string.h>

--- a/daemon/emer-persistent-cache.c
+++ b/daemon/emer-persistent-cache.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-persistent-cache.h"
 
 #include <errno.h>

--- a/daemon/emer-site-id-provider.c
+++ b/daemon/emer-site-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-site-id-provider.h"
 #include <glib.h>
 

--- a/daemon/emer-types.c
+++ b/daemon/emer-types.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-types.h"
 
 #include <gio/gio.h>

--- a/shared/metrics-util.c
+++ b/shared/metrics-util.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "metrics-util.h"
 
 #include <byteswap.h>

--- a/tests/daemon/mock-cache-size-provider.c
+++ b/tests/daemon/mock-cache-size-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-cache-size-provider.h"
 
 /* This is the default maximum cache size in bytes. */

--- a/tests/daemon/mock-circular-file.c
+++ b/tests/daemon/mock-circular-file.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "mock-circular-file.h"
 
 #include <string.h>

--- a/tests/daemon/mock-image-id-provider.c
+++ b/tests/daemon/mock-image-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "mock-image-id-provider.h"
 #include <glib.h>
 #include <string.h>

--- a/tests/daemon/mock-machine-id-provider.c
+++ b/tests/daemon/mock-machine-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-machine-id-provider.h"
 
 #include <uuid/uuid.h>

--- a/tests/daemon/mock-permissions-provider.c
+++ b/tests/daemon/mock-permissions-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-permissions-provider.h"
 #include "mock-permissions-provider.h"
 

--- a/tests/daemon/mock-persistent-cache.c
+++ b/tests/daemon/mock-persistent-cache.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-persistent-cache.h"
 #include "mock-persistent-cache.h"
 

--- a/tests/daemon/mock-site-id-provider.c
+++ b/tests/daemon/mock-site-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-site-id-provider.h"
 #include <glib.h>
 

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-aggregate-tally.h"
 
 #include "shared/metrics-util.h"

--- a/tests/daemon/test-boot-id-provider.c
+++ b/tests/daemon/test-boot-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-boot-id-provider.h"
 
 #include <uuid/uuid.h>

--- a/tests/daemon/test-cache-size-provider.c
+++ b/tests/daemon/test-cache-size-provider.c
@@ -18,6 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-cache-size-provider.h"
 
 #include <string.h>

--- a/tests/daemon/test-cache-version-provider.c
+++ b/tests/daemon/test-cache-version-provider.c
@@ -18,6 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-cache-version-provider.h"
 
 #include <gio/gio.h>

--- a/tests/daemon/test-circular-file.c
+++ b/tests/daemon/test-circular-file.c
@@ -18,6 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-circular-file.h"
 
 #include <string.h>

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-daemon.h"
 
 #include <signal.h>

--- a/tests/daemon/test-gzip.c
+++ b/tests/daemon/test-gzip.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-gzip.h"
 
 #include <gio/gio.h>

--- a/tests/daemon/test-machine-id-provider.c
+++ b/tests/daemon/test-machine-id-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-machine-id-provider.h"
 
 #include <string.h>

--- a/tests/daemon/test-network-send-provider.c
+++ b/tests/daemon/test-network-send-provider.c
@@ -18,6 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-network-send-provider.h"
 
 #include <gio/gio.h>

--- a/tests/daemon/test-permissions-provider.c
+++ b/tests/daemon/test-permissions-provider.c
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-permissions-provider.h"
 
 #include <string.h>

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -18,6 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "emer-persistent-cache.h"
 
 #include <string.h>


### PR DESCRIPTION
2fa2c669ed5e313491f23579ea8a9af0791a0d48 (in
https://github.com/endlessm/eos-event-recorder-daemon/pull/249)
introduced the ability to configure the metrics server URL at build
time, and removed the default being to submit to the Endless server, to
ensure that development builds and builds for other distros don't
accidentally send metrics to Endless.

At the time, --with-default-metrics-server was made mandatory, with the
argument that people don't look at warnings from configure scripts.
While true, I think the other downsides outweigh this. It is desirable
that a project uses a standard build system and can be successfully
built and tested out of the box. Every time I clone this repo, I am
annoyed that I have to set this flag, and have to think about what value
to use during development. We had to hardcode a dummy value in the build
system for 'make distcheck' to pass, and another value in our Jenkins
configuration to allow it to configure the project in the first place in
order to run 'make distcheck'.

Now that I find myself wanting to switch this project to Meson, the
Jenkins stuff is an active impediment, because Meson doesn't accept the
same configuration arguments, so I would need to update the Jenkins
config in lockstep and find some way to maintain build support for older
OS branches.

Instead, let's define an obviously-dummy value as the default, the same
one as used by 'make distcheck', and emit a warning. 'azafea.example'
will never resolve and is obviously a placeholder, so you'll notice soon
enough in the journal that no metrics are being submitted (and they'll
be buffered on disk).

Includes patch from #270 to fix the build.

https://phabricator.endlessm.com/T32969