### PR TITLE
Fix bugs and improve robustness, schema & test coverage of aggregate tally

### DIFF
--- a/daemon/emer-aggregate-tally.c
+++ b/daemon/emer-aggregate-tally.c
@@ -314,7 +314,7 @@ emer_aggregate_tally_constructed (GObject *object)
   g_assert (self->persistent_cache_directory != NULL);
   ensure_folder_exists (self, self->persistent_cache_directory, NULL);
   path = g_build_filename (self->persistent_cache_directory,
-                           "aggregate-events.db",
+                           "metrics.db",
                            NULL);
   if (!emer_aggregate_tally_init_db (self, path, &error))
     g_error ("Failed to initialize %s: %s", path, error->message);

--- a/daemon/emer-aggregate-tally.c
+++ b/daemon/emer-aggregate-tally.c
@@ -320,7 +320,6 @@ emer_aggregate_tally_store_event (EmerAggregateTally  *self,
                                   GVariant            *payload,
                                   guint32              counter,
                                   GDateTime           *datetime,
-                                  gint64               monotonic_time_us,
                                   GError             **error)
 {
   g_return_val_if_fail (g_variant_is_of_type (aggregate_key, G_VARIANT_TYPE_VARIANT), FALSE);

--- a/daemon/emer-aggregate-tally.c
+++ b/daemon/emer-aggregate-tally.c
@@ -432,7 +432,7 @@ emer_aggregate_tally_iter_before (EmerAggregateTally *self,
   const char *SELECT_SQL =
     "SELECT id, event_id, unix_user_id, "
     "       aggregate_key, "
-    "       payload, counter "
+    "       payload, counter, date "
     "FROM tally "
     "WHERE length(date) = ? AND date < ?;";
 
@@ -456,6 +456,7 @@ emer_aggregate_tally_iter_before (EmerAggregateTally *self,
       g_autoptr(GVariant) aggregate_key = column_to_variant (stmt, 3);
       g_autoptr(GVariant) payload = column_to_variant (stmt, 4);
       guint32 counter = column_to_uint32 (stmt, 5);
+      const char *event_date = (const char *) sqlite3_column_text (stmt, 6);
       uuid_t event_id = { 0 };
       EmerTallyIterResult result;
 
@@ -463,7 +464,7 @@ emer_aggregate_tally_iter_before (EmerAggregateTally *self,
 
       result = func (unix_user_id, event_id,
                      aggregate_key, payload,
-                     counter, date, user_data);
+                     counter, event_date, user_data);
 
       if (flags & EMER_TALLY_ITER_FLAG_DELETE)
         {

--- a/daemon/emer-aggregate-tally.c
+++ b/daemon/emer-aggregate-tally.c
@@ -205,20 +205,28 @@ emer_aggregate_tally_constructed (GObject *object)
   /* Magic number is "emer" in ASCII */
   tally_exec_or_die (self, "PRAGMA application_id = 0x656d6572");
   tally_exec_or_die (self, "PRAGMA user_version = 1");
-  tally_exec_or_die (self, "CREATE TABLE IF NOT EXISTS tally (id INTEGER PRIMARY KEY ASC,"
-                           "                                  date TEXT NOT NULL,"
-                           "                                  event_id TEXT NOT NULL,"
-                           "                                  unix_user_id INT NOT NULL,"
-                           "                                  aggregate_key_type TEXT NOT NULL,"
-                           "                                  aggregate_key BLOB NOT NULL,"
-                           "                                  payload_type TEXT,"
-                           "                                  payload BLOB,"
-                           "                                  counter INT NOT NULL);");
+  tally_exec_or_die (self, "CREATE TABLE IF NOT EXISTS tally (\n"
+                           "    id INTEGER PRIMARY KEY ASC,\n"
+                           "    date TEXT NOT NULL,\n"
+                           "    event_id TEXT NOT NULL,\n"
+                           "    unix_user_id INT NOT NULL,\n"
+                           "    aggregate_key_type TEXT NOT NULL,\n"
+                           "    aggregate_key BLOB NOT NULL,\n"
+                           "    payload_type TEXT,\n"
+                           "    payload BLOB,\n"
+                           "    counter INT NOT NULL\n"
+                           ")");
   tally_exec_or_die (self,
                      "CREATE UNIQUE INDEX IF NOT EXISTS "
-                     "ix_tally_unique_fields ON tally (date, event_id, unix_user_id, "
-                     "                                 aggregate_key_type, aggregate_key, "
-                     "                                 payload_type, payload)");
+                     "ix_tally_unique_fields ON tally (\n"
+                     "    date,\n"
+                     "    event_id,\n"
+                     "    unix_user_id,\n"
+                     "    aggregate_key_type,\n"
+                     "    aggregate_key,\n"
+                     "    payload_type,\n"
+                     "    payload\n"
+                     ")");
 }
 
 static void

--- a/daemon/emer-aggregate-tally.c
+++ b/daemon/emer-aggregate-tally.c
@@ -438,21 +438,18 @@ emer_aggregate_tally_iter_before (EmerAggregateTally *self,
     "       aggregate_key, "
     "       payload, counter, date "
     "FROM tally "
-    "WHERE length(date) = ? AND date < ?;";
+    "WHERE length(date) = length(?1) AND date < ?1;";
 
   g_autoptr(GArray) rows_to_delete = NULL;
   g_autofree gchar *date = NULL;
   sqlite3_stmt *stmt = NULL;
-  int date_text_len;
   int ret;
 
   date = format_datetime_for_tally_type (datetime, tally_type);
-  date_text_len = g_utf8_strlen (date, -1);
   rows_to_delete = g_array_new (FALSE, FALSE, sizeof (sqlite3_int64));
 
   CHECK (sqlite3_prepare_v2 (self->db, SELECT_SQL, -1, &stmt, NULL));
-  CHECK (sqlite3_bind_int (stmt, 1, date_text_len));
-  CHECK (sqlite3_bind_text (stmt, 2, date, -1, SQLITE_TRANSIENT));
+  CHECK (sqlite3_bind_text (stmt, 1, date, -1, SQLITE_TRANSIENT));
 
   while ((ret = sqlite3_step (stmt)) == SQLITE_ROW)
     {

--- a/daemon/emer-aggregate-tally.h
+++ b/daemon/emer-aggregate-tally.h
@@ -67,7 +67,6 @@ gboolean emer_aggregate_tally_store_event (EmerAggregateTally  *self,
                                            GVariant            *payload,
                                            guint32              counter,
                                            GDateTime            *datetime,
-                                           gint64               monotonic_time_us,
                                            GError             **error);
 
 void emer_aggregate_tally_iter (EmerAggregateTally *self,

--- a/daemon/emer-aggregate-tally.h
+++ b/daemon/emer-aggregate-tally.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <glib-object.h>
+#include <uuid.h>
 
 G_BEGIN_DECLS
 
@@ -43,7 +44,7 @@ typedef enum
 } EmerTallyType;
 
 typedef EmerTallyIterResult (*EmerTallyIterFunc) (guint32     unix_user_id,
-                                                  GVariant   *event_id,
+                                                  uuid_t      event_id,
                                                   GVariant   *aggregate_key,
                                                   GVariant   *payload,
                                                   guint32     counter,
@@ -61,7 +62,7 @@ emer_aggregate_tally_new (const gchar *persistent_cache_directory);
 gboolean emer_aggregate_tally_store_event (EmerAggregateTally  *self,
                                            EmerTallyType        tally_type,
                                            guint32              unix_user_id,
-                                           GVariant            *event_id,
+                                           uuid_t               event_id,
                                            GVariant            *aggregate_key,
                                            GVariant            *payload,
                                            guint32              counter,

--- a/daemon/emer-aggregate-timer-impl.c
+++ b/daemon/emer-aggregate-timer-impl.c
@@ -37,8 +37,8 @@ struct _EmerAggregateTimerImpl
   gint64 end_monotonic_us;
 
   guint32 unix_user_id;
-  GVariant *event_id; /* owned */
-  GVariant *monthly_event_id; /* owned */
+  uuid_t event_id;
+  uuid_t monthly_event_id;
   GVariant *aggregate_key; /* owned */
   GVariant *payload; /* owned */
   gchar *cache_key_string; /* owned */
@@ -49,23 +49,6 @@ struct _EmerAggregateTimerImpl
 
 G_DEFINE_TYPE (EmerAggregateTimerImpl, emer_aggregate_timer_impl, G_TYPE_OBJECT)
 
-static GVariant *
-create_uuid_variant (GVariant    *event_id,
-                     const gchar *name)
-{
-  g_autoptr(GVariantIter) iter = NULL;
-  uuid_t uuid, new_uuid;
-  size_t i = 0;
-
-  g_variant_get (event_id, "ay", &iter);
-  while (g_variant_iter_loop (iter, "y", &uuid[i++]))
-    ;
-
-  uuid_generate_sha1 (new_uuid, uuid, name, strlen (name));
-
-  return get_uuid_as_variant (new_uuid);
-}
-
 static void
 emer_aggregate_timer_impl_finalize (GObject *object)
 {
@@ -73,8 +56,6 @@ emer_aggregate_timer_impl_finalize (GObject *object)
 
   g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (self->timer));
 
-  g_clear_pointer (&self->event_id, g_variant_unref);
-  g_clear_pointer (&self->monthly_event_id, g_variant_unref);
   g_clear_pointer (&self->aggregate_key, g_variant_unref);
   g_clear_pointer (&self->payload, g_variant_unref);
   g_clear_pointer (&self->cache_key_string, g_free);
@@ -108,8 +89,18 @@ emer_aggregate_timer_impl_new (EmerAggregateTally *tally,
                                gint64              monotonic_time_us)
 {
   EmerAggregateTimerImpl *self;
+  gconstpointer event_id_bytes = NULL;
+  gsize event_id_len = 0;
+  uuid_t event_uuid;
 
-  g_variant_take_ref (event_id);
+  /* TODO: factor this out */
+  g_return_val_if_fail (g_variant_is_of_type (event_id, G_VARIANT_TYPE_BYTESTRING), NULL);
+  g_return_val_if_fail (g_variant_is_of_type (aggregate_key, G_VARIANT_TYPE_VARIANT), NULL);
+  g_return_val_if_fail (payload == NULL || g_variant_is_of_type (payload, G_VARIANT_TYPE_VARIANT), NULL);
+
+  event_id_bytes = g_variant_get_fixed_array (event_id, &event_id_len, sizeof (event_uuid[0]));
+  g_return_val_if_fail (event_id_len == sizeof (event_uuid), NULL);
+
   g_variant_take_ref (aggregate_key);
   if (payload)
     g_variant_take_ref (payload);
@@ -119,8 +110,10 @@ emer_aggregate_timer_impl_new (EmerAggregateTally *tally,
   self->sender_name = g_strdup (sender_name);
   self->tally = tally;
   self->unix_user_id = unix_user_id;
-  self->event_id = g_variant_ref (event_id);
-  self->monthly_event_id = create_uuid_variant (event_id, "monthly");
+
+  memcpy (self->event_id, event_id_bytes, event_id_len);
+  uuid_generate_sha1 (self->monthly_event_id, self->event_id, "monthly", strlen ("monthly"));
+
   self->aggregate_key = g_variant_ref (aggregate_key);
   self->payload = payload ? g_variant_ref (payload) : NULL;
   self->start_monotonic_us = monotonic_time_us;
@@ -142,7 +135,7 @@ emer_aggregate_timer_impl_store (EmerAggregateTimerImpl  *self,
                                  gint64                   monotonic_time_us,
                                  GError                 **error)
 {
-  GVariant *event_id;
+  uuid_t *event_id;
   guint32 counter;
   gint64 difference;
 
@@ -155,11 +148,11 @@ emer_aggregate_timer_impl_store (EmerAggregateTimerImpl  *self,
   switch (tally_type)
     {
     case EMER_TALLY_DAILY_EVENTS:
-      event_id = self->event_id;
+      event_id = &self->event_id;
       break;
 
     case EMER_TALLY_MONTHLY_EVENTS:
-      event_id = self->monthly_event_id;
+      event_id = &self->monthly_event_id;
       break;
 
     default:
@@ -169,7 +162,7 @@ emer_aggregate_timer_impl_store (EmerAggregateTimerImpl  *self,
   return emer_aggregate_tally_store_event (self->tally,
                                            tally_type,
                                            self->unix_user_id,
-                                           event_id,
+                                           *event_id,
                                            self->aggregate_key,
                                            self->payload,
                                            counter,

--- a/daemon/emer-aggregate-timer-impl.c
+++ b/daemon/emer-aggregate-timer-impl.c
@@ -53,7 +53,6 @@ static GVariant *
 create_uuid_variant (GVariant    *event_id,
                      const gchar *name)
 {
-  GVariantBuilder builder;
   g_autoptr(GVariantIter) iter = NULL;
   uuid_t uuid, new_uuid;
   size_t i = 0;
@@ -64,8 +63,7 @@ create_uuid_variant (GVariant    *event_id,
 
   uuid_generate_sha1 (new_uuid, uuid, name, strlen (name));
 
-  get_uuid_builder (new_uuid, &builder);
-  return g_variant_builder_end (&builder);
+  return get_uuid_as_variant (new_uuid);
 }
 
 static void

--- a/daemon/emer-aggregate-timer-impl.c
+++ b/daemon/emer-aggregate-timer-impl.c
@@ -167,7 +167,6 @@ emer_aggregate_timer_impl_store (EmerAggregateTimerImpl  *self,
                                            self->payload,
                                            counter,
                                            datetime,
-                                           monotonic_time_us,
                                            error);
 }
 
@@ -203,7 +202,6 @@ emer_aggregate_timer_impl_stop (EmerAggregateTimerImpl  *self,
                                     self->payload,
                                     counter,
                                     datetime,
-                                    monotonic_time_us,
                                     &local_error);
   if (local_error)
     {
@@ -220,7 +218,6 @@ emer_aggregate_timer_impl_stop (EmerAggregateTimerImpl  *self,
                                     self->payload,
                                     counter,
                                     datetime,
-                                    monotonic_time_us,
                                     &local_error);
   if (local_error)
     {

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1196,7 +1196,7 @@ split_aggregate_timers (EmerDaemon *self,
 
 static EmerTallyIterResult
 buffer_aggregate_event_to_queue (guint32     unix_user_id,
-                                 GVariant   *event_id,
+                                 uuid_t      event_uuid,
                                  GVariant   *aggregate_key,
                                  GVariant   *payload,
                                  guint32     counter,
@@ -1206,7 +1206,7 @@ buffer_aggregate_event_to_queue (guint32     unix_user_id,
   EmerDaemon *self = user_data;
 
   emer_daemon_record_aggregate_event (self,
-                                      event_id,
+                                      get_uuid_as_variant (event_uuid),
                                       date,
                                       counter,
                                       payload != NULL,

--- a/shared/metrics-util.c
+++ b/shared/metrics-util.c
@@ -60,17 +60,10 @@ swap_bytes_if_big_endian (GVariant *variant)
   return g_variant_ref_sink (variant);
 }
 
-/*
- * Initializes the given uuid_builder and populates it with the contents of
- * uuid.
- */
-void
-get_uuid_builder (uuid_t           uuid,
-                  GVariantBuilder *uuid_builder)
+GVariant *
+get_uuid_as_variant (uuid_t uuid)
 {
-  g_variant_builder_init (uuid_builder, G_VARIANT_TYPE_BYTESTRING);
-  for (size_t i = 0; i < UUID_LENGTH; ++i)
-    g_variant_builder_add (uuid_builder, "y", uuid[i]);
+  return g_variant_new_fixed_array (G_VARIANT_TYPE_BYTE, uuid, UUID_LENGTH, sizeof (uuid[0]));
 }
 
 GVariant *

--- a/shared/metrics-util.h
+++ b/shared/metrics-util.h
@@ -38,8 +38,7 @@ guint64   swap_bytes_64_if_big_endian (guint64          value);
 
 GVariant *swap_bytes_if_big_endian    (GVariant        *variant);
 
-void      get_uuid_builder            (uuid_t           uuid,
-                                       GVariantBuilder *uuid_builder);
+GVariant *get_uuid_as_variant         (uuid_t uuid);
 
 GVariant *deep_copy_variant           (GVariant        *variant);
 

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -357,29 +357,10 @@ test_aggregate_tally_iter_before_daily (struct Fixture *fixture,
   size_t i;
   g_autoptr(GError) error = NULL;
 
-  // Add the same aggregate event to different days in the past
-  for (i = 0; i < 25; i++)
+  // Add the same aggregate event to different days in the past and future
+  for (i = 0; i < 50; i++)
     {
-      g_autoptr(GDateTime) past_datetime = g_date_time_add_days (datetime, -(i + 1));
-
-      emer_aggregate_tally_store_event (fixture->tally,
-                                        EMER_TALLY_DAILY_EVENTS,
-                                        1001,
-                                        test_uuid,
-                                        v,
-                                        v,
-                                        1,
-                                        past_datetime,
-                                        g_get_monotonic_time (),
-                                        &error);
-
-      g_assert_no_error (error);
-    }
-
-  // ... and in the future as well
-  for (i = 0; i < 25; i++)
-    {
-      g_autoptr(GDateTime) future_datetime = g_date_time_add_days (datetime, i + 1);
+      g_autoptr(GDateTime) dt = g_date_time_add_days (datetime, i - 25);
 
       emer_aggregate_tally_store_event (fixture->tally,
                                         EMER_TALLY_DAILY_EVENTS,
@@ -388,7 +369,7 @@ test_aggregate_tally_iter_before_daily (struct Fixture *fixture,
                                         v,
                                         v,
                                         1,
-                                        future_datetime,
+                                        dt,
                                         g_get_monotonic_time (),
                                         &error);
 
@@ -450,30 +431,10 @@ test_aggregate_tally_iter_before_monthly (struct Fixture *fixture,
   size_t i;
   g_autoptr(GError) error = NULL;
 
-  // Now test previous months - add as much as 1 year to
-  // the past
-  for (i = 0; i < 12; i++)
+  // Add the same event in different months of the past and future
+  for (i = 0; i < 24; i++)
     {
-      g_autoptr(GDateTime) past_datetime = g_date_time_add_months (datetime, -(i + 1));
-
-      emer_aggregate_tally_store_event (fixture->tally,
-                                        EMER_TALLY_MONTHLY_EVENTS,
-                                        1001,
-                                        test_uuid,
-                                        v,
-                                        v,
-                                        1,
-                                        past_datetime,
-                                        g_get_monotonic_time (),
-                                        &error);
-
-      g_assert_no_error (error);
-    }
-
-  // ... and to the future as well
-  for (i = 0; i < 12; i++)
-    {
-      g_autoptr(GDateTime) future_datetime = g_date_time_add_months (datetime, i + 1);
+      g_autoptr(GDateTime) dt = g_date_time_add_months (datetime, i - 12);
 
       emer_aggregate_tally_store_event (fixture->tally,
                                         EMER_TALLY_MONTHLY_EVENTS,
@@ -482,7 +443,7 @@ test_aggregate_tally_iter_before_monthly (struct Fixture *fixture,
                                         v,
                                         v,
                                         1,
-                                        future_datetime,
+                                        dt,
                                         g_get_monotonic_time (),
                                         &error);
 

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -390,23 +390,6 @@ test_aggregate_tally_large_counter_upper_bound (struct Fixture *fixture,
   g_assert_cmpuint (data.counter, ==, G_MAXUINT32);
 }
 
-static EmerTallyIterResult
-tally_iter_before_func (guint32     unix_user_id,
-                        GVariant   *event_id,
-                        GVariant   *aggregate_key,
-                        GVariant   *payload,
-                        guint32     counter,
-                        const char *date,
-                        gpointer    user_data)
-{
-  struct IterData *data = user_data;
-
-  data->n_iterations++;
-  data->counter += counter;
-
-  return EMER_TALLY_ITER_CONTINUE;
-}
-
 static void
 test_aggregate_tally_iter_before (struct Fixture *fixture,
                                   gconstpointer   dontuseme)
@@ -481,7 +464,7 @@ test_aggregate_tally_iter_before (struct Fixture *fixture,
                                     EMER_TALLY_DAILY_EVENTS,
                                     datetime,
                                     EMER_TALLY_ITER_FLAG_DEFAULT,
-                                    tally_iter_before_func,
+                                    tally_iter_func,
                                     &data);
 
   g_assert_cmpuint (data.n_iterations, ==, 25);
@@ -493,7 +476,7 @@ test_aggregate_tally_iter_before (struct Fixture *fixture,
                                     EMER_TALLY_DAILY_EVENTS,
                                     datetime,
                                     EMER_TALLY_ITER_FLAG_DELETE,
-                                    tally_iter_before_func,
+                                    tally_iter_func,
                                     &data);
 
   g_assert_cmpuint (data.n_iterations, ==, 25);
@@ -505,7 +488,7 @@ test_aggregate_tally_iter_before (struct Fixture *fixture,
                                     EMER_TALLY_DAILY_EVENTS,
                                     datetime,
                                     EMER_TALLY_ITER_FLAG_DEFAULT,
-                                    tally_iter_before_func,
+                                    tally_iter_func,
                                     &data);
 
   g_assert_cmpuint (data.n_iterations, ==, 0);
@@ -576,7 +559,7 @@ test_aggregate_tally_iter_before (struct Fixture *fixture,
                                     EMER_TALLY_MONTHLY_EVENTS,
                                     datetime,
                                     EMER_TALLY_ITER_FLAG_DEFAULT,
-                                    tally_iter_before_func,
+                                    tally_iter_func,
                                     &data);
 
   g_assert_cmpuint (data.n_iterations, ==, 12);
@@ -588,7 +571,7 @@ test_aggregate_tally_iter_before (struct Fixture *fixture,
                                     EMER_TALLY_MONTHLY_EVENTS,
                                     datetime,
                                     EMER_TALLY_ITER_FLAG_DELETE,
-                                    tally_iter_before_func,
+                                    tally_iter_func,
                                     &data);
 
   g_assert_cmpuint (data.n_iterations, ==, 12);
@@ -600,7 +583,7 @@ test_aggregate_tally_iter_before (struct Fixture *fixture,
                                     EMER_TALLY_MONTHLY_EVENTS,
                                     datetime,
                                     EMER_TALLY_ITER_FLAG_DEFAULT,
-                                    tally_iter_before_func,
+                                    tally_iter_func,
                                     &data);
 
   g_assert_cmpuint (data.n_iterations, ==, 0);

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -210,6 +210,14 @@ test_aggregate_tally_iter (struct Fixture *fixture,
   g_assert_cmpuint (events->len, ==, 1);
   AggregateEvent *e = g_ptr_array_index (events, 0);
   g_assert_cmpuint (e->counter, ==, 10);
+  g_assert_cmpuint (e->unix_user_id, ==, 1001);
+  g_assert_cmpstr (e->date, ==, "2021-09-22");
+  g_assert_cmpmem (e->event_id, sizeof (uuid_t), uuids[0], sizeof (uuid_t));
+  g_assert_cmpvariant (e->aggregate_key, aggregate_key);
+  if (payload_str == NULL)
+    g_assert_null (e->payload);
+  else
+    g_assert_cmpvariant (e->payload, payload);
 
   g_ptr_array_set_size (events, 0);
   emer_aggregate_tally_iter (fixture->tally,

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -122,6 +122,15 @@ test_aggregate_tally_new_succeeds (struct Fixture *fixture,
   g_assert_nonnull (fixture->tally);
 }
 
+/* Test reloading the same empty database */
+static void
+test_aggregate_tally_new_succeeds_twice (struct Fixture *fixture,
+                                         gconstpointer   dontuseme)
+{
+  teardown (fixture, dontuseme);
+  setup (fixture, dontuseme);
+}
+
 static void
 test_aggregate_tally_store_events (struct Fixture *fixture,
                                    gconstpointer   dontuseme)
@@ -613,6 +622,8 @@ main (gint                argc,
 
   ADD_AGGREGATE_TALLY_TEST_FUNC ("/aggregate-tally/new-succeeds",
                                  test_aggregate_tally_new_succeeds);
+  ADD_AGGREGATE_TALLY_TEST_FUNC ("/aggregate-tally/new-succeeds-twice",
+                                 test_aggregate_tally_new_succeeds_twice);
   ADD_AGGREGATE_TALLY_TEST_FUNC ("/aggregate-tally/store-events",
                                  test_aggregate_tally_store_events);
   g_test_add ("/aggregate-tally/iter/null-payload",

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -443,6 +443,23 @@ test_aggregate_tally_iter_before_daily (struct Fixture *fixture,
       g_assert_no_error (error);
     }
 
+  // Add a monthly event, which should be ignored in the queries below
+    {
+      g_autoptr(GDateTime) dt = g_date_time_add_months (datetime, -1);
+
+      emer_aggregate_tally_store_event (fixture->tally,
+                                        EMER_TALLY_MONTHLY_EVENTS,
+                                        1001,
+                                        uuids[0],
+                                        v,
+                                        v,
+                                        1,
+                                        dt,
+                                        &error);
+
+      g_assert_no_error (error);
+    }
+
   /* Iterate but don't delete */
   emer_aggregate_tally_iter_before (fixture->tally,
                                     EMER_TALLY_DAILY_EVENTS,
@@ -507,6 +524,23 @@ test_aggregate_tally_iter_before_monthly (struct Fixture *fixture,
 
       emer_aggregate_tally_store_event (fixture->tally,
                                         EMER_TALLY_MONTHLY_EVENTS,
+                                        1001,
+                                        uuids[0],
+                                        v,
+                                        v,
+                                        1,
+                                        dt,
+                                        &error);
+
+      g_assert_no_error (error);
+    }
+
+  // Add a daily event which should be ignored in the queries below
+    {
+      g_autoptr(GDateTime) dt = g_date_time_add_months (datetime, -1);
+
+      emer_aggregate_tally_store_event (fixture->tally,
+                                        EMER_TALLY_DAILY_EVENTS,
                                         1001,
                                         uuids[0],
                                         v,

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -348,15 +348,14 @@ test_aggregate_tally_large_counter_upper_bound (struct Fixture *fixture,
 }
 
 static void
-test_aggregate_tally_iter_before (struct Fixture *fixture,
-                                  gconstpointer   dontuseme)
+test_aggregate_tally_iter_before_daily (struct Fixture *fixture,
+                                        gconstpointer   dontuseme)
 {
   g_autoptr(GDateTime) datetime = g_date_time_new_utc (2021, 9, 22, 0, 0, 0);
   g_autoptr(GVariant) v = v_str (G_STRFUNC);
   g_autoptr(GPtrArray) events = g_ptr_array_new_with_free_func (aggregate_event_free);
   size_t i;
   g_autoptr(GError) error = NULL;
-
 
   // Add the same aggregate event to different days in the past
   for (i = 0; i < 25; i++)
@@ -439,6 +438,17 @@ test_aggregate_tally_iter_before (struct Fixture *fixture,
                                     events);
 
   g_assert_cmpuint (events->len, ==, 0);
+}
+
+static void
+test_aggregate_tally_iter_before_monthly (struct Fixture *fixture,
+                                          gconstpointer   dontuseme)
+{
+  g_autoptr(GDateTime) datetime = g_date_time_new_utc (2021, 9, 22, 0, 0, 0);
+  g_autoptr(GVariant) v = v_str (G_STRFUNC);
+  g_autoptr(GPtrArray) events = g_ptr_array_new_with_free_func (aggregate_event_free);
+  size_t i;
+  g_autoptr(GError) error = NULL;
 
   // Now test previous months - add as much as 1 year to
   // the past
@@ -480,7 +490,6 @@ test_aggregate_tally_iter_before (struct Fixture *fixture,
     }
 
   /* Iterate but don't delete */
-  g_ptr_array_set_size (events, 0);
   emer_aggregate_tally_iter_before (fixture->tally,
                                     EMER_TALLY_MONTHLY_EVENTS,
                                     datetime,
@@ -559,8 +568,10 @@ main (gint                argc,
                                  test_aggregate_tally_large_counter_add);
   ADD_AGGREGATE_TALLY_TEST_FUNC ("/aggregate-tally/large-counter/upper-bound",
                                  test_aggregate_tally_large_counter_upper_bound);
-  ADD_AGGREGATE_TALLY_TEST_FUNC ("/aggregate-tally/iter-before",
-                                 test_aggregate_tally_iter_before);
+  ADD_AGGREGATE_TALLY_TEST_FUNC ("/aggregate-tally/iter-before/daily",
+                                 test_aggregate_tally_iter_before_daily);
+  ADD_AGGREGATE_TALLY_TEST_FUNC ("/aggregate-tally/iter-before/monthly",
+                                 test_aggregate_tally_iter_before_monthly);
 
 #undef ADD_AGGREGATE_TALLY_TEST_FUNC
 

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -230,6 +230,73 @@ test_aggregate_tally_iter (struct Fixture *fixture,
 }
 
 static void
+test_aggregate_tally_permutations (struct Fixture *fixture,
+                                   gconstpointer   data)
+{
+  g_autoptr(GDateTime) datetime = g_date_time_new_utc (2021, 9, 22, 0, 0, 0);
+  char *aggregate_keys[] = { "a", "b", "c" };
+  g_autoptr(GPtrArray) events = g_ptr_array_new_with_free_func (aggregate_event_free);
+  g_autoptr(GError) error = NULL;
+  const guint32 n_unix_uids = 3;
+  int iterations_per_permutation = 3;
+
+  for (guint32 unix_uid = 0; unix_uid < n_unix_uids; unix_uid++)
+    for (size_t uuid_ix = 0; uuid_ix < G_N_ELEMENTS (uuids); uuid_ix++)
+      for (size_t agg_ix = 0; agg_ix < G_N_ELEMENTS (aggregate_keys); agg_ix++)
+        for (gboolean has_payload = FALSE; has_payload <= TRUE; has_payload++)
+          for (int datetime_offset = 0; datetime_offset < 3; datetime_offset++)
+            for (EmerTallyType tally_type = EMER_TALLY_DAILY_EVENTS;
+                 tally_type <= EMER_TALLY_MONTHLY_EVENTS;
+                 tally_type++)
+              {
+                g_autoptr(GDateTime) dt = g_date_time_add_days (datetime, datetime_offset);
+                g_autoptr(GVariant) aggregate_key = v_str (aggregate_keys[agg_ix]);
+                GVariant *payload = has_payload ? aggregate_key : NULL;
+
+                for (int i = 1; i <= iterations_per_permutation; i++)
+                  {
+                    emer_aggregate_tally_store_event (fixture->tally,
+                                                      tally_type,
+                                                      unix_uid,
+                                                      uuids[uuid_ix],
+                                                      aggregate_key,
+                                                      payload,
+                                                      i,
+                                                      dt,
+                                                      &error);
+                    g_assert_no_error (error);
+                  }
+              }
+
+  emer_aggregate_tally_iter (fixture->tally,
+                             EMER_TALLY_DAILY_EVENTS,
+                             datetime,
+                             EMER_TALLY_ITER_FLAG_DELETE,
+                             tally_iter_func,
+                             events);
+
+  g_assert_cmpuint (events->len, ==, n_unix_uids * G_N_ELEMENTS (uuids) * G_N_ELEMENTS (aggregate_keys) * 2);
+  for (size_t i = 0; i < events->len; i++)
+    {
+      AggregateEvent *e = events->pdata[i];
+      g_assert_cmpuint (e->counter, ==, 1 + 2 + 3);
+      /* TODO: If we were feeling really enthusiastic we could test that we have one instance of each permutation */
+    }
+
+  /* Since we gave the DELETE flag above, these same events should not be
+   * retrievable a second time.
+   */
+  g_ptr_array_set_size (events, 0);
+  emer_aggregate_tally_iter (fixture->tally,
+                             EMER_TALLY_DAILY_EVENTS,
+                             datetime,
+                             EMER_TALLY_ITER_FLAG_DELETE,
+                             tally_iter_func,
+                             events);
+  g_assert_cmpuint (events->len, ==, 0);
+}
+
+static void
 test_aggregate_tally_large_counter_single (struct Fixture *fixture,
                                            gconstpointer   dontuseme)
 {
@@ -526,6 +593,9 @@ main (gint                argc,
               setup,
               test_aggregate_tally_iter,
               teardown);
+
+  ADD_AGGREGATE_TALLY_TEST_FUNC ("/aggregate-tally/permutations",
+                                 test_aggregate_tally_permutations);
   ADD_AGGREGATE_TALLY_TEST_FUNC ("/aggregate-tally/large-counter/single",
                                  test_aggregate_tally_large_counter_single);
   ADD_AGGREGATE_TALLY_TEST_FUNC ("/aggregate-tally/large-counter/add",

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -390,6 +390,8 @@ test_aggregate_tally_iter_before_daily (struct Fixture *fixture,
       AggregateEvent *e = g_ptr_array_index (events, i);
 
       g_assert_cmpuint (e->counter, ==, 1);
+      /* All returned dates should be before the requested date */
+      g_assert_cmpstr (e->date, <, "2021-09-22");
     }
 
   /* Iterate again, and delete entries this time */
@@ -464,6 +466,8 @@ test_aggregate_tally_iter_before_monthly (struct Fixture *fixture,
       AggregateEvent *e = g_ptr_array_index (events, i);
 
       g_assert_cmpuint (e->counter, ==, 1);
+      /* All returned dates should be before the requested date */
+      g_assert_cmpstr (e->date, <, "2021-09");
     }
 
   /* Iterate again, and delete entries this time */

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -80,8 +80,8 @@ create_aggregate_event (guint32     unix_user_id,
   event = g_new0 (struct AggregateEvent, 1);
   event->unix_user_id = unix_user_id;
   event->event_id = g_variant_ref_sink (event_id_to_variant (event_id));
-  event->aggregate_key = g_variant_ref_sink (aggregate_key);
-  event->payload = g_variant_ref_sink (payload);
+  event->aggregate_key = g_variant_ref_sink (g_variant_new_variant (aggregate_key));
+  event->payload = g_variant_ref_sink (g_variant_new_variant (payload));
 
   return event;
 }

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -139,7 +139,6 @@ test_aggregate_tally_store_events (struct Fixture *fixture,
                                     payload,
                                     1,
                                     datetime,
-                                    g_get_monotonic_time (),
                                     &error);
   g_assert_no_error (error);
 
@@ -151,7 +150,6 @@ test_aggregate_tally_store_events (struct Fixture *fixture,
                                     payload,
                                     2,
                                     datetime,
-                                    g_get_monotonic_time (),
                                     &error);
   g_assert_no_error (error);
 }
@@ -197,7 +195,6 @@ test_aggregate_tally_iter (struct Fixture *fixture,
                                         payload,
                                         1,
                                         datetime,
-                                        g_get_monotonic_time (),
                                         &error);
 
       g_assert_no_error (error);
@@ -243,7 +240,6 @@ test_aggregate_tally_large_counter_single (struct Fixture *fixture,
                                     v,
                                     ((guint32) G_MAXINT32) + 1,
                                     datetime,
-                                    g_get_monotonic_time (),
                                     &error);
   g_assert_no_error (error);
 
@@ -278,7 +274,6 @@ test_aggregate_tally_large_counter_add (struct Fixture *fixture,
                                     v,
                                     (guint32) G_MAXINT32,
                                     datetime,
-                                    g_get_monotonic_time (),
                                     &error);
   g_assert_no_error (error);
 
@@ -291,7 +286,6 @@ test_aggregate_tally_large_counter_add (struct Fixture *fixture,
                                     v,
                                     1,
                                     datetime,
-                                    g_get_monotonic_time (),
                                     &error);
   g_assert_no_error (error);
 
@@ -330,7 +324,6 @@ test_aggregate_tally_large_counter_upper_bound (struct Fixture *fixture,
                                         v,
                                         G_MAXUINT32,
                                         datetime,
-                                        g_get_monotonic_time (),
                                         &error);
       g_assert_no_error (error);
     }
@@ -370,7 +363,6 @@ test_aggregate_tally_iter_before_daily (struct Fixture *fixture,
                                         v,
                                         1,
                                         dt,
-                                        g_get_monotonic_time (),
                                         &error);
 
       g_assert_no_error (error);
@@ -446,7 +438,6 @@ test_aggregate_tally_iter_before_monthly (struct Fixture *fixture,
                                         v,
                                         1,
                                         dt,
-                                        g_get_monotonic_time (),
                                         &error);
 
       g_assert_no_error (error);

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -58,15 +58,12 @@ struct Fixture
 static GVariant *
 event_id_to_variant (const char *event_id)
 {
-  GVariantBuilder event_id_builder;
   uuid_t parsed_event_id;
 
   if (uuid_parse (event_id, parsed_event_id) != 0)
     return NULL;
 
-  get_uuid_builder (parsed_event_id, &event_id_builder);
-
-  return g_variant_new ("ay", &event_id_builder);
+  return get_uuid_as_variant (parsed_event_id);
 }
 
 static struct AggregateEvent *

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -382,9 +382,7 @@ make_variant_for_event_id (const gchar *event_id)
 {
   uuid_t uuid;
   g_assert_cmpint (uuid_parse (event_id, uuid), ==, 0);
-  GVariantBuilder event_id_builder;
-  get_uuid_builder (uuid, &event_id_builder);
-  return g_variant_builder_end (&event_id_builder);
+  return get_uuid_as_variant (uuid);
 }
 
 static GVariant *


### PR DESCRIPTION
The primary purpose of this branch is to improve and simplify the database schema used to store aggregate events.

Along the way I discovered the cause of a known bug, and discovered and fixed two other bugs. I also improved test coverage, and improved error recovery so that the daemon doesn't crash on the first sign of any error from SQLite.

https://phabricator.endlessm.com/T33140
https://phabricator.endlessm.com/T32794
https://phabricator.endlessm.com/T33232

I can only apologise for the sheer size of this branch, but it seemed impractical to disentangle the changes. In particular all the changes affecting on-disk storage should be landed together to avoid the need for migration logic, and they ended up entangled with the improvements to the test suite, which were then entangled with the fixes for the other bugs.