### PR TITLE
Set G_DEBUG=fatal-warnings in tests

### DIFF
--- a/daemon/emer-cache-size-provider.c
+++ b/daemon/emer-cache-size-provider.c
@@ -40,10 +40,10 @@
  * @path: (allow-none): the path to the file where the maximum persistent
  *  cache size is stored.
  *
- * Returns the maximum persistent cache size in bytes. If @path is %NULL, it
+ * Returns the maximum persistent cache size in bytes. If @path is %NULL, not
  * defaults to DEFAULT_CACHE_SIZE_FILE_PATH. If the underlying configuration
- * file doesn't exist yet, or is corrupt, it is recreated with a default value
- * of DEFAULT_MAX_CACHE_SIZE.
+ * file doesn't exist, is corrupt, or does not contain this key,
+ * %DEFAULT_MAX_CACHE_SIZE is returned.
  */
 guint64
 emer_cache_size_provider_get_max_cache_size (const gchar *path)
@@ -55,8 +55,7 @@ emer_cache_size_provider_get_max_cache_size (const gchar *path)
   if (path == NULL)
     path = DEFAULT_CACHE_SIZE_FILE_PATH;
 
-  if (g_key_file_load_from_file (key_file, path, G_KEY_FILE_NONE,
-                                  &error))
+  if (g_key_file_load_from_file (key_file, path, G_KEY_FILE_NONE, &error))
     {
       cache_size = g_key_file_get_uint64 (key_file, CACHE_SIZE_GROUP,
                                           MAX_CACHE_SIZE_KEY, &error);
@@ -76,16 +75,8 @@ emer_cache_size_provider_get_max_cache_size (const gchar *path)
           g_warning ("Error reading cache size from %s: %s", path,
                      error->message);
         }
-      g_clear_error (&error);
 
       cache_size = DEFAULT_MAX_CACHE_SIZE;
-      g_key_file_set_uint64 (key_file, CACHE_SIZE_GROUP,
-                             MAX_CACHE_SIZE_KEY, cache_size);
-      if (!g_key_file_save_to_file (key_file, path, &error))
-        {
-          g_warning ("Failed to write default cache size file to %s. Error: %s.",
-                     path, error->message);
-        }
     }
 
   return cache_size;

--- a/daemon/emer-permissions-provider.c
+++ b/daemon/emer-permissions-provider.c
@@ -231,7 +231,10 @@ get_ostree_url_from_ostree_repo (void)
   GError *error = NULL;
   if (!ostree_repo_open (ostree_repo, NULL /* GCancellable */, &error))
     {
-      g_warning ("Unable to open OSTree repo. Error: %s.", error->message);
+      /* Don't warn if simply not on an OSTree system. */
+      if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+       g_warning ("Unable to open OSTree repo: %s", error->message);
+
       g_clear_error (&error);
       g_object_unref (ostree_repo);
       return NULL;

--- a/data/cache-size.conf
+++ b/data/cache-size.conf
@@ -1,0 +1,2 @@
+[persistent_cache_size]
+maximum=10000000

--- a/data/meson.build
+++ b/data/meson.build
@@ -44,6 +44,11 @@ install_data(
     install_dir: config_dir,
     install_mode: ['rwxrwsr-x', 'metrics', 'metrics'],
 )
+install_data(
+    'cache-size.conf',
+    install_dir: config_dir,
+    install_mode: ['rw-r--r--'],
+)
 
 # Polkit policy
 install_data(

--- a/tests/daemon/test-cache-size-provider.c
+++ b/tests/daemon/test-cache-size-provider.c
@@ -35,10 +35,6 @@
  "[persistent_cache_size]\n" \
  "maximum=40\n"
 
-#define DEFAULT_CACHE_SIZE_FILE_CONTENTS \
- "[persistent_cache_size]\n" \
- "maximum=10000000\n"
-
 // Helper Functions
 
 typedef struct Fixture
@@ -92,34 +88,11 @@ test_cache_size_provider_can_get_max_cache_size (Fixture      *fixture,
 }
 
 static void
-assert_file_has_default_contents (Fixture *fixture)
+assert_gets_default_max_cache_size (Fixture *fixture)
 {
-  gboolean ret;
-  g_autoptr(GError) error = NULL;
-  g_autofree gchar *contents = NULL;
-
   guint64 max_cache_size =
     emer_cache_size_provider_get_max_cache_size (fixture->tmp_path);
   g_assert_cmpint (max_cache_size, ==, DEFAULT_MAX_CACHE_SIZE);
-
-  ret = g_file_get_contents (fixture->tmp_path, &contents, NULL, &error);
-  g_assert_no_error (error);
-  g_assert_true (ret);
-
-  g_assert_cmpstr (contents, ==, DEFAULT_CACHE_SIZE_FILE_CONTENTS);
-
-  /* Re-reading the file should return the same value */
-  max_cache_size =
-    emer_cache_size_provider_get_max_cache_size (fixture->tmp_path);
-  g_assert_cmpint (max_cache_size, ==, DEFAULT_MAX_CACHE_SIZE);
-}
-
-static void
-assert_string_contains (const gchar *haystack,
-                        const gchar *needle)
-{
-  if (strstr (haystack, needle) == NULL)
-    g_error ("\"%s\" not in \"%s\"", needle, haystack);
 }
 
 static void
@@ -133,7 +106,7 @@ test_cache_size_provider_writes_file_if_missing (Fixture      *fixture,
   g_assert_no_error (error);
   g_assert_true (ret);
 
-  assert_file_has_default_contents (fixture);
+  assert_gets_default_max_cache_size (fixture);
 }
 
 static void
@@ -141,7 +114,7 @@ test_cache_size_provider_recovers_if_corrupt_empty (Fixture      *fixture,
                                                     gconstpointer unused)
 {
   write_cache_size_file (fixture, "", 0);
-  assert_file_has_default_contents (fixture);
+  assert_gets_default_max_cache_size (fixture);
 }
 
 static void
@@ -156,7 +129,7 @@ test_cache_size_provider_recovers_if_corrupt_nul (Fixture      *fixture,
    *
    * The key file appears to be empty when one tries to read it (since GKeyFile
    * reads the contents as a NUL-terminated string) so we should recover by
-   * re-initializing it in this case, silently.
+   * returning the default value.
    */
   g_test_bug ("T19953");
 
@@ -164,15 +137,16 @@ test_cache_size_provider_recovers_if_corrupt_nul (Fixture      *fixture,
   gchar *contents = g_malloc0 (41);
 
   write_cache_size_file (fixture, contents, size);
-  assert_file_has_default_contents (fixture);
+  assert_gets_default_max_cache_size (fixture);
 }
 
 static void
 test_cache_size_provider_recovers_if_corrupt_missing_key (Fixture      *fixture,
                                                           gconstpointer unused)
 {
-  /* If the file is not logically empty, we still want to fill in the 'maximum'
-   * key, but leave any other fields untouched. (Perhaps the file is destined
+  /* If the file is not logically empty, but does not contain the expected
+   * max_cache_size key, we still want to return the default value.
+   * (Perhaps the file is destined
    * for a future version of the daemon which accepts some new field.)
    */
   const gchar *contents = "[persistent_cache_size]\nunrelated_key=1";
@@ -182,32 +156,19 @@ test_cache_size_provider_recovers_if_corrupt_missing_key (Fixture      *fixture,
   guint64 max_cache_size =
     emer_cache_size_provider_get_max_cache_size (fixture->tmp_path);
   g_assert_cmpint (max_cache_size, ==, DEFAULT_MAX_CACHE_SIZE);
-
-  gboolean ret;
-  g_autoptr(GError) error = NULL;
-  g_autofree gchar *new_contents = NULL;
-
-  ret = g_file_get_contents (fixture->tmp_path, &new_contents, NULL, &error);
-  g_assert_no_error (error);
-  g_assert_true (ret);
-
-  assert_string_contains (new_contents, "maximum=10000000");
-  assert_string_contains (new_contents, "unrelated_key=1");
 }
 
 static void
 test_cache_size_provider_recovers_if_corrupt_garbage (Fixture      *fixture,
                                                       gconstpointer unused)
 {
-  /* If the file exists but is malformed, we should log a warning before
-   * reinitialising the file.
-   */
+  /* If the file exists but is malformed, we should log a warning */
   const gchar *contents = "i think i'm paranoid";
 
   write_cache_size_file (fixture, contents, -1);
 
   g_test_expect_message (NULL, G_LOG_LEVEL_WARNING, "*Key file*i think i'm paranoid*");
-  assert_file_has_default_contents (fixture);
+  assert_gets_default_max_cache_size (fixture);
   g_test_assert_expected_messages ();
 }
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -36,15 +36,20 @@ simple_tests = {
 }
 
 foreach name, sources : simple_tests
-    test(name, executable(name,
-        sources + ['daemon/@0@.c'.format(name)],
-        dependencies: [
-            emer_required_modules,
-            emer_shared_dep,
-        ],
-        include_directories: include_directories('../daemon'),
-        install: false,
-    ))
+    test(name,
+        executable(name,
+            sources + ['daemon/@0@.c'.format(name)],
+            dependencies: [
+                emer_required_modules,
+                emer_shared_dep,
+            ],
+            include_directories: include_directories('../daemon'),
+            install: false,
+        ),
+        env: {
+            'G_DEBUG': 'fatal-warnings',
+        },
+    )
 endforeach
 
 test_daemon = executable('test-daemon',
@@ -80,6 +85,9 @@ test_daemon = executable('test-daemon',
 test('test-daemon',
     find_program('launch-mock-dbus-tests.sh'),
     args: [test_daemon],
+    env: {
+        'G_DEBUG': 'fatal-warnings',
+    },
     # TODO: These tests are slow because they set the daemon's upload interval
     # to 2 seconds and constantly wait for this time to elapse, rather than
     # mocking the clock or telling the daemon to upload. Sure, *some* of them
@@ -91,5 +99,6 @@ test('test-opt-out-integration',
     find_program('test-opt-out-integration.py'),
     env: {
         'EMER_PATH': daemon.full_path(),
+        'G_DEBUG': 'fatal-warnings',
     },
 )

--- a/tests/test-opt-out-integration.py
+++ b/tests/test-opt-out-integration.py
@@ -60,7 +60,6 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
         self.config_file = os.path.join(self.test_dir.name, 'permissions.conf')
         config_file_arg = '--config-file-path={}'.format(self.config_file)
 
-        # TODO: Address both issues above, then enable fatal warnings.
         daemon_path = os.environ.get('EMER_PATH', './eos-metrics-event-recorder')
         self.daemon = subprocess.Popen([daemon_path,
                                         persistent_cache_dir_arg,

--- a/tests/test-opt-out-integration.py
+++ b/tests/test-opt-out-integration.py
@@ -60,13 +60,6 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
         self.config_file = os.path.join(self.test_dir.name, 'permissions.conf')
         config_file_arg = '--config-file-path={}'.format(self.config_file)
 
-        # TODO: The daemon attempts to create CONFIG_DIR / cache-size.conf when
-        # launched; this will typically fail while running this test because
-        # either CONFIG_DIR does not exist, or it exists and is not owned by
-        # the user running the test. The daemon logs a warning in this case.
-        # (If the test is running as root or the metrics user, and the
-        # directory exists, then the test will overwrite the file within!)
-
         # TODO: The daemon assumes it is running on an OSTree system and
         # attempts to open /ostree/repo/config to determine whether to adjust
         # the environment in its own configuration (self.config_file above).

--- a/tests/test-opt-out-integration.py
+++ b/tests/test-opt-out-integration.py
@@ -60,13 +60,6 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
         self.config_file = os.path.join(self.test_dir.name, 'permissions.conf')
         config_file_arg = '--config-file-path={}'.format(self.config_file)
 
-        # TODO: The daemon assumes it is running on an OSTree system and
-        # attempts to open /ostree/repo/config to determine whether to adjust
-        # the environment in its own configuration (self.config_file above).
-        # When running on a non-OSTree system such as a build server or
-        # development container, this fails, and logs a warning. (This could
-        # be addressed by, for example, checking ostree_sysroot_is_booted().)
-
         # TODO: Address both issues above, then enable fatal warnings.
         daemon_path = os.environ.get('EMER_PATH', './eos-metrics-event-recorder')
         self.daemon = subprocess.Popen([daemon_path,


### PR DESCRIPTION
This requires two bits of cleanup to remove some warnings routinely emitted in one of the tests.

https://phabricator.endlessm.com/T32765