### PR TITLE
Clear tally when metrics are disabled

### DIFF
--- a/daemon/emer-aggregate-tally.c
+++ b/daemon/emer-aggregate-tally.c
@@ -608,3 +608,15 @@ emer_aggregate_tally_iter_before (EmerAggregateTally *self,
                                            &error))
     g_critical ("%s: %s", G_STRFUNC, error->message);
 }
+
+gboolean
+emer_aggregate_tally_clear (EmerAggregateTally  *self,
+                            GError             **error)
+{
+  g_return_val_if_fail (EMER_IS_AGGREGATE_TALLY (self), FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+  return CHECK (sqlite3_exec (self->db,
+                              "DELETE FROM tally",
+                              NULL, NULL, NULL));
+}

--- a/daemon/emer-aggregate-tally.h
+++ b/daemon/emer-aggregate-tally.h
@@ -81,4 +81,7 @@ void emer_aggregate_tally_iter_before (EmerAggregateTally *self,
                                        EmerTallyIterFunc   func,
                                        gpointer            user_data);
 
+gboolean emer_aggregate_tally_clear (EmerAggregateTally  *self,
+                                     GError             **error);
+
 G_END_DECLS

--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1042,6 +1042,12 @@ on_permissions_changed (EmerPermissionsProvider *permissions_provider,
           g_clear_error (&error);
         }
 
+      if (!emer_aggregate_tally_clear (priv->aggregate_tally, &error))
+        {
+          g_warning ("failed to clear tally: %s", error->message);
+          g_clear_error (&error);
+        }
+
       /* If NULL (because no upload is in progress), this is a no-op. */
       g_cancellable_cancel (priv->current_upload_cancellable);
     }

--- a/tests/test-opt-out-integration.py
+++ b/tests/test-opt-out-integration.py
@@ -21,7 +21,6 @@
 import configparser
 import dbus
 import os
-import shlex
 import subprocess
 import taptestrunner
 import tempfile
@@ -55,9 +54,7 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
             prefix='eos-event-recorder-daemon-test.')
 
         persistent_cache_directory = os.path.join(self.test_dir.name, 'cache')
-        os.mkdir(persistent_cache_directory)
-        escaped_dir = shlex.quote(persistent_cache_directory)
-        persistent_cache_dir_arg = '--persistent-cache-directory=' + escaped_dir
+        persistent_cache_dir_arg = '--persistent-cache-directory=' + persistent_cache_directory
 
         self.config_file = os.path.join(self.test_dir.name, 'permissions.conf')
         config_file_arg = '--config-file-path={}'.format(self.config_file)


### PR DESCRIPTION
Previously, disabling metrics would cause any running aggregate timers
to be stopped, and any aggregate events from previous days/months which
are already in the EmerPersistentCache to be discarded, but events from
the current day/month would remain in the EmerAggregateTally.
Re-enabling metrics would cause these to be sent in due course.

Disabling metrics should remove all buffered data. Clear the tally too.

This also adds a test that validates the first point above.

https://phabricator.endlessm.com/T32765