### PR TITLE
Don't critical on aggregates with NULL payload

### DIFF
--- a/daemon/emer-daemon.h
+++ b/daemon/emer-daemon.h
@@ -94,11 +94,10 @@ void                     emer_daemon_record_singular_event    (EmerDaemon       
                                                                gboolean                 has_payload,
                                                                GVariant                *payload);
 
-void                     emer_daemon_record_aggregate_event   (EmerDaemon              *self,
+void                     emer_daemon_enqueue_aggregate_event  (EmerDaemon              *self,
                                                                GVariant                *event_id,
                                                                const char              *period_start,
                                                                guint32                  count,
-                                                               gboolean                 has_payload,
                                                                GVariant                *payload);
 
 void                     emer_daemon_record_event_sequence    (EmerDaemon              *self,


### PR DESCRIPTION
Previously, when aggregate events from previous days & months are taken from the tally and enqueued for submission (which occurs at midnight or when the computer starts up), if any of those events has a NULL payload, the daemon would log a pair of CRITICAL messages due to attempting to unref a NULL `GVariant *`.

The underlying cause is the code to fake the 'maybe' type over D-Bus with a (boolean, variant) pair. But the offending function is no longer exposed over D-Bus, so the signature can be simplified.

While I was here I finally understood why event payloads reach azafea with two levels of variant wrapper rather than one, and fixed it.

I also added a minimal test for enqueueing events from the tally on startup. I have not added a test for enqueueing events at midnight because this would require a more invasive refactoring to be able to mock the passage of time in tests.

https://phabricator.endlessm.com/T33299