### PR TITLE
daemon: Don't crash at startup if metrics are disabled

### DIFF
--- a/daemon/emer-daemon.c
+++ b/daemon/emer-daemon.c
@@ -1480,17 +1480,17 @@ emer_daemon_constructed (GObject *object)
       g_free (network_send_path);
     }
 
-  gchar *environment =
-    emer_permissions_provider_get_environment (priv->permissions_provider);
-  schedule_upload (self, environment);
-  g_free (environment);
-
   if (priv->aggregate_tally == NULL)
     {
       priv->aggregate_tally =
         emer_aggregate_tally_new (priv->persistent_cache_directory ?: g_get_user_cache_dir ());
     }
   buffer_past_aggregate_events (self);
+
+  gchar *environment =
+    emer_permissions_provider_get_environment (priv->permissions_provider);
+  schedule_upload (self, environment);
+  g_free (environment);
 
   G_OBJECT_CLASS (emer_daemon_parent_class)->constructed (object);
 }

--- a/tests/daemon/mock-permissions-provider.c
+++ b/tests/daemon/mock-permissions-provider.c
@@ -101,6 +101,15 @@ emer_permissions_provider_get_uploading_enabled (EmerPermissionsProvider *self)
 gchar *
 emer_permissions_provider_get_environment (EmerPermissionsProvider *self)
 {
+  /* The real class emits these signals whenever this function is called,
+   * regardless of whether the values have changed. This weird behaviour
+   * led to a bug where the daemon would crash on startup if it was disabled.
+   *
+   * Replicate this behaviour here.
+   */
+  g_signal_emit_by_name (self, "notify::daemon-enabled", NULL);
+  g_signal_emit_by_name (self, "notify::uploading-enabled", NULL);
+
   return g_strdup ("test");
 }
 

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -931,6 +931,19 @@ test_daemon_new_succeeds (Fixture      *fixture,
 }
 
 static void
+test_daemon_new_succeeds_if_disabled (Fixture       *fixture,
+                                      gconstpointer  unused)
+{
+  emer_permissions_provider_set_daemon_enabled (fixture->mock_permissions_provider, FALSE);
+
+  EmerDaemon *daemon = emer_daemon_new (NULL /* persistent cache directory */,
+                                        fixture->mock_permissions_provider,
+                                        NULL /* machine id provider */);
+  g_assert_nonnull (daemon);
+  g_object_unref (daemon);
+}
+
+static void
 test_daemon_new_full_succeeds (Fixture      *fixture,
                                gconstpointer unused)
 {
@@ -1345,6 +1358,7 @@ main (gint                argc,
   g_test_add ((path), Fixture, NULL, setup, (test_func), teardown)
 
   ADD_DAEMON_TEST ("/daemon/new-succeeds", test_daemon_new_succeeds);
+  ADD_DAEMON_TEST ("/daemon/new-succeeds-if-disabled", test_daemon_new_succeeds_if_disabled);
   ADD_DAEMON_TEST ("/daemon/new-full-succeeds", test_daemon_new_full_succeeds);
   ADD_DAEMON_TEST ("/daemon/records-singulars", test_daemon_records_singulars);
   ADD_DAEMON_TEST ("/daemon/records-aggregates",


### PR DESCRIPTION
Since 898c773 ("daemon: Clear tally when metrics are disabled"),
disabling metrics would cause the daemon to crash on startup. Here's the
chain of events:

1. set_permissions_provider(), called at construct time, connects to the
   notify::daemon-enabled signal on the EmerPermissionsProvider.
2. In emer_daemon_constructed(), if no EmerAggregateTally was provided
   as a construct-time property, priv->aggregate_tally was NULL until
   after a call to emer_permissions_provider_get_environment().
3. emer_permissions_provider_get_environment() causes the
   EmerPermissionsProvider to re-read its configuration file, and to
   unconditionally emit notify::daemon-enabled and
   notify::uploading-enabled even if those properties have not really
   changed.
4. on_permissions_changed() updates priv->recording_enabled and, if it
   is now FALSE, calls emer_aggregate_tally_clear(priv->aggregate_tally).
5. emer_aggregate_tally_clear() calls
      g_return_val_if_fail (EMER_IS_AGGREGATE_TALLY (self), FALSE);
   so returns FALSE with *error unset if called on a NULL pointer.
6. If emer_aggregate_tally_clear() fails, on_permissions_changed()
   dereferences its GError *, which is NULL in this case.

The fix is in step 2, to reorder emer_daemon_constructed() so that the
object is fully initialised before it calls
emer_permissions_provider_get_environment().

(You might reasonably argue that the bug is in step 3, but that is a
more invasive fix.)

https://phabricator.endlessm.com/T33305
