### PR TITLE
Store running timers on shutdown, add test & fix some exposed bugs

### DIFF
--- a/daemon/emer-aggregate-timer-impl.c
+++ b/daemon/emer-aggregate-timer-impl.c
@@ -39,10 +39,7 @@ struct _EmerAggregateTimerImpl
   uuid_t event_id;
   uuid_t monthly_event_id;
   GVariant *payload; /* owned */
-  gchar *cache_key_string; /* owned */
   gchar *sender_name; /* owned */
-
-  guint32 run_count;
 };
 
 G_DEFINE_TYPE (EmerAggregateTimerImpl, emer_aggregate_timer_impl, G_TYPE_OBJECT)
@@ -55,7 +52,6 @@ emer_aggregate_timer_impl_finalize (GObject *object)
   g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (self->timer));
 
   g_clear_pointer (&self->payload, g_variant_unref);
-  g_clear_pointer (&self->cache_key_string, g_free);
   g_clear_pointer (&self->sender_name, g_free);
   g_clear_object (&self->timer);
 
@@ -110,12 +106,6 @@ emer_aggregate_timer_impl_new (EmerAggregateTally *tally,
 
   self->payload = payload ? g_variant_ref (payload) : NULL;
   self->start_monotonic_us = monotonic_time_us;
-  self->cache_key_string =
-    emer_aggregate_timer_impl_compose_hash_string (sender_name,
-                                                   unix_user_id,
-                                                   event_id,
-                                                   payload);
-  self->run_count = 1;
 
   return self;
 }
@@ -218,52 +208,9 @@ emer_aggregate_timer_impl_stop (EmerAggregateTimerImpl  *self,
 }
 
 const gchar *
-emer_aggregate_timer_impl_get_cache_key (EmerAggregateTimerImpl *self)
-{
-  g_return_val_if_fail (EMER_IS_AGGREGATE_TIMER_IMPL (self), NULL);
-
-  return self->cache_key_string;
-}
-
-const gchar *
 emer_aggregate_timer_impl_get_sender_name (EmerAggregateTimerImpl *self)
 {
   g_return_val_if_fail (EMER_IS_AGGREGATE_TIMER_IMPL (self), NULL);
 
   return self->sender_name;
-}
-
-gchar *
-emer_aggregate_timer_impl_compose_hash_string (const gchar *sender_name,
-                                               guint32      unix_user_id,
-                                               GVariant    *event_id,
-                                               GVariant    *payload)
-{
-  g_autoptr(GVariant) cache_key = NULL;
-
-  cache_key = g_variant_new ("(su@aymv)",
-                             sender_name,
-                             unix_user_id,
-                             g_variant_take_ref (event_id),
-                             payload ? g_variant_take_ref (payload) : NULL);
-
-  return g_variant_print (cache_key, TRUE);
-}
-
-void
-emer_aggregate_timer_impl_push_run_count (EmerAggregateTimerImpl *self)
-{
-  g_return_if_fail (EMER_IS_AGGREGATE_TIMER_IMPL (self));
-
-  self->run_count++;
-}
-
-gboolean
-emer_aggregate_timer_impl_pop_run_count (EmerAggregateTimerImpl *self)
-{
-  g_return_val_if_fail (EMER_IS_AGGREGATE_TIMER_IMPL (self), FALSE);
-
-  self->run_count--;
-
-  return self->run_count == 0;
 }

--- a/daemon/emer-aggregate-timer-impl.h
+++ b/daemon/emer-aggregate-timer-impl.h
@@ -56,20 +56,8 @@ gboolean emer_aggregate_timer_impl_stop (EmerAggregateTimerImpl  *self,
                                          GDateTime               *datetime,
                                          gint64                   monotonic_time_us,
                                          GError                 **error);
-const gchar *
-emer_aggregate_timer_impl_get_cache_key (EmerAggregateTimerImpl *self);
 
 const gchar *
 emer_aggregate_timer_impl_get_sender_name (EmerAggregateTimerImpl *self);
-
-gchar *
-emer_aggregate_timer_impl_compose_hash_string (const gchar *sender_name,
-                                               guint32      unix_user_id,
-                                               GVariant    *event_id,
-                                               GVariant    *payload);
-
-void emer_aggregate_timer_impl_push_run_count (EmerAggregateTimerImpl *self);
-
-gboolean emer_aggregate_timer_impl_pop_run_count (EmerAggregateTimerImpl *self);
 
 G_END_DECLS

--- a/daemon/emer-daemon.h
+++ b/daemon/emer-daemon.h
@@ -127,6 +127,8 @@ gboolean                 emer_daemon_start_aggregate_timer    (EmerDaemon       
                                                                gchar                  **out_timer_object_path,
                                                                GError                 **error);
 
+void                     emer_daemon_shutdown                 (EmerDaemon              *self);
+
 G_END_DECLS
 
 #endif /* EMER_DAEMON_H */

--- a/tests/daemon/mock-server.py
+++ b/tests/daemon/mock-server.py
@@ -22,14 +22,15 @@ import gzip
 import http.server
 import sys
 
+
 class PrintingHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
     def do_PUT(self):
         print(self.path, flush=True)
 
-        content_encoding = self.headers['X-Endless-Content-Encoding']
+        content_encoding = self.headers["X-Endless-Content-Encoding"]
         print(content_encoding, flush=True)
 
-        content_length = int(self.headers['Content-Length'])
+        content_length = int(self.headers["Content-Length"])
         compressed_request_body = self.rfile.read(content_length)
         decompressed_request_body = gzip.decompress(compressed_request_body)
         print(len(decompressed_request_body), flush=True)
@@ -41,13 +42,15 @@ class PrintingHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         self.send_response(status_code)
         self.end_headers()
 
+
 # A metrics server that simply prints the requests it receives to stdout
 class MockServer(http.server.HTTPServer):
     def __init__(self):
-        SERVER_ADDRESS = ('localhost', 0)
+        SERVER_ADDRESS = ("localhost", 0)
         super().__init__(SERVER_ADDRESS, PrintingHTTPRequestHandler)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     mock_server = MockServer()
     print(mock_server.server_port, flush=True)
     mock_server.serve_forever()

--- a/tests/daemon/test-daemon.c
+++ b/tests/daemon/test-daemon.c
@@ -475,22 +475,10 @@ assert_variants_equal (GVariant *actual_variant,
                        GVariant *expected_variant)
 {
   g_assert_nonnull (actual_variant);
+  g_assert_nonnull (expected_variant);
 
-  if (!g_variant_equal (actual_variant, expected_variant))
-    {
-      /* Assertion failures of the form
-       *   ERROR:../tests/daemon/test-daemon.c:495:assert_variants_equal:
-       *   'g_variant_equal (actual_variant, expected_variant)' should be TRUE
-       * are not very helpful -- you want to see the actual variants!
-       */
-      g_autofree gchar *actual_str = g_variant_print (actual_variant, TRUE);
-      g_autofree gchar *expected_str = g_variant_print (expected_variant, TRUE);
-      g_assert_cmpstr (actual_str, ==, expected_str);
+  g_assert_cmpvariant (actual_variant, expected_variant);
 
-      /* Should not be reached: */
-      g_error ("variants compared non-equal, but their type-annotated "
-               "stringified representations compared equal!");
-    }
   g_variant_unref (actual_variant);
   g_variant_unref (expected_variant);
 }

--- a/tests/daemon/test-persistent-cache.c
+++ b/tests/daemon/test-persistent-cache.c
@@ -402,7 +402,7 @@ assert_variants_equal (GVariant **actual_variants,
     }
 
   for (gsize i = 0; i < num_variants; i++)
-    g_assert_true (g_variant_equal (actual_variants[i], expected_variants[i]));
+    g_assert_cmpvariant (actual_variants[i], expected_variants[i]);
 }
 
 static void

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -102,3 +102,11 @@ test('test-opt-out-integration',
         'G_DEBUG': 'fatal-warnings',
     },
 )
+
+test('test-timers',
+    find_program('test-timers.py'),
+    env: {
+        'EMER_PATH': daemon.full_path(),
+        'G_DEBUG': 'fatal-warnings',
+    },
+)

--- a/tests/test-opt-out-integration.py
+++ b/tests/test-opt-out-integration.py
@@ -93,7 +93,7 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
 
     def test_opt_out_not_writable(self):
         """Make sure the Enabled property is not writable."""
-        with self.assertRaisesRegex(dbus.DBusException, 'org\.freedesktop\.DBus\.Error\.InvalidArgs'):
+        with self.assertRaisesRegex(dbus.DBusException, r'org\.freedesktop\.DBus\.Error\.InvalidArgs'):
             self.interface.Set(_METRICS_IFACE, 'Enabled', False,
                 dbus_interface=dbus.PROPERTIES_IFACE)
 
@@ -122,7 +122,7 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
         """
         Make sure that accessing SetEnabled fails if not explicitly authorized.
         """
-        with self.assertRaisesRegex(dbus.DBusException, 'org\.freedesktop\.DBus\.Error\.AuthFailed'):
+        with self.assertRaisesRegex(dbus.DBusException, r'org\.freedesktop\.DBus\.Error\.AuthFailed'):
             self.interface.SetEnabled(True)
 
     def test_upload_doesnt_change_config(self):

--- a/tests/test-opt-out-integration.py
+++ b/tests/test-opt-out-integration.py
@@ -31,7 +31,7 @@ import uuid
 
 import dbusmock
 
-_METRICS_IFACE = 'com.endlessm.Metrics.EventRecorderServer'
+_METRICS_IFACE = "com.endlessm.Metrics.EventRecorderServer"
 _TIMER_IFACE = "com.endlessm.Metrics.AggregateTimer"
 
 
@@ -39,6 +39,7 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
     """
     Makes sure the Enabled property can be set and retrieved.
     """
+
     @classmethod
     def setUpClass(klass):
         """Set up a mock system bus."""
@@ -49,31 +50,38 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
         """Start the event recorder on the mock system bus."""
 
         # Put polkitd mocks onto the mock system bus.
-        (self.polkit_popen, self.polkit_obj) = self.spawn_server_template('polkitd')
+        (self.polkit_popen, self.polkit_obj) = self.spawn_server_template("polkitd")
 
         self.test_dir = tempfile.TemporaryDirectory(
-            prefix='eos-event-recorder-daemon-test.')
+            prefix="eos-event-recorder-daemon-test."
+        )
 
-        persistent_cache_directory = os.path.join(self.test_dir.name, 'cache')
-        persistent_cache_dir_arg = '--persistent-cache-directory=' + persistent_cache_directory
+        persistent_cache_directory = os.path.join(self.test_dir.name, "cache")
+        persistent_cache_dir_arg = (
+            "--persistent-cache-directory=" + persistent_cache_directory
+        )
 
-        self.config_file = os.path.join(self.test_dir.name, 'permissions.conf')
-        config_file_arg = '--config-file-path={}'.format(self.config_file)
+        self.config_file = os.path.join(self.test_dir.name, "permissions.conf")
+        config_file_arg = "--config-file-path={}".format(self.config_file)
 
-        daemon_path = os.environ.get('EMER_PATH', './eos-metrics-event-recorder')
-        self.daemon = subprocess.Popen([daemon_path,
-                                        persistent_cache_dir_arg,
-                                        config_file_arg])
+        daemon_path = os.environ.get("EMER_PATH", "./eos-metrics-event-recorder")
+        self.daemon = subprocess.Popen(
+            [daemon_path, persistent_cache_dir_arg, config_file_arg]
+        )
 
         # Wait for the service to come up
-        self.wait_for_bus_object('com.endlessm.Metrics',
-            '/com/endlessm/Metrics', system_bus=True)
+        self.wait_for_bus_object(
+            "com.endlessm.Metrics", "/com/endlessm/Metrics", system_bus=True
+        )
 
-        metrics_object = self.dbus_con.get_object('com.endlessm.Metrics',
-            '/com/endlessm/Metrics')
+        metrics_object = self.dbus_con.get_object(
+            "com.endlessm.Metrics", "/com/endlessm/Metrics"
+        )
         self.interface = dbus.Interface(metrics_object, _METRICS_IFACE)
 
-        self.db = sqlite3.connect(os.path.join(persistent_cache_directory, "metrics.db"))
+        self.db = sqlite3.connect(
+            os.path.join(persistent_cache_directory, "metrics.db")
+        )
 
     def tearDown(self):
         self.polkit_popen.terminate()
@@ -88,14 +96,18 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
 
     def test_opt_out_readable(self):
         """Make sure the Enabled property exists."""
-        self.interface.Get(_METRICS_IFACE, 'Enabled',
-            dbus_interface=dbus.PROPERTIES_IFACE)
+        self.interface.Get(
+            _METRICS_IFACE, "Enabled", dbus_interface=dbus.PROPERTIES_IFACE
+        )
 
     def test_opt_out_not_writable(self):
         """Make sure the Enabled property is not writable."""
-        with self.assertRaisesRegex(dbus.DBusException, r'org\.freedesktop\.DBus\.Error\.InvalidArgs'):
-            self.interface.Set(_METRICS_IFACE, 'Enabled', False,
-                dbus_interface=dbus.PROPERTIES_IFACE)
+        with self.assertRaisesRegex(
+            dbus.DBusException, r"org\.freedesktop\.DBus\.Error\.InvalidArgs"
+        ):
+            self.interface.Set(
+                _METRICS_IFACE, "Enabled", False, dbus_interface=dbus.PROPERTIES_IFACE
+            )
 
     def test_set_enabled_authorized(self):
         """
@@ -103,26 +115,34 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
         succeeds when it is set to allowed.
         """
         # Check defaults look good and erase the file before our next change
-        self._check_config_file(enabled='true', uploading_enabled='false')
+        self._check_config_file(enabled="true", uploading_enabled="false")
 
-        self.polkit_obj.SetAllowed(['com.endlessm.Metrics.SetEnabled'])
+        self.polkit_obj.SetAllowed(["com.endlessm.Metrics.SetEnabled"])
         self.interface.SetEnabled(True)
-        self.assertTrue(self.interface.Get(_METRICS_IFACE, 'Enabled',
-            dbus_interface=dbus.PROPERTIES_IFACE))
+        self.assertTrue(
+            self.interface.Get(
+                _METRICS_IFACE, "Enabled", dbus_interface=dbus.PROPERTIES_IFACE
+            )
+        )
 
-        self._check_config_file(enabled='true', uploading_enabled='true')
+        self._check_config_file(enabled="true", uploading_enabled="true")
 
         self.interface.SetEnabled(False)
-        self.assertFalse(self.interface.Get(_METRICS_IFACE, 'Enabled',
-            dbus_interface=dbus.PROPERTIES_IFACE))
+        self.assertFalse(
+            self.interface.Get(
+                _METRICS_IFACE, "Enabled", dbus_interface=dbus.PROPERTIES_IFACE
+            )
+        )
 
-        self._check_config_file(enabled='false', uploading_enabled='false')
+        self._check_config_file(enabled="false", uploading_enabled="false")
 
     def test_set_enabled_unauthorized(self):
         """
         Make sure that accessing SetEnabled fails if not explicitly authorized.
         """
-        with self.assertRaisesRegex(dbus.DBusException, r'org\.freedesktop\.DBus\.Error\.AuthFailed'):
+        with self.assertRaisesRegex(
+            dbus.DBusException, r"org\.freedesktop\.DBus\.Error\.AuthFailed"
+        ):
             self.interface.SetEnabled(True)
 
     def test_upload_doesnt_change_config(self):
@@ -136,27 +156,33 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
         be set to TRUE.
         """
         # Check defaults look good and erase the file before our next change
-        self._check_config_file(enabled='true', uploading_enabled='false')
+        self._check_config_file(enabled="true", uploading_enabled="false")
 
-        with self.assertRaisesRegex(dbus.exceptions.DBusException,
-                                    r'uploading is disabled') as context:
+        with self.assertRaisesRegex(
+            dbus.exceptions.DBusException, r"uploading is disabled"
+        ) as context:
             self.interface.UploadEvents()
-        self.assertEqual(context.exception.get_dbus_name(),
-                         "com.endlessm.Metrics.Error.UploadingDisabled")
+        self.assertEqual(
+            context.exception.get_dbus_name(),
+            "com.endlessm.Metrics.Error.UploadingDisabled",
+        )
 
-        self._check_config_file(enabled='true', uploading_enabled='false')
+        self._check_config_file(enabled="true", uploading_enabled="false")
 
     def test_UploadEvents_fails_if_disabled(self):
-        self.polkit_obj.SetAllowed(['com.endlessm.Metrics.SetEnabled'])
+        self.polkit_obj.SetAllowed(["com.endlessm.Metrics.SetEnabled"])
         self.interface.SetEnabled(False)
-        with self.assertRaisesRegex(dbus.exceptions.DBusException,
-                                    r'metrics system is disabled') as context:
+        with self.assertRaisesRegex(
+            dbus.exceptions.DBusException, r"metrics system is disabled"
+        ) as context:
             self.interface.UploadEvents()
-        self.assertEqual(context.exception.get_dbus_name(),
-                         "com.endlessm.Metrics.Error.MetricsDisabled")
+        self.assertEqual(
+            context.exception.get_dbus_name(),
+            "com.endlessm.Metrics.Error.MetricsDisabled",
+        )
 
     def test_clears_tally_when_disabled(self):
-        self.polkit_obj.SetAllowed(['com.endlessm.Metrics.SetEnabled'])
+        self.polkit_obj.SetAllowed(["com.endlessm.Metrics.SetEnabled"])
         self.interface.SetEnabled(True)
         event_id = uuid.UUID("350ac4ff-3026-4c25-9e7e-e8103b4fd5d8")
         monthly_event_id = uuid.uuid5(event_id, "monthly")
@@ -166,10 +192,12 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
             False,
             False,
         )
-        timer = self.dbus_con.get_object('com.endlessm.Metrics', timer_path)
+        timer = self.dbus_con.get_object("com.endlessm.Metrics", timer_path)
         timer.StopTimer(dbus_interface=_TIMER_IFACE)
 
-        rows = self.db.execute("select event_id from tally order by event_id asc").fetchall()
+        rows = self.db.execute(
+            "select event_id from tally order by event_id asc"
+        ).fetchall()
         self.assertEqual(rows, sorted([(event_id.bytes,), (monthly_event_id.bytes,)]))
 
         self.interface.SetEnabled(False)
@@ -177,7 +205,7 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
         self.assertEqual(rows, [])
 
     def test_cancels_running_timer_when_disabled(self):
-        self.polkit_obj.SetAllowed(['com.endlessm.Metrics.SetEnabled'])
+        self.polkit_obj.SetAllowed(["com.endlessm.Metrics.SetEnabled"])
         self.interface.SetEnabled(True)
         event_id = uuid.UUID("350ac4ff-3026-4c25-9e7e-e8103b4fd5d8")
         timer_path = self.interface.StartAggregateTimer(
@@ -186,31 +214,36 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
             False,
             False,
         )
-        timer = self.dbus_con.get_object('com.endlessm.Metrics', timer_path)
+        timer = self.dbus_con.get_object("com.endlessm.Metrics", timer_path)
 
         self.interface.SetEnabled(False)
         with self.assertRaises(dbus.exceptions.DBusException) as context:
             timer.StopTimer(dbus_interface=_TIMER_IFACE)
 
-        self.assertEqual(context.exception.get_dbus_name(),
-                         "org.freedesktop.DBus.Error.UnknownMethod")
+        self.assertEqual(
+            context.exception.get_dbus_name(),
+            "org.freedesktop.DBus.Error.UnknownMethod",
+        )
 
         rows = self.db.execute("select event_id from tally").fetchall()
         self.assertEqual(rows, [])
 
     def test_StartAggregateEvent_fails_if_disabled(self):
-        self.polkit_obj.SetAllowed(['com.endlessm.Metrics.SetEnabled'])
+        self.polkit_obj.SetAllowed(["com.endlessm.Metrics.SetEnabled"])
         self.interface.SetEnabled(False)
-        with self.assertRaisesRegex(dbus.exceptions.DBusException,
-                                    r'metrics system is disabled') as context:
+        with self.assertRaisesRegex(
+            dbus.exceptions.DBusException, r"metrics system is disabled"
+        ) as context:
             self.interface.StartAggregateTimer(
                 0,
                 uuid.UUID("350ac4ff-3026-4c25-9e7e-e8103b4fd5d8").bytes,
                 False,
                 False,
             ),
-        self.assertEqual(context.exception.get_dbus_name(),
-                         "com.endlessm.Metrics.Error.MetricsDisabled")
+        self.assertEqual(
+            context.exception.get_dbus_name(),
+            "com.endlessm.Metrics.Error.MetricsDisabled",
+        )
 
     def _check_config_file(self, enabled, uploading_enabled):
         # the config file is written asynchronously by the daemon,
@@ -232,5 +265,5 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
         os.unlink(self.config_file)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(testRunner=taptestrunner.TAPTestRunner())

--- a/tests/test-timers.py
+++ b/tests/test-timers.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 Endless OS Foundation LLC
+
+# This file is part of eos-event-recorder-daemon.
+#
+# eos-event-recorder-daemon is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or (at your
+# option) any later version.
+#
+# eos-event-recorder-daemon is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with eos-event-recorder-daemon.  If not, see
+# <http://www.gnu.org/licenses/>.
+
+import datetime
+import dbus
+import os
+import sqlite3
+import subprocess
+import taptestrunner
+import tempfile
+import unittest
+import uuid
+
+import dbusmock
+
+_METRICS_IFACE = "com.endlessm.Metrics.EventRecorderServer"
+_TIMER_IFACE = "com.endlessm.Metrics.AggregateTimer"
+
+
+class TestRunningTimersOnShutdown(dbusmock.DBusTestCase):
+    """
+    Checks what happens to timers when the daemon is shut down.
+    """
+
+    @classmethod
+    def setUpClass(klass):
+        """Set up a mock system bus."""
+        klass.start_system_bus()
+        klass.dbus_con = klass.get_dbus(system_bus=True)
+
+    def setUp(self):
+        """Start the event recorder on the mock system bus."""
+
+        # Put polkitd mocks onto the mock system bus.
+        (self.polkit_popen, self.polkit_obj) = self.spawn_server_template("polkitd")
+
+        self.test_dir = tempfile.TemporaryDirectory(
+            prefix="eos-event-recorder-daemon-test."
+        )
+
+        persistent_cache_directory = os.path.join(self.test_dir.name, "cache")
+        persistent_cache_dir_arg = (
+            "--persistent-cache-directory=" + persistent_cache_directory
+        )
+
+        config_file = os.path.join(self.test_dir.name, "permissions.conf")
+        config_file_arg = "--config-file-path={}".format(config_file)
+
+        daemon_path = os.environ.get("EMER_PATH", "./eos-metrics-event-recorder")
+        self.daemon = subprocess.Popen(
+            [daemon_path, persistent_cache_dir_arg, config_file_arg]
+        )
+
+        # Wait for the service to come up
+        self.wait_for_bus_object(
+            "com.endlessm.Metrics", "/com/endlessm/Metrics", system_bus=True
+        )
+
+        self.metrics_object = self.dbus_con.get_object(
+            "com.endlessm.Metrics", "/com/endlessm/Metrics"
+        )
+        self.interface = dbus.Interface(self.metrics_object, _METRICS_IFACE)
+
+        self.db = sqlite3.connect(
+            os.path.join(persistent_cache_directory, "metrics.db")
+        )
+
+    def tearDown(self):
+        self.polkit_popen.terminate()
+        self.daemon.terminate()
+
+        self.polkit_popen.wait()
+        self.assertEqual(self.daemon.wait(), 0)
+
+        self.db.close()
+
+        self.test_dir.cleanup()
+
+    def test_timers_saved_on_clean_shutdown(self):
+        """
+        Tests that running timers are stored on a clean shutdown.
+        """
+        event_id = uuid.UUID("350ac4ff-3026-4c25-9e7e-e8103b4fd5d8")
+        monthly_event_id = uuid.uuid5(event_id, "monthly")
+        self.interface.StartAggregateTimer(
+            0,
+            event_id.bytes,
+            False,
+            False,
+        )
+
+        # FIXME: This test will fail when run across midnight.
+        # It would be better to test from C (rather than over D-Bus) and
+        # refactor the daemon to mock the passage of time.
+        today = datetime.date.today()
+
+        self.daemon.terminate()
+        self.assertEqual(self.daemon.wait(), 0)
+
+        rows = self.db.execute(
+            "select event_id, date, counter from tally order by event_id asc"
+        ).fetchall()
+        event_ids, dates, counters = zip(*rows)
+        self.assertEqual(
+            [uuid.UUID(bytes=x) for x in event_ids],
+            [event_id, monthly_event_id],
+        )
+        self.assertEqual(dates, (f"{today:%Y-%m-%d}", f"{today:%Y-%m}"))
+        self.assertEqual(counters[0], counters[1])
+        self.assertGreaterEqual(counters[0], 0)
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=taptestrunner.TAPTestRunner())


### PR DESCRIPTION
I initially set out to fix the specific issue that running timers are not stored when the metrics daemon shuts down cleanly. In doing so, I added some tests, at which point it was relatively easy to test some other interesting cases, which turned out to fail. So there are some other changes & fixes to the timer code here.

This incorporates the test cleanups that were hanging out on #283 for a while.

https://phabricator.endlessm.com/T32730
