### PR TITLE
More Valgrinding

### DIFF
--- a/daemon/emer-main.c
+++ b/daemon/emer-main.c
@@ -156,6 +156,7 @@ handle_upload_finished (EmerDaemon       *daemon,
     g_dbus_method_invocation_take_error (callback_data->invocation, error);
 
   g_object_unref (callback_data->server);
+  g_object_unref (callback_data->invocation);
   g_free (callback_data);
 }
 

--- a/meson.build
+++ b/meson.build
@@ -72,19 +72,28 @@ valgrind = find_program('valgrind', required: false)
 if valgrind.found()
   glib_suppression_file = glib_dep.get_variable(pkgconfig: 'prefix') / 'share/glib-2.0/valgrind/glib.supp'
 
+  valgrind_arguments = [
+    '--tool=memcheck',
+    '--error-exitcode=1',
+    '--track-origins=yes',
+    '--leak-check=full',
+    '--leak-resolution=high',
+    '--num-callers=50',
+    '--show-leak-kinds=definite,possible',
+    '--show-error-list=yes',
+    '--suppressions=@0@'.format(glib_suppression_file),
+  ]
   add_test_setup('valgrind',
-    exe_wrapper: [
-      valgrind,
-      '--tool=memcheck',
-      '--error-exitcode=1',
-      '--track-origins=yes',
-      '--leak-check=full',
-      '--leak-resolution=high',
-      '--num-callers=50',
-      '--show-leak-kinds=definite,possible',
-      '--show-error-list=yes',
-      '--suppressions=@0@'.format(glib_suppression_file),
-    ],
+    exe_wrapper: [valgrind, valgrind_arguments],
+    # For a test which runs the entire daemon as a subprocess. We don't use
+    # --trace-children=yes because that test also spawns other things such as
+    # a dbus-daemon and we don't want to valgrind those.
+    env: {
+      'EXE_WRAPPER': ' '.join(
+        # TODO: use .full_path() once we require meson ≥ 0.55
+        [valgrind.path()] + valgrind_arguments
+      ),
+    },
     timeout_multiplier: 10,
   )
 endif

--- a/tests/daemon/test-aggregate-tally.c
+++ b/tests/daemon/test-aggregate-tally.c
@@ -136,8 +136,9 @@ test_aggregate_tally_store_events (struct Fixture *fixture,
 {
   g_autoptr(GDateTime) datetime = g_date_time_new_utc (2021, 9, 22, 0, 0, 0);
   g_autoptr(GError) error = NULL;
-  GVariant *payload = v_str (G_STRFUNC);
+  g_autoptr(GVariant) payload = v_str (G_STRFUNC);
 
+  // Store a non-floating payload
   emer_aggregate_tally_store_event (fixture->tally,
                                     EMER_TALLY_DAILY_EVENTS,
                                     1001,
@@ -148,11 +149,24 @@ test_aggregate_tally_store_events (struct Fixture *fixture,
                                     &error);
   g_assert_no_error (error);
 
+  // Store a floating payload
+  GVariant *floaty = g_variant_new_variant (g_variant_new_string ("mcfloatface"));
   emer_aggregate_tally_store_event (fixture->tally,
                                     EMER_TALLY_DAILY_EVENTS,
                                     1001,
                                     uuids[0],
-                                    payload,
+                                    floaty,
+                                    2,
+                                    datetime,
+                                    &error);
+  g_assert_no_error (error);
+
+  // Store a null payload
+  emer_aggregate_tally_store_event (fixture->tally,
+                                    EMER_TALLY_DAILY_EVENTS,
+                                    1001,
+                                    uuids[0],
+                                    NULL,
                                     2,
                                     datetime,
                                     &error);

--- a/tests/daemon/test-cache-size-provider.c
+++ b/tests/daemon/test-cache-size-provider.c
@@ -134,7 +134,7 @@ test_cache_size_provider_recovers_if_corrupt_nul (Fixture      *fixture,
   g_test_bug ("T19953");
 
   gssize size = 41;
-  gchar *contents = g_malloc0 (41);
+  g_autofree gchar *contents = g_malloc0 (41);
 
   write_cache_size_file (fixture, contents, size);
   assert_gets_default_max_cache_size (fixture);

--- a/tests/test-opt-out-integration.py
+++ b/tests/test-opt-out-integration.py
@@ -65,9 +65,10 @@ class TestOptOutIntegration(dbusmock.DBusTestCase):
         config_file_arg = "--config-file-path={}".format(self.config_file)
 
         daemon_path = os.environ.get("EMER_PATH", "./eos-metrics-event-recorder")
-        self.daemon = subprocess.Popen(
-            [daemon_path, persistent_cache_dir_arg, config_file_arg]
-        )
+        # e.g. valgrind
+        exe_wrapper = os.environ.get("EXE_WRAPPER", "").split()
+        daemon_command = exe_wrapper + [daemon_path, persistent_cache_dir_arg, config_file_arg]
+        self.daemon = subprocess.Popen(daemon_command)
 
         # Wait for the service to come up
         self.wait_for_bus_object(


### PR DESCRIPTION
This extends the valgrinding to `test-opt-out-integration.py`, the increasingly-misnamed integration test which exercises the daemon's D-Bus API, and fixes four errors (two of which were uncovered by that test).

With the exception of `test-daemon`, I believe the rest of the test suite is now covered by Valgrind & has a clean bill of health.

https://phabricator.endlessm.com/T34115