### PR TITLE
daemon: Avoid criticals on non-EOS where image version isn't set

### DIFF
--- a/daemon/emer-image-id-provider.c
+++ b/daemon/emer-image-id-provider.c
@@ -94,6 +94,9 @@ emer_image_id_provider_get_version (void)
   if (image_version == NULL)
     image_version = get_image_version_for_path (EOS_IMAGE_VERSION_ALT_PATH);
 
+  if (image_version == NULL)
+    image_version = g_strdup ("unknown");
+
   return image_version;
 }
 


### PR DESCRIPTION
Add fallbacks to read OSTREE_VERSION for Silverblue, and VERSION_ID for other distros that aren't image based.

Fixes https://github.com/endlessm/eos-event-recorder-daemon/issues/292